### PR TITLE
allocated the error code range between 260000 to 269999

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"fmt"
-
 	"github.com/golang/glog"
 )
 
@@ -168,8 +166,9 @@ func parseAccountHostPort(posAt, posSlash int, dsn string) (account, host string
 			port, err = strconv.Atoi(dsn[k+1 : posSlash])
 			if err != nil {
 				err = &SnowflakeError{
-					Number:  0,
-					Message: fmt.Sprintf("failed to parse a port number. port: %v", dsn[k+1:posSlash]),
+					Number:      ErrCodeFailedToParsePort,
+					Message:     ErrMsgFailedToParsePort,
+					MessageArgs: []interface{}{dsn[k+1 : posSlash]},
 				}
 				return
 			}

--- a/errors.go
+++ b/errors.go
@@ -5,7 +5,6 @@
 package gosnowflake
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -15,23 +14,61 @@ type SnowflakeError struct {
 	SQLState       string
 	QueryID        string
 	Message        string
+	MessageArgs    []interface{}
 	IncludeQueryID bool // TODO: populate this in connection
 }
 
 func (se *SnowflakeError) Error() string {
-	if se.IncludeQueryID {
-		return fmt.Sprintf("%06d (%s): %s: %s", se.Number, se.SQLState, se.QueryID, se.Message)
+	message := se.Message
+	if len(se.MessageArgs) > 0 {
+		message = fmt.Sprintf(se.Message, se.MessageArgs)
 	}
-	return fmt.Sprintf("%06d (%s): %s", se.Number, se.SQLState, se.Message)
+	if se.IncludeQueryID {
+		return fmt.Sprintf("%06d (%s): %s: %s", se.Number, se.SQLState, se.QueryID, message)
+	}
+	return fmt.Sprintf("%06d (%s): %s", se.Number, se.SQLState, message)
 }
 
+const (
+	// connection
+
+	// ErrCodeInvalidConnCode is an error code for the case where a connection is not available or in invalid state.
+	ErrCodeInvalidConnCode = 260000
+	// ErrCodeEmptyAccountCode is an error code for the case where a DNS doesn't include account parameter
+	ErrCodeEmptyAccountCode = 260001
+	// ErrCodeEmptyUsernameCode is an error code for the case where a DNS doesn't include user parameter
+	ErrCodeEmptyUsernameCode = 260002
+	// ErrCodeEmptyPasswordCode is an error code for the case where a DNS doesn't include password parameter
+	ErrCodeEmptyPasswordCode = 260003
+	// ErrCodeFailedToParsePort is an error code for the case where a DNS includes an invalid port number
+	ErrCodeFailedToParsePort = 260004
+)
+
+const (
+	// ErrMsgFailedToParsePort is an error message for the where a DNS includes an invalid port number
+	ErrMsgFailedToParsePort = "failed to parse a port number. port: %v"
+)
+
 var (
-	// ErrEmptyAccount is returned if a DNS doesn't include account parameter.
-	ErrEmptyAccount = errors.New("account is empty")
-	// ErrEmptyUsername is returned if a DNS doesn't include user parameter.
-	ErrEmptyUsername = errors.New("user is empty")
-	// ErrEmptyPassword is returned if a DNS doesn't include password parameter.
-	ErrEmptyPassword = errors.New("password is empty")
+	// preformatted errors
+
 	// ErrInvalidConn is returned if a connection is not available or in invalid state.
-	ErrInvalidConn = errors.New("invalid connection")
+	ErrInvalidConn = &SnowflakeError{
+		Number:  ErrCodeInvalidConnCode,
+		Message: "invalid connection",
+	}
+	// ErrEmptyAccount is returned if a DNS doesn't include account parameter.
+	ErrEmptyAccount = &SnowflakeError{
+		Number:  ErrCodeEmptyAccountCode,
+		Message: "account is empty",
+	}
+	// ErrEmptyUsername is returned if a DNS doesn't include user parameter.
+	ErrEmptyUsername = &SnowflakeError{
+		Number:  ErrCodeEmptyUsernameCode,
+		Message: "user is empty",
+	}
+	// ErrEmptyPassword is returned if a DNS doesn't include password parameter.
+	ErrEmptyPassword = &SnowflakeError{
+		Number:  ErrCodeEmptyPasswordCode,
+		Message: "password is empty"}
 )

--- a/restful.go
+++ b/restful.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"time"
 
+	"strconv"
+
 	"github.com/golang/glog"
 	"github.com/satori/go.uuid"
 )
@@ -218,9 +220,16 @@ func (sr *snowflakeRestful) closeSession() error {
 		if err != nil {
 			return err
 		}
-
 		if respd.Success == false && respd.Code != sessionExpiredCode {
-			return &SnowflakeError{Message: respd.Message, SQLState: respd.Code}
+			c, err := strconv.Atoi(respd.Code)
+			if err != nil {
+				return err
+			}
+			return &SnowflakeError{
+				Number:   c,
+				Message:  respd.Message,
+				SQLState: respd.Code,
+			}
 		}
 		return nil
 	}
@@ -270,7 +279,15 @@ func (sr *snowflakeRestful) renewSession() error {
 		}
 
 		if respd.Success == false {
-			return &SnowflakeError{Message: respd.Message, SQLState: respd.Code}
+			c, err := strconv.Atoi(respd.Code)
+			if err != nil {
+				return err
+			}
+			return &SnowflakeError{
+				Number:   c,
+				Message:  respd.Message,
+				SQLState: respd.Code,
+			}
 		}
 		sr.Token = respd.Data.SessionToken
 		sr.MasterToken = respd.Data.MasterToken


### PR DESCRIPTION
### Description
allocated the error code range between 260000 to 269999. Those error codes are used in Golang driver specific errors. If the error code is given from Snowflake db, it will be used.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
