### PR TITLE
Fixes emphasis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Connection Parameters
   - EU (Frankfurt) region, specify ``eu-central-1``.
 
 ``account <string>``
-  :emph:`Required`
+  **Required**
 
   Specifies the name of your Snowflake account, where *string* is the name assigned to your account by Snowflake. In the URL you received from Snowflake, your account name is the first segment in the domain (e.g. ``abc123`` in ``https://abc123.snowflakecomputing.com``).
 


### PR DESCRIPTION
### Description
The README.rst doesn't render properly with the `:emph:` tag.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
