### PR TITLE
Make logging optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ all: fmt lint cov
 setup:
 	go get github.com/Masterminds/glide
 	go get github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/goimports
 	go get github.com/Songmu/make2help/cmd/make2help
 
 ## Run tests
@@ -40,9 +39,9 @@ lint: setup
 		(cd cmd/$$c;  make lint); \
 	done
 
-## Format source codes using goimports
+## Format source codes using gofmt
 fmt: setup
-	goimports -w $$(glide nv -x)
+	gofmt -w $$(glide nv -x)
 	for c in $$(ls cmd); do \
 		(cd cmd/$$c;  make fmt); \
 	done

--- a/auth.go
+++ b/auth.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/satori/go.uuid"
 )
 

--- a/authokta.go
+++ b/authokta.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/satori/go.uuid"
 )
 

--- a/connection.go
+++ b/connection.go
@@ -13,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-
-	"github.com/golang/glog"
 )
 
 const (

--- a/converter.go
+++ b/converter.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 // goTypeToSnowflake translates Go data type to Snowflake data type.

--- a/driver.go
+++ b/driver.go
@@ -9,8 +9,6 @@ import (
 	"database/sql/driver"
 	"net/http"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 // SnowflakeDriver is a context of Go Driver

--- a/driver_test.go
+++ b/driver_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 var (

--- a/dsn.go
+++ b/dsn.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 const (

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 type tcParseDSN struct {

--- a/location.go
+++ b/location.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 var timezones map[int]*time.Location

--- a/log.go
+++ b/log.go
@@ -1,0 +1,35 @@
+// +build !sfdebug
+
+// Wrapper for glog to replace direct use, so that glog usage remains optional.
+// This file contains the no-op glog wrapper/emulator.
+
+package gosnowflake
+
+// glogWrapper is an empty struct to create a no-op glog wrapper
+type glogWrapper struct{}
+
+// V emulates the glog.V() call
+func (glogWrapper) V(int) glogWrapper {
+	return glogWrapper{}
+}
+
+// Flush emulates the glog.Flush() call
+func (glogWrapper) Flush() {}
+
+// Info emulates the glog.V(?).Info call
+func (glogWrapper) Info(...interface{}) {}
+
+// Infoln emulates the glog.V(?).Infoln call
+func (glogWrapper) Infoln(...interface{}) {}
+
+// Infof emulates the glog.V(?).Infof call
+func (glogWrapper) Infof(...interface{}) {}
+
+// InfoDepth emulates the glog.V(?).InfoDepth call
+func (glogWrapper) InfoDepth(...interface{}) {}
+
+// NOTE: Warning* and Error* methods are not emulated since they are not used.
+// NOTE: Fatal* and Exit* methods are not emulated, since they also require additional calls (like os.Exit() and stack traces) to be compatible.
+
+// glog is our glog emulator
+var glog = glogWrapper{}

--- a/log_debug.go
+++ b/log_debug.go
@@ -1,0 +1,26 @@
+// +build sfdebug
+
+// Wrapper for glog to replace direct use, so that glog usage remains optional.
+// This file contains the actual/operational glog wrapper.
+
+package gosnowflake
+
+import logger "github.com/golang/glog"
+
+// glogWrapper wraps glog's Verbose type, enabling the use of glog.V().* methods directly
+type glogWrapper struct {
+	logger.Verbose
+}
+
+// V provides a wrapper for the glog.V() call
+func (l *glogWrapper) V(level int32) glogWrapper {
+	return glogWrapper{logger.V(logger.Level(level))}
+}
+
+// Flush calls flush on the underlying logger
+func (l *glogWrapper) Flush() {
+	logger.Flush()
+}
+
+// glog is our glog wrapper
+var glog = glogWrapper{}

--- a/ocsp.go
+++ b/ocsp.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
 	"golang.org/x/crypto/ocsp"
 )
 

--- a/restful.go
+++ b/restful.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/golang/glog"
 	"github.com/satori/go.uuid"
 )
 

--- a/restful_test.go
+++ b/restful_test.go
@@ -12,8 +12,6 @@ import (
 	"net/url"
 	"testing"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 func postTestError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {

--- a/retry.go
+++ b/retry.go
@@ -16,8 +16,6 @@ import (
 	"context"
 
 	"sync"
-
-	"github.com/golang/glog"
 )
 
 var random *rand.Rand

--- a/retry_test.go
+++ b/retry_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"testing"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 func fakeRequestFunc(_, _ string, _ io.Reader) (*http.Request, error) {

--- a/rows.go
+++ b/rows.go
@@ -18,8 +18,6 @@ import (
 
 	"os"
 	"os/signal"
-
-	"github.com/golang/glog"
 )
 
 const (

--- a/rows_test.go
+++ b/rows_test.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 // test variables

--- a/statement.go
+++ b/statement.go
@@ -7,8 +7,6 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
-
-	"github.com/golang/glog"
 )
 
 type snowflakeStmt struct {


### PR DESCRIPTION
### Description
glog is now optional as described in #111.

This is achieved using a package-level variable named `glog` instead of the glog import. glog is only imported in `log_debug.go`, which is included only if the `sfdebug` build-tag is set, like `go build -tags=sfdebug ./cmd/select1`. In normal mode glog calls are now no-ops and `log.go` provides appropriate wrappers for them.

The use of goimports was unnecessary and was also causing a bug: if there is glog installed in GOPATH, it was being incorrectly imported, breaking the build. This is a known issue of goimports, as described in https://github.com/golang/go/issues/7463. The use of goimports was removed only from the main Makefile, to be replaced with `gofmt` which is included in the standard Go distribution.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
