### PR TITLE
Remove committed binary and fix .gitignore definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ parameters.json
 vendor/
 coverage.txt
 fuzz-*/
+/select1
+/selectmany
+/verifycert

--- a/cmd/selectmany/.gitignore
+++ b/cmd/selectmany/.gitignore
@@ -1,1 +1,1 @@
-select1
+selectmany


### PR DESCRIPTION
A `selectmany` binary was incorrectly committed, because of a glitch in the tool's `.gitignore`. This PR removes it, also adding entries for each cmd to the main `.gitignore` file.
