### PR TITLE
Move signal handling to cmd/

### DIFF
--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 
 	_ "github.com/snowflakedb/gosnowflake"
 )
@@ -15,6 +17,20 @@ func main() {
 		// enable glog for Go Snowflake Driver
 		flag.Parse()
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	defer func() {
+		signal.Stop(c)
+		cancel()
+	}()
+	go func() {
+		<-c
+		log.Println("Caught signal, canceling...")
+		cancel()
+	}()
+
 	// get environment variables
 	env := func(k string) string {
 		if value := os.Getenv(k); value != "" {
@@ -35,7 +51,7 @@ func main() {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}
 	query := "SELECT 1"
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		log.Fatalf("failed to run a query. %v, err: %v", query, err)
 	}

--- a/errors.go
+++ b/errors.go
@@ -75,8 +75,6 @@ const (
 	ErrFailedToAuthOKTA
 	// ErrFailedToGetSSO is an error code for the case where authentication via OKTA failed for unknown reason.
 	ErrFailedToGetSSO
-	// ErrCodeCanceled is an error code for the case where a user has canceled the current operation.
-	ErrCodeCanceled
 
 	/* rows */
 
@@ -138,9 +136,4 @@ var (
 	ErrEmptyPassword = &SnowflakeError{
 		Number:  ErrCodeEmptyPasswordCode,
 		Message: "password is empty"}
-
-	// ErrCanceled is returned if a user has canceled an operation.
-	ErrCanceled = &SnowflakeError{
-		Number:  ErrCodeCanceled,
-		Message: "canceled operation"}
 )

--- a/restful.go
+++ b/restful.go
@@ -14,9 +14,6 @@ import (
 	"strconv"
 	"time"
 
-	"os"
-	"os/signal"
-
 	"github.com/satori/go.uuid"
 )
 
@@ -126,13 +123,6 @@ func postRestfulQuery(
 
 	requestID := uuid.NewV4().String()
 	execResponseChan := make(chan execResponseAndErr)
-	ctx, cancel := context.WithCancel(ctx)
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	defer func() {
-		signal.Stop(c)
-		cancel()
-	}()
 
 	go func() {
 		data, err := sr.FuncPostQueryHelper(ctx, sr, params, headers, body, timeout, requestID)
@@ -142,15 +132,7 @@ func postRestfulQuery(
 	}()
 
 	select {
-	case <-c:
-		cancel()
-		err := sr.FuncCancelQuery(sr, requestID)
-		if err != nil {
-			return nil, err
-		}
-		return nil, ErrCanceled
 	case <-ctx.Done():
-		cancel()
 		err := sr.FuncCancelQuery(sr, requestID)
 		if err != nil {
 			return nil, err

--- a/retry.go
+++ b/retry.go
@@ -110,8 +110,7 @@ func retryHTTP(
 			// success
 			break
 		}
-		if err == ErrCanceled {
-			// user cancel only. not context.Canceled
+		if err == context.Canceled {
 			break
 		}
 		// cannot just return 4xx and 5xx status as the error can be sporadic. retry often helps.


### PR DESCRIPTION
### Description
Signal handling code was moved to individual cmd/ commands. Queries are still automatically canceled with the parent context.

Since this package already requires Go 1.8, and the "context" family of database/sql methods are included in the 1.8 standard library, there is no need to use an internal and implicit signal handler to cancel queries.

### Reasoning
Signal handling should only be handled by a process, always explicitly (often by `package main`)
In the current implementation, this functionality is hidden in various parts of the library.

This change enables the user to handle `os.Interrupt` signals differently, ie. A single Ctrl+C could warn the user or do a soft-cancel, while a second one could cancel the running queries and quit. If the user wants to cancel a specific query, he/she can explicitly cancel the parent context.

Please see [./cmd/selectmany](https://github.com/peakgames/gosnowflake/blob/contextonly-cancellation/cmd/selectmany/selectmany.go#L55) for an example.

### Notes
Additionally, in retry.go:113, the parent context's cancellation was ignored. So, if the user wanted to cancel a query, by cancelling the provided context, retry logic would not stop on some occasions. (try with a ` context.WithTimeout(context.Background(), n)`, where `n` is lower than the backend's average response time)

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
