### PR TITLE
Based on PR 115, added default cancel context for legacy method calls

### DIFF
--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 
 	_ "github.com/snowflakedb/gosnowflake"
 )
@@ -15,6 +17,20 @@ func main() {
 		// enable glog for Go Snowflake Driver
 		flag.Parse()
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	defer func() {
+		signal.Stop(c)
+		cancel()
+	}()
+	go func() {
+		<-c
+		log.Println("Caught signal, canceling...")
+		cancel()
+	}()
+
 	// get environment variables
 	env := func(k string) string {
 		if value := os.Getenv(k); value != "" {
@@ -35,7 +51,7 @@ func main() {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}
 	query := "SELECT 1"
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		log.Fatalf("failed to run a query. %v, err: %v", query, err)
 	}

--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -1,13 +1,13 @@
+// This sample code demonstrates how to fetch one row.
+
 package main
 
 import (
-	"context"
 	"database/sql"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 
 	_ "github.com/snowflakedb/gosnowflake"
 )
@@ -17,19 +17,6 @@ func main() {
 		// enable glog for Go Snowflake Driver
 		flag.Parse()
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	defer func() {
-		signal.Stop(c)
-		cancel()
-	}()
-	go func() {
-		<-c
-		log.Println("Caught signal, canceling...")
-		cancel()
-	}()
 
 	// get environment variables
 	env := func(k string) string {
@@ -51,7 +38,7 @@ func main() {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}
 	query := "SELECT 1"
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.Query(query)
 	if err != nil {
 		log.Fatalf("failed to run a query. %v, err: %v", query, err)
 	}

--- a/cmd/selectmany_legacy/.gitignore
+++ b/cmd/selectmany_legacy/.gitignore
@@ -1,0 +1,1 @@
+selectmany

--- a/cmd/selectmany_legacy/Makefile
+++ b/cmd/selectmany_legacy/Makefile
@@ -1,0 +1,31 @@
+## Setup
+setup:
+	go get github.com/Masterminds/glide
+	go get github.com/golang/lint/golint
+	go get github.com/Songmu/make2help/cmd/make2help
+
+## Install
+install:
+	export GOBIN=$$GOPATH/bin; \
+	go install -tags=sfdebug selectmany.go
+
+## Run
+run: install
+	selectmany
+
+## Lint
+lint: setup
+	go vet $$(glide novendor)
+	for pkg in $$(glide novendor -x); do \
+		golint -set_exit_status $$pkg || exit $$?; \
+	done
+
+## Format source codes using gofmt
+fmt: setup
+	gofmt -w $$(glide nv -x)
+
+## Show help
+help:
+	@make2help $(MAKEFILE_LIST)
+
+.PHONY: install run

--- a/cmd/selectmany_legacy/selectmany.go
+++ b/cmd/selectmany_legacy/selectmany.go
@@ -1,15 +1,14 @@
 // This sample code demonstrates how to fetch many rows and allow cancel the query by Ctrl+C.
+// The difference to other selectmany sample code is this uses the method Query instead of QueryContext such that the default context is used.
 
 package main
 
 import (
-	"context"
 	"database/sql"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 
 	_ "github.com/snowflakedb/gosnowflake"
 )
@@ -19,20 +18,6 @@ func main() {
 		// enable glog for Go Snowflake Driver
 		flag.Parse()
 	}
-
-	// handle interrupt signal
-	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	defer func() {
-		signal.Stop(c)
-		cancel()
-	}()
-	go func() {
-		<-c
-		log.Println("Caught signal, canceling...")
-		cancel()
-	}()
 
 	// get environment variables
 	env := func(k string) string {
@@ -55,7 +40,7 @@ func main() {
 	}
 	query := "SELECT seq8(), randstr(5, random()) from table(generator(rowcount=>10000000))"
 	fmt.Printf("Executing a query. It may take long. You may stop by Ctrl+C.\n")
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.Query(query)
 	if err != nil {
 		log.Fatalf("failed to run a query. %v, err: %v", query, err)
 	}

--- a/connection.go
+++ b/connection.go
@@ -46,8 +46,8 @@ func (sc *snowflakeConn) isDml(v int64) bool {
 }
 
 func (sc *snowflakeConn) exec(
-  ctx context.Context,
-  query string, noResult bool, isInternal bool, parameters []driver.NamedValue) (*execResponse, error) {
+	ctx context.Context,
+	query string, noResult bool, isInternal bool, parameters []driver.NamedValue) (*execResponse, error) {
 	var err error
 	counter := atomic.AddUint64(&sc.SequeceCounter, 1) // query sequence counter
 
@@ -289,17 +289,17 @@ func (sc *snowflakeConn) QueryContext(ctx context.Context, query string, args []
 }
 
 func (sc *snowflakeConn) Exec(
-  query string,
-  args []driver.Value) (
-  driver.Result, error) {
+	query string,
+	args []driver.Value) (
+	driver.Result, error) {
 	// NOTE: this method never used, instead ExecContext is called directly from driver manager.
 	return sc.ExecContext(context.Background(), query, toNamedValues(args))
 }
 
 func (sc *snowflakeConn) Query(
-  query string,
-  args []driver.Value) (
-  driver.Rows, error) {
+	query string,
+	args []driver.Value) (
+	driver.Rows, error) {
 	// NOTE: this method never used, instead QueryContext is called directly from driver manager.
 	return sc.QueryContext(context.Background(), query, toNamedValues(args))
 }

--- a/connection.go
+++ b/connection.go
@@ -197,8 +197,7 @@ func (sc *snowflakeConn) Prepare(query string) (driver.Stmt, error) {
 
 func (sc *snowflakeConn) finalizeCancel(c chan os.Signal, cancel context.CancelFunc) func() {
 	return func() {
-		signal.Stop(c)
-		cancel()
+		signal.Stop(c) // stop trapping SIGINT
 	}
 }
 
@@ -254,6 +253,7 @@ func (sc *snowflakeConn) QueryContext(ctx context.Context, query string, args []
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
+
 	if ctx == context.Background() {
 		ctx1, cancel := context.WithCancel(context.Background())
 		c := make(chan os.Signal, 1)

--- a/errors.go
+++ b/errors.go
@@ -75,8 +75,6 @@ const (
 	ErrFailedToAuthOKTA
 	// ErrFailedToGetSSO is an error code for the case where authentication via OKTA failed for unknown reason.
 	ErrFailedToGetSSO
-	// ErrCodeCanceled is an error code for the case where a user has canceled the current operation.
-	ErrCodeCanceled
 
 	/* rows */
 
@@ -138,9 +136,4 @@ var (
 	ErrEmptyPassword = &SnowflakeError{
 		Number:  ErrCodeEmptyPasswordCode,
 		Message: "password is empty"}
-
-	// ErrCanceled is returned if a user has canceled an operation.
-	ErrCanceled = &SnowflakeError{
-		Number:  ErrCodeCanceled,
-		Message: "canceled operation"}
 )

--- a/restful.go
+++ b/restful.go
@@ -14,9 +14,6 @@ import (
 	"strconv"
 	"time"
 
-	"os"
-	"os/signal"
-
 	"github.com/satori/go.uuid"
 )
 
@@ -126,13 +123,6 @@ func postRestfulQuery(
 
 	requestID := uuid.NewV4().String()
 	execResponseChan := make(chan execResponseAndErr)
-	ctx, cancel := context.WithCancel(ctx)
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	defer func() {
-		signal.Stop(c)
-		cancel()
-	}()
 
 	go func() {
 		data, err := sr.FuncPostQueryHelper(ctx, sr, params, headers, body, timeout, requestID)
@@ -142,15 +132,7 @@ func postRestfulQuery(
 	}()
 
 	select {
-	case <-c:
-		cancel()
-		err := sr.FuncCancelQuery(sr, requestID)
-		if err != nil {
-			return nil, err
-		}
-		return nil, ErrCanceled
 	case <-ctx.Done():
-		cancel()
 		err := sr.FuncCancelQuery(sr, requestID)
 		if err != nil {
 			return nil, err

--- a/retry.go
+++ b/retry.go
@@ -110,8 +110,7 @@ func retryHTTP(
 			// success
 			break
 		}
-		if err == ErrCanceled {
-			// user cancel only. not context.Canceled
+		if err == context.Canceled {
 			break
 		}
 		// cannot just return 4xx and 5xx status as the error can be sporadic. retry often helps.


### PR DESCRIPTION
### Description
Added the default context on top of #115

This patch is for those applications that naively calls `Query` or `Execute` that don't have context parameters to still allow them to cancel queries by Ctrl+C. While #115 yields flexibility of signal handling to applications (that's great), ones already written to call legacy methods can no longer take advantage of builtin Ctrl+C handler.

I'm not sure if we want to enforce all applications to have context explicitly or don't need to care those applications that use legacy `Query` and `Execute` methods just because 1.8 is the minimum requirement.
 
@disq and anybody watching this repo, any thought?

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
