### PR TITLE
Fix checking the identical errors

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -151,7 +151,7 @@ func (sc *snowflakeConn) BeginTx(ctx context.Context, opts driver.TxOptions) (dr
 		return nil, driver.ErrBadConn
 	}
 	_, err := sc.exec(ctx, "BEGIN", false, false, nil)
-	if err != err {
+	if err != nil {
 		return nil, err
 	}
 	return &snowflakeTx{sc}, err


### PR DESCRIPTION
### Description

left and right handside of the comparison are identical. These types of typos/errors are easily be spotted with a static analyzer.

What do you think about adding such a tool to CI?

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
