### PR TITLE
Fix no no test in the latest Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8
   - 1.9
+  - tip
 before_install:
   - openssl aes-256-cbc -k "$super_secret_password" -in parameters.json.enc -out parameters.json -d
 install:

--- a/benchmark/largesetresult/largesetresult.go
+++ b/benchmark/largesetresult/largesetresult.go
@@ -1,0 +1,7 @@
+// Benchmark Test
+//
+// This exists to mitigate "no non-test Go files" in the latest Go
+package largesetresult
+
+func main() {
+}


### PR DESCRIPTION
### Description
For some reason, the latest Go, aka, tip on Travis, complains no no-test error in the benchmark tests. Obviously no no-test for benchmark, but `go build` runs in the directory and raise the error.

This additional patch is workaround. No impact to the driver itself.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
