### PR TITLE
Added no connection pool example

### DIFF
--- a/cmd/noconnpool/.gitignore
+++ b/cmd/noconnpool/.gitignore
@@ -1,0 +1,1 @@
+noconnpool

--- a/cmd/noconnpool/Makefile
+++ b/cmd/noconnpool/Makefile
@@ -1,0 +1,16 @@
+include ../../gosnowflake.mak
+CMD_TARGET=noconnpool
+
+## Install
+install: cinstall
+
+## Run
+run: crun
+
+## Lint
+lint: clint
+
+## Format source codes
+fmt: cfmt
+
+.PHONY: install run lint fmt

--- a/cmd/noconnpool/noconnpool.go
+++ b/cmd/noconnpool/noconnpool.go
@@ -1,0 +1,76 @@
+// Example: No connection pool
+//
+// Setting the pool size to 1, a single session is used at all times. This guarantees USE <object type> <object name>
+// changes the current working object and subsequent commands can have the access.
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	_ "github.com/snowflakedb/gosnowflake"
+)
+
+func main() {
+	if !flag.Parsed() {
+		// enable glog for Go Snowflake Driver
+		flag.Parse()
+	}
+
+	// get environment variables
+	env := func(k string) string {
+		if value := os.Getenv(k); value != "" {
+			return value
+		}
+		log.Fatalf("%v environment variable is not set.", k)
+		return ""
+	}
+
+	account := env("SNOWFLAKE_TEST_ACCOUNT")
+	user := env("SNOWFLAKE_TEST_USER")
+	password := env("SNOWFLAKE_TEST_PASSWORD")
+
+	dsn := fmt.Sprintf("%v:%v@%v", user, password, account)
+	db, err := sql.Open("snowflake", dsn)
+	if err != nil {
+		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
+	}
+	// single session
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	var wg sync.WaitGroup
+	n := 10
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			query := "select current_session()"
+			rows, err := db.Query(query) // no cancel is allowed
+			if err != nil {
+				log.Fatalf("failed to run a query. %v, err: %v", query, err)
+			}
+			defer rows.Close()
+			var v int
+			for rows.Next() {
+				err := rows.Scan(&v)
+				if err != nil {
+					log.Fatalf("failed to get result. err: %v", err)
+				}
+				fmt.Printf("Session: %v\n", v)
+			}
+			if rows.Err() != nil {
+				fmt.Printf("ERROR: %v\n", rows.Err())
+				return
+			}
+		}()
+	}
+	fmt.Println("Waiting to finish...")
+	wg.Wait()
+	fmt.Printf("Congrats! You have successfully!\n")
+}


### PR DESCRIPTION
### Description
`nonconnpool` demonstrates how to guarantee USE <object type> <object name> changes the current working object and subsequent commands have the access. Since Golang SQL creates a connection pool by default, if you run multiple commands/SQL, each may run on separate sessions. By setting the pool size to 1, it guarantees all commands on the same session.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
