### PR TITLE
Removed proxy parameters. 

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -83,22 +83,14 @@ The following connection parameters are supported:
 		Security Certified Professional (OSCP) certificate revocation check.
 		IMPORTANT: Change the default value for testing or emergency situations only.
 
-	*proxyHost: Specifies the host name for the proxy server. The proxy
-		must be accessible via the URL http://proxyHost:proxyPort/. The
-		proxyUser and proxyPassword parameters are optional. Note that SSL
-		proxy configuration is not supported.
-
-	* proxyPort: Specifies the port number for the proxy server.
-
-	* proxyUser: Specifies the name of the user used to connect to the proxy server.
-
-	* proxyPassword: Specifies the password for the user account used to connect to the proxy server.
-
 All other parameters are taken as session parameters. For example, TIMESTAMP_OUTPUT_FORMAT session parameter can be
 set by adding:
 
 	...&TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY...
 
+Proxy
+
+The Go Snowflake Driver honors the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY for the forward proxy setting.
 
 Logging
 

--- a/driver.go
+++ b/driver.go
@@ -30,14 +30,8 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 		// no revocation check with OCSP. Think twice when you want to enable this option.
 		st = snowflakeInsecureTransport
 	}
-	proxyURL, err := proxyURL(proxyHost, proxyPort, proxyUser, proxyPassword)
 	if err != nil {
 		return nil, err
-	}
-	if proxyURL != nil {
-		st.Proxy = http.ProxyURL(proxyURL)
-		glog.V(2).Infof("proxy: %v, %v, %v, %v",
-			proxyURL.Scheme, proxyURL.Host, proxyURL.Port, proxyURL.User)
 	}
 	// authenticate
 	sc.rest = &snowflakeRestful{

--- a/dsn.go
+++ b/dsn.go
@@ -409,19 +409,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				return
 			}
 			cfg.InsecureMode = vv
-		case "proxyHost":
-			proxyHost = value
-		case "proxyPort":
-			var vv int64
-			vv, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return
-			}
-			proxyPort = int(vv)
-		case "proxyUser":
-			proxyUser = value
-		case "proxyPassword":
-			proxyPassword = value
 		default:
 			if cfg.Params == nil {
 				cfg.Params = make(map[string]*string)

--- a/ocsp.go
+++ b/ocsp.go
@@ -370,13 +370,7 @@ func getRevocationStatus(wg *sync.WaitGroup, ocspStatusChan chan<- *ocspStatus, 
 	}
 	glog.V(2).Infof("cache missed: %v\n", ocspValidatedWithCache.err)
 
-	proxyURL, _ := proxyURL(proxyHost, proxyPort, proxyUser, proxyPassword)
 	st := snowflakeInsecureTransport
-	if proxyURL != nil {
-		st.Proxy = http.ProxyURL(proxyURL)
-		glog.V(2).Infof("proxy: %v, %v, %v, %v",
-			proxyURL.Scheme, proxyURL.Host, proxyURL.Port, proxyURL.User)
-	}
 	ocspClient := &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: st,

--- a/restful.go
+++ b/restful.go
@@ -27,13 +27,6 @@ const (
 	queryInProgressAsyncCode = "333334"
 )
 
-var (
-	proxyHost     string
-	proxyPort     int
-	proxyUser     string
-	proxyPassword string
-)
-
 type snowflakeRestful struct {
 	Host           string
 	Port           int

--- a/util.go
+++ b/util.go
@@ -4,8 +4,6 @@ package gosnowflake
 
 import (
 	"database/sql/driver"
-	"fmt"
-	"net/url"
 	"time"
 )
 
@@ -48,16 +46,4 @@ func toNamedValues(values []driver.Value) []driver.NamedValue {
 		namedValues[idx] = driver.NamedValue{Name: "", Ordinal: idx + 1, Value: value}
 	}
 	return namedValues
-}
-
-//proxyURL constructs a URL string including proxy info. No https proxy is supported.
-func proxyURL(host string, port int, user string, password string) (*url.URL, error) {
-	if host != "" && port != 0 {
-		proxyAuth := ""
-		if user != "" || password != "" {
-			proxyAuth = fmt.Sprintf("%s:%s@", user, password)
-		}
-		return url.Parse(fmt.Sprintf("http://%v%v:%v", proxyAuth, host, port))
-	}
-	return nil, nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -4,8 +4,6 @@ package gosnowflake
 
 import (
 	"database/sql/driver"
-	"fmt"
-	"net/url"
 	"testing"
 	"time"
 )
@@ -128,74 +126,6 @@ func TestToNamedValues(t *testing.T) {
 
 		if !compareNamedValues(test.out, a) {
 			t.Errorf("failed int max. v1: %v, v2: %v, expected: %v, got: %v", test.values, test.out, test.out, a)
-		}
-	}
-}
-
-type tcProxyURL struct {
-	proxyHost     string
-	proxyPort     int
-	proxyUser     string
-	proxyPassword string
-	output        *url.URL
-	err           error
-}
-
-func TestProxyURL(t *testing.T) {
-	var genProxyURL = func(urlStr string) *url.URL {
-		ret, err := url.Parse(urlStr)
-		if err != nil {
-			panic(fmt.Sprintf("failed to parse URL: %v", urlStr))
-		}
-		return ret
-	}
-	testcases := []tcProxyURL{
-		{
-			proxyHost: "proxy.host.com",
-			proxyPort: 123,
-			output:    genProxyURL("http://proxy.host.com:123"),
-		},
-		{
-			proxyHost:     "proxy.host.com",
-			proxyPort:     123,
-			proxyUser:     "u",
-			proxyPassword: "p",
-			output:        genProxyURL("http://u:p@proxy.host.com:123"),
-		},
-		{
-			proxyHost: "proxy.host.com",
-			proxyPort: 123,
-			proxyUser: "u",
-			output:    genProxyURL("http://u:@proxy.host.com:123"),
-		},
-		{
-			proxyHost: "proxy.host.com",
-			output:    nil,
-		},
-		{
-			proxyPort: 456,
-			output:    nil,
-		},
-		{
-			output: nil,
-		},
-	}
-	for _, test := range testcases {
-		a, err := proxyURL(test.proxyHost, test.proxyPort, test.proxyUser, test.proxyPassword)
-		if err != nil && test.err == nil {
-			t.Errorf("unexpected error. err: %v, input: %v", err, test)
-		}
-		if err == nil && test.err != nil {
-			t.Errorf("error is expected. err: %v, input: %v", test.err, test)
-		}
-		if a == nil && test.output != nil || a != nil && test.output == nil {
-			t.Errorf("failed to get proxy URL. host: %v, port: %v, user: %v, password: %v, expected: %v, got: %v",
-				test.proxyHost, test.proxyPort, test.proxyUser, test.proxyPassword, test.output, a)
-		}
-
-		if a != nil && test.output != nil && test.output.String() != a.String() {
-			t.Errorf("failed to get proxy URL. host: %v, port: %v, user: %v, password: %v, expected: %v, got: %v",
-				test.proxyHost, test.proxyPort, test.proxyUser, test.proxyPassword, test.output, a)
 		}
 	}
 }


### PR DESCRIPTION
### Description
Fixed #125 
The environment variables should e used. HTTP_PROXY, HTTPS_PROXY and NO_PROXY

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
