### PR TITLE
Fixed HTTP 403 errors when getting results from AWS S3.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -244,6 +244,7 @@ func (sc *snowflakeConn) QueryContext(ctx context.Context, query string, args []
 		Total:              int64(data.Data.Total),
 		TotalRowIndex:      int64(-1),
 		Qrmk:               data.Data.Qrmk,
+		ChunkHeader:        data.Data.ChunkHeaders,
 		FuncDownload:       downloadChunk,
 		FuncDownloadHelper: downloadChunkHelper,
 		FuncGet:            getChunk,

--- a/query.go
+++ b/query.go
@@ -54,6 +54,7 @@ type execResponseData struct {
 	Version            int64                 `json:"version,omitempty"`         // java:long
 	Chunks             []execResponseChunk   `json:"chunks,omitempty"`
 	Qrmk               string                `json:"qrmk,omitempty"`
+	ChunkHeaders       map[string]string     `json:"chunkHeaders,omitempty"`
 
 	// ping pong response data
 	GetResultURL         string        `json:"getResultUrl,omitempty"`

--- a/retry.go
+++ b/retry.go
@@ -94,10 +94,10 @@ func retryHTTP(
 		// cannot just return 4xx and 5xx status as the error can be sporadic. retry often helps.
 		if err != nil {
 			glog.V(2).Infof(
-				"failed http connection. no response is returned. err: %v. retrying.\n", err)
+				"failed http connection. no response is returned. err: %v. retrying...\n", err)
 		} else {
 			glog.V(2).Infof(
-				"failed http connection. HTTP Status: %v. retrying.\n", res.StatusCode)
+				"failed http connection. HTTP Status: %v. retrying...\n", res.StatusCode)
 		}
 		// uses decorrelated jitter backoff
 		sleepTime = defaultWaitAlgo.decorr(retryCounter, sleepTime)


### PR DESCRIPTION
### Description
As the new server release 2.23 started enforcing a signature of key to fetch result set from AWS S3, the client should specify it in the header. Both signature and key are provided by the server already.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
