### PR TITLE
raise HTTP 403 immediately if Snowflake authentication fails

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -99,7 +99,7 @@ func postAuth(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port,
 		"/session/v1/login-request?"+params.Encode())
 	glog.V(2).Infof("full URL: %v", fullURL)
-	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, body, timeout)
+	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, body, timeout, true)
 	if err != nil {
 		return nil, err
 	}

--- a/driver.go
+++ b/driver.go
@@ -7,7 +7,6 @@ import (
 	"database/sql/driver"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // SnowflakeDriver is a context of Go Driver
@@ -39,7 +38,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 		Port:     sc.cfg.Port,
 		Protocol: sc.cfg.Protocol,
 		Client: &http.Client{
-			Timeout:   60 * time.Second, // each request timeout
+			Timeout:   defaultLoginTimeout, // each request timeout
 			Transport: st,
 		},
 		Authenticator:       sc.cfg.Authenticator,

--- a/driver_test.go
+++ b/driver_test.go
@@ -276,9 +276,9 @@ func invalidUserPassErrorTests(invalidDNS string, t *testing.T) {
 
 func TestBogusHostNameParameters(t *testing.T) {
 	invalidDNS := fmt.Sprintf("%s:%s@%s", user, pass, "INVALID_HOST:1234")
-	invalidHostErrorTests(invalidDNS, []string{"no such host", "HTTP Status: 403"}, t)
+	invalidHostErrorTests(invalidDNS, []string{"no such host", "verify account name is correct", "HTTP Status: 403"}, t)
 	invalidDNS = fmt.Sprintf("%s:%s@%s", user, pass, "INVALID_HOST")
-	invalidHostErrorTests(invalidDNS, []string{"read: connection reset by peer.", "EOF", "HTTP Status: 403"}, t)
+	invalidHostErrorTests(invalidDNS, []string{"read: connection reset by peer.", "EOF", "verify account name is correct", "HTTP Status: 403"}, t)
 }
 
 func invalidHostErrorTests(invalidDNS string, mstr []string, t *testing.T) {

--- a/ocsp.go
+++ b/ocsp.go
@@ -271,7 +271,7 @@ func retryOCSP(
 	sleepTime := time.Duration(0)
 	for {
 		sleepTime = defaultWaitAlgo.decorr(retryCounter, sleepTime)
-		res, err := retryHTTP(context.TODO(), client, req, "POST", ocspHost, headers, reqBody, httpTimeout)
+		res, err := retryHTTP(context.TODO(), client, req, "POST", ocspHost, headers, reqBody, httpTimeout, false)
 		if err != nil {
 			if ok := retryRevocationStatusCheck(&totalTimeout, sleepTime); ok {
 				retryCounter++

--- a/restful_test.go
+++ b/restful_test.go
@@ -11,42 +11,42 @@ import (
 	"time"
 )
 
-func postTestError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
 	}, errors.New("failed to run post method")
 }
 
-func postTestSuccessButInvalidJSON(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestSuccessButInvalidJSON(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
 	}, nil
 }
 
-func postTestAppBadGatewayError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestAppBadGatewayError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusBadGateway,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
 	}, nil
 }
 
-func postTestAppForbiddenError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestAppForbiddenError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusForbidden,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
 	}, nil
 }
 
-func postTestAppUnexpectedError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestAppUnexpectedError(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusInsufficientStorage,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
 	}, nil
 }
 
-func postTestRenew(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestRenew(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	dd := &execResponseData{}
 	er := &execResponse{
 		Data:    *dd,
@@ -66,7 +66,7 @@ func postTestRenew(_ context.Context, _ *snowflakeRestful, _ string, _ map[strin
 	}, nil
 }
 
-func postTestAfterRenew(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration) (*http.Response, error) {
+func postTestAfterRenew(_ context.Context, _ *snowflakeRestful, _ string, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 	dd := &execResponseData{}
 	er := &execResponse{
 		Data:    *dd,

--- a/retry_test.go
+++ b/retry_test.go
@@ -84,7 +84,7 @@ func TestRetry(t *testing.T) {
 	}
 	_, err := retryHTTP(context.TODO(),
 		client,
-		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 60*time.Second)
+		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 60*time.Second, false)
 	if err != nil {
 		t.Fatal("failed to run retry")
 	}
@@ -96,7 +96,7 @@ func TestRetry(t *testing.T) {
 	}
 	_, err = retryHTTP(context.TODO(),
 		client,
-		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 10*time.Second)
+		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 10*time.Second, false)
 	if err == nil {
 		t.Fatal("should fail to run retry")
 	}
@@ -109,7 +109,7 @@ func TestRetry(t *testing.T) {
 	}
 	_, err = retryHTTP(context.TODO(),
 		client,
-		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 60*time.Second)
+		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 60*time.Second, false)
 	if err != nil {
 		t.Fatal("failed to run retry")
 	}
@@ -121,7 +121,7 @@ func TestRetry(t *testing.T) {
 	}
 	_, err = retryHTTP(context.TODO(),
 		client,
-		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 10*time.Second)
+		fakeRequestFunc, "POST", "", make(map[string]string), []byte{0}, 10*time.Second, false)
 	if err == nil {
 		t.Fatal("should fail to run retry")
 	}

--- a/rows.go
+++ b/rows.go
@@ -259,7 +259,9 @@ func getChunk(
 	headers map[string]string,
 	timeout time.Duration) (
 	*http.Response, error) {
-	return retryHTTP(ctx, scd.sc.rest.Client, http.NewRequest, "GET", fullURL, headers, nil, timeout)
+	return retryHTTP(
+		ctx, scd.sc.rest.Client, http.NewRequest,
+		"GET", fullURL, headers, nil, timeout, false)
 }
 
 /* largeResultSetReader is a reader that wraps the large result set with leading and tailing brackets. */


### PR DESCRIPTION
### Description
Raise HTTP 403 error immediately if Snowflake authentication fails.

By default, Snowflake retries HTTP connections for the given timeout to mitigate connection stability issue. HTTP 502 and 504 are the common ones that the Snowflake clients must retry, and sometimes AWS S3 connections return HTTP 4XX and retry helps. That's main reason behind.

However you may not get HTTP 403 immediately for an invalid url as the Go driver doesn't distinguish valid and intermittent errors.

This fix is to mitigate the situation where HTTP 403 is raised immediately only when Snowflake authentication fails.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
