### PR TITLE
Detach chunk dowloader memory alter used

### DIFF
--- a/benchmark/largesetresult/largesetresult_test.go
+++ b/benchmark/largesetresult/largesetresult_test.go
@@ -13,8 +13,11 @@ import (
 	"database/sql"
 
 	"context"
-	_ "github.com/snowflakedb/gosnowflake"
 	"os/signal"
+
+	"runtime/debug"
+
+	_ "github.com/snowflakedb/gosnowflake"
 )
 
 func TestLargeResultSet(t *testing.T) {
@@ -64,18 +67,35 @@ func runLargeResultSet() {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}
 
-	query := "SELECT seq8(), randstr(100, random()) FROM table(generator(rowcount=>100000))"
+	query := `select * from
+	  (select 0 a union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) A,
+	  (select 0 b union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) B,
+	  (select 0 c union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) C,
+	  (select 0 d union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) E,
+	  (select 0 e union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) F,
+	  (select 0 f union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) G,
+	  (select 0 f union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) H`
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		log.Fatalf("failed to run a query. %v, err: %v", query, err)
 	}
 	defer rows.Close()
-	var v int
-	var s string
+	var v1 int
+	var v2 int
+	var v3 int
+	var v4 int
+	var v5 int
+	var v6 int
+	var v7 int
+	counter := 0
 	for rows.Next() {
-		err := rows.Scan(&v, &s)
+		err := rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6, &v7)
 		if err != nil {
 			log.Fatalf("failed to get result. err: %v", err)
 		}
+		if counter%1000000 == 0 {
+			debug.FreeOSMemory()
+		}
+		counter++
 	}
 }

--- a/cmd/selectmany/selectmany.go
+++ b/cmd/selectmany/selectmany.go
@@ -9,16 +9,20 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime/pprof"
+	"strconv"
 
-	_ "github.com/snowflakedb/gosnowflake"
+	_ "net/http/pprof"
+
+	"runtime/debug"
+
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
-func main() {
-	if !flag.Parsed() {
-		// enable glog for Go Snowflake Driver
-		flag.Parse()
-	}
+var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
+var memprofile = flag.String("memprofile", "", "write memory profile to this file")
 
+func run(dsn string) {
 	// handler interrupt signal
 	ctx, cancel := context.WithCancel(context.Background())
 	c := make(chan os.Signal, 1)
@@ -32,47 +36,118 @@ func main() {
 		cancel()
 	}()
 
-	// get environment variables
-	env := func(k string) string {
-		if value := os.Getenv(k); value != "" {
-			return value
-		}
-		log.Fatalf("%v environment variable is not set.", k)
-		return ""
-	}
-
-	account := env("SNOWFLAKE_TEST_ACCOUNT")
-	user := env("SNOWFLAKE_TEST_USER")
-	password := env("SNOWFLAKE_TEST_PASSWORD")
-
-	dsn := fmt.Sprintf("%v:%v@%v", user, password, account)
 	db, err := sql.Open("snowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
-	query := "SELECT seq8(), randstr(5, random()) from table(generator(rowcount=>10000000))"
+	query := `select * from
+	  (select 0 a union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) A,
+	  (select 0 b union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) B,
+	  (select 0 c union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) C,
+	  (select 0 d union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) E,
+	  (select 0 e union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) F,
+	  (select 0 f union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) G,
+	  (select 0 f union select 1 union select 2 union select 3 union select 4 union select 5 union select 6 union select 7 union select 8 union select 9) H`
 	fmt.Printf("Executing a query. It may take long. You may stop by Ctrl+C.\n")
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		log.Fatalf("failed to run a query. %v, err: %v", query, err)
 	}
 	defer rows.Close()
-	var v int
-	var s string
+	var v1 int
+	var v2 int
+	var v3 int
+	var v4 int
+	var v5 int
+	var v6 int
+	var v7 int
 	fmt.Printf("Fetching the results. It may take long. You may stop by Ctrl+C.\n")
+	counter := 0
 	for rows.Next() {
-		err := rows.Scan(&v, &s)
+		err := rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6, &v7)
 		if err != nil {
 			log.Fatalf("failed to get result. err: %v", err)
 		}
-		if v%10000 == 0 {
-			fmt.Printf("idx: %v, data: %v\n", v, s)
+		if counter%10000 == 0 {
+			fmt.Printf("data: %v, %v, %v, %v, %v, %v, %v\n", v1, v2, v3, v4, v5, v6, v7)
 		}
+		if counter%1000000 == 0 {
+			debug.FreeOSMemory()
+		}
+		counter++
 	}
 	if rows.Err() != nil {
 		fmt.Printf("ERROR: %v\n", rows.Err())
 		return
 	}
 	fmt.Printf("Congrats! You have successfully run %v with Snowflake DB!\n", query)
+}
+func main() {
+	if !flag.Parsed() {
+		// enable glog for Go Snowflake Driver
+		flag.Parse()
+	}
+
+	// get environment variables
+	env := func(k string, check bool) string {
+		if value := os.Getenv(k); value != "" {
+			return value
+		}
+		if check {
+			log.Fatalf("%v environment variable is not set.", k)
+		}
+		return ""
+	}
+
+	account := env("SNOWFLAKE_TEST_ACCOUNT", true)
+	user := env("SNOWFLAKE_TEST_USER", true)
+	password := env("SNOWFLAKE_TEST_PASSWORD", true)
+	host := env("SNOWFLAKE_TEST_HOST", false)
+	port := env("SNOWFLAKE_TEST_PORT", false)
+	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
+
+	portStr, _ := strconv.Atoi(port)
+	cfg := &sf.Config{
+		Account:  account,
+		User:     user,
+		Password: password,
+		Host:     host,
+		Port:     portStr,
+		Protocol: protocol,
+	}
+
+	dsn, err := sf.DSN(cfg)
+	if err != nil {
+		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
+	}
+
+	/*
+		go func() {
+			log.Println(http.ListenAndServe("localhost:6060", nil))
+		}()
+	*/
+	if *cpuprofile != "" {
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	// var wg sync.WaitGroup
+	// wg.Add(1)
+	run(dsn)
+	//wg.Wait()
+
+	if *memprofile != "" {
+		f, err := os.Create(*memprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.WriteHeapProfile(f)
+		f.Close()
+		return
+	}
 }

--- a/dsn.go
+++ b/dsn.go
@@ -48,7 +48,9 @@ type Config struct {
 
 // DSN constructs a DSN for Snowflake db.
 func DSN(cfg *Config) (dsn string, err error) {
+	hasHost := true
 	if cfg.Host == "" {
+		hasHost = false
 		if cfg.Region == "" {
 			cfg.Host = cfg.Account + defaultDomain
 		} else {
@@ -67,6 +69,10 @@ func DSN(cfg *Config) (dsn string, err error) {
 		return "", err
 	}
 	params := &url.Values{}
+	if hasHost && cfg.Account != "" {
+		// account may not be included in a Host string
+		params.Add("account", cfg.Account)
+	}
 	if cfg.Database != "" {
 		params.Add("database", cfg.Database)
 	}
@@ -99,6 +105,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	}
 	if cfg.Application != clientType {
 		params.Add("application", cfg.Application)
+	}
+	if cfg.Protocol != "" && cfg.Protocol != "https" {
+		params.Add("protocol", cfg.Protocol)
 	}
 	if cfg.Token != "" {
 		params.Add("token", cfg.Token)


### PR DESCRIPTION
### Description
Detach chunk loader memory after used so that GC may reclaim the memory. However it is not guaranteed that GC will run right after it is detached but usually in 5 min. In my experiments, the memory is freed after 3~4 minutes. In order to force to remove the memory, the applications may call `debug.FreeOSMemory`.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
