### PR TITLE
Bumping up version to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 1.1.6
+
+- Fixed memory leak in the large result set. The chunk of memory is freed as soon as the cursor moved forward.
+- Removed glide dependency in favor of dep #149 (@tjj5036)
+- Added Go 1.10 test.
+
 ## Version 1.1.5
 
 - Added externalbrowser authenticator support PR #141, #142 (@tjj5036)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed memory leak in the large result set. The chunk of memory is freed as soon as the cursor moved forward.
 - Removed glide dependency in favor of dep #149 (@tjj5036)
+- Fixed username and password URL escape issue #151
 - Added Go 1.10 test.
 
 ## Version 1.1.5

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 package gosnowflake
 
 // SnowflakeGoDriverVersion is the version of Go Snowflake Driver.
-const SnowflakeGoDriverVersion = "1.1.5"
+const SnowflakeGoDriverVersion = "1.1.6"


### PR DESCRIPTION
### Description
- Fixed memory leak in the large result set. The chunk of memory is freed as soon as the cursor moved forward.
- Removed glide dependency in favor of dep #149 (@tjj5036)
- Fixed username and password URL escape issue
- Added Go 1.10 test.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
