### PR TITLE
Heartbeat

### DIFF
--- a/cmd/keepalive/.gitignore
+++ b/cmd/keepalive/.gitignore
@@ -1,0 +1,1 @@
+keepalive

--- a/cmd/keepalive/Makefile
+++ b/cmd/keepalive/Makefile
@@ -1,0 +1,16 @@
+include ../../gosnowflake.mak
+CMD_TARGET=keepalive
+
+## Install
+install: cinstall
+
+## Run
+run: crun
+
+## Lint
+lint: clint
+
+## Format source codes
+fmt: cfmt
+
+.PHONY: install run lint fmt

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -1,6 +1,6 @@
 // Example: client session keep alive
 // By default, the token expires in 4 hours if the connection is idle. CLIENT_SESSION_KEEP_ALIVE parameter will
-// have a heartbeat in the backend to keep the connection alive explicit heartbeats.
+// have a heartbeat in the background to keep the connection alive by making explicit heartbeats
 package main
 
 import (

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -34,6 +34,10 @@ func getDSN() (string, *sf.Config, error) {
 	port := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
+	params := make(map[string]*string)
+	valueTrue := "true"
+	params["client_session_keep_alive"] = &valueTrue
+
 	portStr, _ := strconv.Atoi(port)
 	cfg := &sf.Config{
 		Account:  account,
@@ -42,10 +46,10 @@ func getDSN() (string, *sf.Config, error) {
 		Host:     host,
 		Port:     portStr,
 		Protocol: protocol,
+		Params:   params,
 	}
 
 	dsn, err := sf.DSN(cfg)
-	dsn += "&client_session_keep_alive=true" // CLIENT_SESSION_KEEP_ALIVE
 	return dsn, cfg, err
 }
 

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -1,0 +1,105 @@
+// Example: client session keep alive
+// By default, the token expires in 4 hours if the connection is idle. CLIENT_SESSION_KEEP_ALIVE parameter will
+// have a heartbeat in the backend to keep the connection alive explicit heartbeats.
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	sf "github.com/snowflakedb/gosnowflake"
+	"time"
+)
+
+// getDSN constructs a DSN based on the test connection parameters
+func getDSN() (string, *sf.Config, error) {
+	env := func(k string, failOnMissing bool) string {
+		if value := os.Getenv(k); value != "" {
+			return value
+		}
+		if failOnMissing {
+			log.Fatalf("%v environment variable is not set.", k)
+		}
+		return ""
+	}
+
+	account := env("SNOWFLAKE_TEST_ACCOUNT", true)
+	user := env("SNOWFLAKE_TEST_USER", true)
+	password := env("SNOWFLAKE_TEST_PASSWORD", true)
+	host := env("SNOWFLAKE_TEST_HOST", false)
+	port := env("SNOWFLAKE_TEST_PORT", false)
+	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
+
+	portStr, _ := strconv.Atoi(port)
+	cfg := &sf.Config{
+		Account:  account,
+		User:     user,
+		Password: password,
+		Host:     host,
+		Port:     portStr,
+		Protocol: protocol,
+	}
+
+	dsn, err := sf.DSN(cfg)
+	dsn += "&client_session_keep_alive=true" // CLIENT_SESSION_KEEP_ALIVE
+	return dsn, cfg, err
+}
+
+func runQuery(db *sql.DB, query string) {
+	rows, err := db.Query(query) // no cancel is allowed
+	if err != nil {
+		log.Fatalf("failed to run a query. %v, err: %v", query, err)
+	}
+	defer rows.Close()
+	var v int
+	for rows.Next() {
+		err := rows.Scan(&v)
+		if err != nil {
+			log.Fatalf("failed to get result. err: %v", err)
+		}
+		if v != 1 {
+			log.Fatalf("failed to get 1. got: %v", v)
+		}
+	}
+	if rows.Err() != nil {
+		fmt.Printf("ERROR: %v\n", rows.Err())
+		return
+	}
+
+}
+
+func main() {
+	if !flag.Parsed() {
+		// enable glog for Go Snowflake Driver
+		flag.Parse()
+	}
+
+	dsn, cfg, err := getDSN()
+	if err != nil {
+		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
+	}
+
+	db, err := sql.Open("snowflake", dsn)
+	if err != nil {
+		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
+	}
+	defer db.Close()
+	query := "SELECT 1"
+	runQuery(db, query)
+
+	time.Sleep(90 * time.Minute)
+
+	runQuery(db, query)
+
+	time.Sleep(4 * time.Hour)
+
+	runQuery(db, query)
+
+	time.Sleep(8 * time.Hour)
+
+	fmt.Printf("Congrats! You have successfully run %v with Snowflake DB!\n", query)
+}

--- a/connection.go
+++ b/connection.go
@@ -313,16 +313,11 @@ func (sc *snowflakeConn) populateSessionParameters(parameters []nameValueParamet
 }
 
 func (sc *snowflakeConn) isClientSessionKeepAliveEnabled() bool {
-	ret := false
-	for k, v := range sc.cfg.Params {
-		if k == sessionClientSessionKeepAlive {
-			if strings.Compare(*v, "true") == 0 {
-				ret = true
-			}
-			break
-		}
+	v, ok := sc.cfg.Params[sessionClientSessionKeepAlive]
+	if !ok {
+		return false
 	}
-	return ret
+	return strings.Compare(*v, "true") == 0
 }
 
 func (sc *snowflakeConn) startHeartBeat() {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1846,6 +1846,8 @@ func createDSNWithClientSessionKeepAlive() {
 }
 
 func TestClientSessionKeepAliveParameter(t *testing.T) {
+	// This test doesn't really validate the CLIENT_SESSION_KEEP_ALIVE functionality but simply checks
+	// the session parameter.
 	var db *sql.DB
 	var err error
 	var rows *sql.Rows

--- a/driver_test.go
+++ b/driver_test.go
@@ -1863,8 +1863,10 @@ func TestClientSessionKeepAliveParameter(t *testing.T) {
 	if !rows.Next() {
 		t.Fatal("failed to get timezone.")
 	}
-	var k, v, d, lv, de, c1, c2, c3, c4, c5, c6, c7 string
-	err = rows.Scan(&k, &v, &d, &lv, &de, &c1, &c2, &c3, &c4, &c5, &c6, &c7)
+	// var k, v, d, lv, de, c1, c2, c3, c4, c5, c6, c7 string
+	// err = rows.Scan(&k, &v, &d, &lv, &de, &c1, &c2, &c3, &c4, &c5, &c6, &c7)
+	var k, v, d, lv, de string
+	err = rows.Scan(&k, &v, &d, &lv, &de)
 	if err != nil {
 		t.Errorf("failed to run get client_session_keep_alive value. err: %v", err)
 	}

--- a/errors.go
+++ b/errors.go
@@ -79,6 +79,8 @@ const (
 	ErrFailedToParseResponse = 261008
 	// ErrFailedToGetExternalBrowserResponse is an error code for when there's an error reading from the open socket.
 	ErrFailedToGetExternalBrowserResponse = 261009
+	// ErrFailedToHeartbeat is an error code when a heartbeat fails.
+	ErrFailedToHeartbeat = 261010
 
 	/* rows */
 

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2018 Snowflake Computing Inc. All right reserved.
+
+package gosnowflake
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"context"
+
+	"io/ioutil"
+	"net/http"
+
+	"encoding/json"
+
+	"github.com/satori/go.uuid"
+)
+
+const (
+	// heartbeatDuration = 1 * time.Second
+	heartbeatDuration = 60 * time.Minute
+)
+
+type heartbeat struct {
+	restful      *snowflakeRestful
+	ShutdownChan chan int
+}
+
+func (hc *heartbeat) run() {
+	hbTimer := time.NewTimer(heartbeatDuration)
+	for {
+		go func() {
+			<-hbTimer.C
+			err := hc.heartbeatMain()
+			if err != nil {
+				glog.V(2).Info("failed to heartbeat")
+				return
+			}
+			hbTimer = time.NewTimer(heartbeatDuration)
+		}()
+		select {
+		case <-hc.ShutdownChan:
+			// stop
+			hbTimer.Stop()
+			glog.V(2).Info("stopping")
+			return
+		default:
+			// no more download
+			glog.V(2).Info("no shutdown signal")
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (hc *heartbeat) start() {
+	hc.ShutdownChan = make(chan int)
+	go hc.run()
+	glog.V(2).Info("heartbeat started")
+}
+
+func (hc *heartbeat) stop() {
+	hc.ShutdownChan <- 1
+	close(hc.ShutdownChan)
+	glog.V(2).Info("heartbeat stopped")
+}
+
+func (hc *heartbeat) heartbeatMain() error {
+	glog.V(2).Info("Heartbeating!")
+	params := &url.Values{}
+	params.Add("requestId", uuid.NewV4().String())
+	fullURL := fmt.Sprintf(
+		"%s://%s:%d%s", hc.restful.Protocol, hc.restful.Host, hc.restful.Port, "/session/heartbeat?"+params.Encode())
+	headers := make(map[string]string)
+	headers["Content-Type"] = headerContentTypeApplicationJSON
+	headers["accept"] = headerAcceptTypeApplicationSnowflake
+	headers["User-Agent"] = userAgent
+	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, hc.restful.Token)
+
+	resp, err := hc.restful.FuncPost(context.TODO(), hc.restful, fullURL, headers, nil, hc.restful.RequestTimeout, false)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		glog.V(2).Infof("postQuery: resp: %v", resp)
+		var respd execResponse
+		err = json.NewDecoder(resp.Body).Decode(&respd)
+		if err != nil {
+			glog.V(1).Infof("failed to decode JSON. err: %v", err)
+			glog.Flush()
+			return err
+		}
+		if respd.Code == sessionExpiredCode {
+			err = hc.restful.FuncRenewSession(context.TODO(), hc.restful)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		glog.V(1).Infof("failed to extract HTTP response body. err: %v", err)
+		return err
+	}
+	glog.V(1).Infof("HTTP: %v, URL: %v, Body: %v", resp.StatusCode, fullURL, b)
+	glog.V(1).Infof("Header: %v", resp.Header)
+	glog.Flush()
+	return &SnowflakeError{
+		Number:   ErrFailedToHeartbeat,
+		SQLState: SQLStateConnectionFailure,
+		Message:  "Failed to heartbeat.",
+	}
+}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	// heartbeatDuration = 1 * time.Second
-	heartbeatDuration = 60 * time.Minute
+	// One hour interval should be good enough to renew tokens for four hours master token validity
+	heartBeatInterval = 60 * time.Minute
 )
 
 type heartbeat struct {
@@ -28,7 +28,7 @@ type heartbeat struct {
 }
 
 func (hc *heartbeat) run() {
-	hbTimer := time.NewTimer(heartbeatDuration)
+	hbTimer := time.NewTimer(heartBeatInterval)
 	for {
 		go func() {
 			<-hbTimer.C
@@ -37,7 +37,7 @@ func (hc *heartbeat) run() {
 				glog.V(2).Info("failed to heartbeat")
 				return
 			}
-			hbTimer = time.NewTimer(heartbeatDuration)
+			hbTimer = time.NewTimer(heartBeatInterval)
 		}()
 		select {
 		case <-hc.ShutdownChan:
@@ -83,7 +83,7 @@ func (hc *heartbeat) heartbeatMain() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		glog.V(2).Infof("postQuery: resp: %v", resp)
+		glog.V(2).Infof("heartbeatMain: resp: %v", resp)
 		var respd execResponse
 		err = json.NewDecoder(resp.Body).Decode(&respd)
 		if err != nil {

--- a/restful.go
+++ b/restful.go
@@ -39,6 +39,7 @@ type snowflakeRestful struct {
 	Token       string
 	MasterToken string
 	SessionID   int
+	HeartBeat   *heartbeat
 
 	Connection          *snowflakeConn
 	FuncPostQuery       func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration) (*execResponse, error)


### PR DESCRIPTION
### Description
Added CLIENT_SESSION_KEEP_ALIVE option support that keeps the connection alive by heartbeating it.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
