### PR TITLE
Removes the username restriction when using the OAuth Authenticator

### DIFF
--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -31,14 +31,12 @@ func main() {
 	}
 
 	account := env("SNOWFLAKE_TEST_ACCOUNT")
-	user := env("SNOWFLAKE_TEST_USER")
-	password := env("SNOWFLAKE_TEST_PASSWORD") // will not matter
 	token := env("SNOWFLAKE_TEST_OAUTH_TOKEN")
 
 	// Tokens must be escaped before being used in the DSN!
 	escapedToken := url.QueryEscape(token)
 
-	dsn := fmt.Sprintf("%v:%v@%v/?authenticator=OAUTH&token=%v", user, password, account, escapedToken)
+	dsn := fmt.Sprintf("%v?authenticator=OAUTH&token=%v", account, escapedToken)
 	db, err := sql.Open("snowflake", dsn)
 	if err != nil {
 		log.Fatalf("failed to connect. %v, err: %v", dsn, err)

--- a/dsn.go
+++ b/dsn.go
@@ -136,6 +136,8 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 	// user[:password]@account/database[?param1=value1&paramN=valueN]
 	// or
 	// user[:password]@host:port/database/schema?account=user_account[?param1=value1&paramN=valueN]
+	// or
+	// host:port/database/schema?account=user_account[?param1=value1&paramN=valueN]
 
 	foundSlash := false
 	secondSlash := false
@@ -269,10 +271,13 @@ func fillMissingConfigParameters(cfg *Config) error {
 	if strings.Trim(cfg.Account, " ") == "" {
 		return ErrEmptyAccount
 	}
-	if strings.Trim(cfg.User, " ") == "" {
+	authenticator := strings.ToUpper(cfg.Authenticator)
+
+	if authenticator != authenticatorOAuth && strings.Trim(cfg.User, " ") == "" {
+		// oauth does not require a username
 		return ErrEmptyUsername
 	}
-	authenticator := strings.ToUpper(cfg.Authenticator)
+
 	if authenticator != authenticatorExternalBrowser && authenticator != authenticatorOAuth && strings.Trim(cfg.Password, " ") == "" {
 		// no password parameter is required for EXTERNALBROWSER and OAUTH.
 		return ErrEmptyPassword

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -102,6 +102,14 @@ func TestParseDSN(t *testing.T) {
 			err: nil,
 		},
 		{
+			dsn: "snowflake.local:9876?account=a&protocol=http&authenticator=OAUTH",
+			config: &Config{
+				Account: "a", Authenticator: "OAUTH",
+				Protocol: "http", Host: "snowflake.local", Port: 9876,
+			},
+			err: nil,
+		},
+		{
 			dsn: "u:p@snowflake.local:NNNN?account=a&protocol=http",
 			config: &Config{
 				Account: "a", User: "u", Password: "p",


### PR DESCRIPTION
### Description
Removes the restriction that username be present in the DSN when using the OAuth Authenticator. Added a test to verify that a DSN without the username / password works in dsn_test.go.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x]  Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
