### PR TITLE
not run megacache on Go1.8

### DIFF
--- a/gosnowflake.mak
+++ b/gosnowflake.mak
@@ -6,7 +6,7 @@ setup:
 	go get -u github.com/golang/dep/cmd/dep
 	go get github.com/golang/lint/golint
 	go get github.com/Songmu/make2help/cmd/make2help
-	go get honnef.co/go/tools/cmd/megacheck
+	[[ $$(go version | awk '{print $3}' | cut -d'.' -f 2) != "8" ]] && go get honnef.co/go/tools/cmd/megacheck || true
 
 ## Install dependencies
 deps: setup

--- a/gosnowflake.mak
+++ b/gosnowflake.mak
@@ -26,7 +26,7 @@ cfmt: setup
 
 # Lint (internally used)
 clint: setup
-	megacheck
+	[[ $$(go version | awk '{print $3}' | cut -d'.' -f 2) != "8" ]] && echo "Running megacache" && megacheck || echo "No megacheck run, because Go1.8 is not supported."
 	for pkg in $$(go list ./... | grep -v /vendor/); do \
 		echo "Verifying $$pkg"; \
 		go vet $$pkg; \


### PR DESCRIPTION
### Description
no megacache run on Go1.8

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
