### PR TITLE
Fix proxy settings

### DIFF
--- a/ocsp.go
+++ b/ocsp.go
@@ -574,6 +574,7 @@ func init() {
 var snowflakeInsecureTransport = &http.Transport{
 	MaxIdleConns:    10,
 	IdleConnTimeout: 30 * time.Minute,
+	Proxy:           http.ProxyFromEnvironment,
 }
 
 // SnowflakeTransport includes the certificate revocation check with OCSP in parallel. By default, the driver uses
@@ -585,6 +586,7 @@ var SnowflakeTransport = &http.Transport{
 	},
 	MaxIdleConns:    10,
 	IdleConnTimeout: 30 * time.Minute,
+	Proxy:           http.ProxyFromEnvironment,
 }
 
 // SnowflakeTransportSerial includes the certificate revocation check with OCSP in serial.
@@ -595,6 +597,7 @@ var SnowflakeTransportSerial = &http.Transport{
 	},
 	MaxIdleConns:    10,
 	IdleConnTimeout: 30 * time.Minute,
+	Proxy:           http.ProxyFromEnvironment,
 }
 
 // SnowflakeTransportTest includes the certificate revocation check in parallel


### PR DESCRIPTION
### Description
To use the HTTP_PROXY environment variable in custom Transports, `http.ProxyFromEnvironment` must be used as the `Proxy`.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
