### PR TITLE
optimize decoding of large-chunk 

### DIFF
--- a/benchmark/jsonresultset/.gitignore
+++ b/benchmark/jsonresultset/.gitignore
@@ -1,0 +1,3 @@
+*.test
+*.out
+prof_largeresults

--- a/benchmark/jsonresultset/Makefile
+++ b/benchmark/jsonresultset/Makefile
@@ -1,0 +1,35 @@
+## Setup
+SHELL := /bin/bash
+SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+
+setup:
+	go get github.com/golang/lint/golint
+	go get github.com/Songmu/make2help/cmd/make2help
+
+## Benchmark
+profile:
+	go test -run none -bench . -benchtime 3s -benchmem -cpuprofile cpu.out -memprofile mem.out
+	@echo "For CPU usage, run 'go tool pprof jsonresultset.test cpu.out'"
+	@echo "For Memory usage, run 'go tool pprof -alloc_space jsonresultset.test mem.out'"
+
+## Trace
+trace:
+	go test -trace trace.out
+	@echo "Run 'go tool trace jsonresultset.test trace.out'"
+
+## Lint
+lint: setup
+	go vet $(SRC)
+	for pkg in $$(go list ./... | grep -v vendor); do \
+		golint -set_exit_status $$pkg || exit $$?; \
+	done
+
+## Format source codes using gfmt
+fmt: setup
+	@gofmt -l -w $(SRC)
+
+## Show help
+help:
+	@make2help $(MAKEFILE_LIST)
+
+.PHONY: install run

--- a/benchmark/jsonresultset/README.rst
+++ b/benchmark/jsonresultset/README.rst
@@ -1,0 +1,54 @@
+********************************************************************************
+Benchmark Large Result Set
+********************************************************************************
+
+This folder includes a benchmark test case for "JSON Result Set", which refers
+to a query result of more than 100 MB of JSON objects. This differs from the "Large
+Result Set" case, since it benchmarks large strings with many escaped characters.
+
+Profiling
+=========
+
+Using Go's profilers, you may see CPU and memory usage on each function/method. 
+This command instruments CPU and memory usage and save them into files.
+
+.. code-block:: bash
+
+    SNOWFLAKE_TEST_ACCOUNT=<your_account> \
+    SNOWFLAKE_TEST_USER=<your_user> \
+    SNOWFLAKE_TEST_PASSWORD=<your_password> \
+    make profile
+
+Check CPU usage on the web browser:
+
+.. code-block:: bash
+
+    go tool pprof jsonresultset.test cpu.out
+    (pprof) web
+
+Check memory usage on the web browser:
+
+.. code-block:: bash
+
+    go tool pprof -alloc_space jsonresultset.test mem.out
+    (pprof) web
+
+Tracing
+=======
+
+Using Go's trace tool, you may see all of the goroutine's activity with timeline.
+
+.. code-block:: bash
+
+    SNOWFLAKE_TEST_ACCOUNT=<your_account> \
+    SNOWFLAKE_TEST_USER=<your_user> \
+    SNOWFLAKE_TEST_PASSWORD=<your_password> \
+    make trace
+
+Check goroutine's activities on web browser.
+
+.. code-block:: bash
+
+    go tool trace jsonresultset.test trace.out
+
+

--- a/benchmark/jsonresultset/jsonresultset.go
+++ b/benchmark/jsonresultset/jsonresultset.go
@@ -1,0 +1,7 @@
+// Package jsonresultset is a benchmark for large json result sets
+//
+// This exists to mitigate "no non-test Go files" in the latest Go
+package jsonresultset
+
+func main() {
+}

--- a/benchmark/jsonresultset/jsonresultset_test.go
+++ b/benchmark/jsonresultset/jsonresultset_test.go
@@ -1,0 +1,115 @@
+// This code is to profile a large json result set query. It is basically similar to selectmany example code but
+// leverages benchmark framework.
+package jsonresultset
+
+import (
+	"flag"
+	"log"
+	_ "net/http/pprof"
+	"os"
+	"testing"
+
+	"database/sql"
+
+	"context"
+	"os/signal"
+
+	"runtime/debug"
+
+	"strconv"
+
+	sf "github.com/snowflakedb/gosnowflake"
+)
+
+func TestJsonResultSet(t *testing.T) {
+	runJsonResultSet()
+}
+
+func BenchmarkJsonResultSet(*testing.B) {
+	runJsonResultSet()
+}
+
+// getDSN constructs a DSN based on the test connection parameters
+func getDSN() (dsn string, cfg *sf.Config, err error) {
+	env := func(k string, failOnMissing bool) string {
+		if value := os.Getenv(k); value != "" {
+			return value
+		}
+		if failOnMissing {
+			log.Fatalf("%v environment variable is not set.", k)
+		}
+		return ""
+	}
+
+	account := env("SNOWFLAKE_TEST_ACCOUNT", true)
+	user := env("SNOWFLAKE_TEST_USER", true)
+	password := env("SNOWFLAKE_TEST_PASSWORD", true)
+	host := env("SNOWFLAKE_TEST_HOST", false)
+	port := env("SNOWFLAKE_TEST_PORT", false)
+	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
+	role := env("SNOWFLAKE_TEST_ROLE", false)
+
+	portStr, _ := strconv.Atoi(port)
+	cfg = &sf.Config{
+		Account:  account,
+		User:     user,
+		Password: password,
+		Host:     host,
+		Role:     role,
+		Port:     portStr,
+		Protocol: protocol,
+	}
+
+	dsn, err = sf.DSN(cfg)
+	return dsn, cfg, err
+}
+
+func runJsonResultSet() {
+	if !flag.Parsed() {
+		// enable glog for Go Snowflake Driver
+		flag.Parse()
+	}
+
+	// handler interrupt signal
+	ctx, cancel := context.WithCancel(context.Background())
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	defer func() {
+		signal.Stop(c)
+	}()
+	go func() {
+		<-c
+		log.Println("Caught signal, canceling...")
+		cancel()
+	}()
+
+	dsn, cfg, err := getDSN()
+	if err != nil {
+		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
+	}
+
+	db, err := sql.Open("snowflake", dsn)
+	defer db.Close()
+	if err != nil {
+		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
+	}
+
+	query := `SELECT V FROM SNOWFLAKE_SAMPLE_DATA.WEATHER.HOURLY_14_TOTAL LIMIT 100000`
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		log.Fatalf("failed to run a query. %v, err: %v", query, err)
+	}
+	defer rows.Close()
+	var v1 string
+	counter := 0
+	for rows.Next() {
+		err := rows.Scan(&v1)
+		if err != nil {
+			log.Fatalf("failed to get result. err: %v", err)
+		}
+		if counter%1000000 == 0 {
+			debug.FreeOSMemory()
+		}
+		counter++
+	}
+}

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,307 @@
+package gosnowflake
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+const (
+	defaultChunkBufferSize  int64 = 8 << 10 // 8k
+	defaultStringBufferSize int64 = 512
+)
+
+type largeChunkDecoder struct {
+	r io.Reader
+
+	rows  int // hint for number of rows
+	cells int // hint for number of cells/row
+
+	rem int // bytes remaining in rbuf
+	ptr int // position in rbuf
+
+	rbuf []byte
+	sbuf *bytes.Buffer // buffer for decodeString
+
+	ioError error
+}
+
+func decodeLargeChunk(r io.Reader, rowCount int, cellCount int) ([][]*string, error) {
+	lcd := largeChunkDecoder{
+		r, rowCount, cellCount,
+		0, 0,
+		make([]byte, defaultChunkBufferSize),
+		bytes.NewBuffer(make([]byte, defaultStringBufferSize)),
+		nil,
+	}
+
+	rows, err := lcd.decode()
+	if lcd.ioError != nil && lcd.ioError != io.EOF {
+		return nil, lcd.ioError
+	} else if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+func (lcd *largeChunkDecoder) mkError(s string) error {
+	return fmt.Errorf("corrupt chunk: %s", s)
+}
+
+func (lcd *largeChunkDecoder) decode() ([][]*string, error) {
+	if '[' != lcd.nextByteNonWhitespace() {
+		return nil, lcd.mkError("expected chunk to begin with '['")
+	}
+
+	rows := make([][]*string, 0, lcd.rows)
+	if ']' == lcd.nextByteNonWhitespace() {
+		return rows, nil // special case of an empty chunk
+	}
+	lcd.rewind(1)
+
+OuterLoop:
+	for {
+		row, err := lcd.decodeRow()
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+
+		switch c := lcd.nextByteNonWhitespace(); {
+		case c == ',':
+			continue // more elements in the array
+		case c == ']':
+			return rows, nil // we've scanned the whole chunk
+		default:
+			break OuterLoop
+		}
+	}
+	return nil, lcd.mkError("invalid row boundary")
+}
+
+func (lcd *largeChunkDecoder) decodeRow() ([]*string, error) {
+	if '[' != lcd.nextByteNonWhitespace() {
+		return nil, lcd.mkError("expected row to begin with '['")
+	}
+
+	row := make([]*string, 0, lcd.cells)
+	if ']' == lcd.nextByteNonWhitespace() {
+		return row, nil // special case of an empty row
+	}
+	lcd.rewind(1)
+
+OuterLoop:
+	for {
+		cell, err := lcd.decodeCell()
+		if err != nil {
+			return nil, err
+		}
+		row = append(row, cell)
+
+		switch c := lcd.nextByteNonWhitespace(); {
+		case c == ',':
+			continue // more elements in the array
+		case c == ']':
+			return row, nil // we've scanned the whole row
+		default:
+			break OuterLoop
+		}
+	}
+	return nil, lcd.mkError("invalid cell boundary")
+}
+
+func (lcd *largeChunkDecoder) decodeCell() (*string, error) {
+	c := lcd.nextByteNonWhitespace()
+	if c == '"' {
+		s, err := lcd.decodeString()
+		return &s, err
+	} else if c == 'n' {
+		if 'u' == lcd.nextByte() &&
+			'l' == lcd.nextByte() &&
+			'l' == lcd.nextByte() {
+			return nil, nil
+		}
+	}
+	return nil, lcd.mkError("cell begins with unexpected byte")
+}
+
+// TODO we can optimize this further by optimistically searching
+// the read buffer for the next string. If it's short enough and
+// doesn't contain any escaped characters, we can construct the
+// return string directly without writing to the sbuf
+func (lcd *largeChunkDecoder) decodeString() (string, error) {
+	lcd.sbuf.Reset()
+	for {
+		// NOTE if you make changes here, ensure this
+		// variable does not escape to the heap
+		c := lcd.nextByte()
+		if c == '"' {
+			break
+		} else if c == '\\' {
+			if err := lcd.decodeEscaped(); err != nil {
+				return "", err
+			}
+		} else if c < ' ' {
+			return "", lcd.mkError("unexpected control character")
+		} else if c < utf8.RuneSelf {
+			lcd.sbuf.WriteByte(c)
+		} else {
+			lcd.rewind(1)
+			lcd.sbuf.WriteRune(lcd.readRune())
+		}
+	}
+	return lcd.sbuf.String(), nil
+}
+
+func (lcd *largeChunkDecoder) decodeEscaped() error {
+	// NOTE if you make changes here, ensure this
+	// variable does not escape to the heap
+	c := lcd.nextByte()
+
+	switch c {
+	case '"', '\\', '/', '\'':
+		lcd.sbuf.WriteByte(c)
+	case 'b':
+		lcd.sbuf.WriteByte('\b')
+	case 'f':
+		lcd.sbuf.WriteByte('\f')
+	case 'n':
+		lcd.sbuf.WriteByte('\n')
+	case 'r':
+		lcd.sbuf.WriteByte('\r')
+	case 't':
+		lcd.sbuf.WriteByte('\t')
+	case 'u':
+		rr := lcd.getu4()
+		if rr < 0 {
+			return lcd.mkError("invalid escape sequence")
+		}
+		if utf16.IsSurrogate(rr) {
+			rr1, size := lcd.getu4WithPrefix()
+			if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+				// A valid pair; consume.
+				lcd.sbuf.WriteRune(dec)
+				break
+			}
+			// Invalid surrogate; fall back to replacement rune.
+			lcd.rewind(size)
+			rr = unicode.ReplacementChar
+		}
+		lcd.sbuf.WriteRune(rr)
+	default:
+		return lcd.mkError("invalid escape sequence: " + string(c))
+	}
+	return nil
+}
+
+func (lcd *largeChunkDecoder) readRune() rune {
+	lcd.ensureBytes(4)
+	r, size := utf8.DecodeRune(lcd.rbuf[lcd.ptr:])
+	lcd.ptr += size
+	lcd.rem -= size
+	return r
+}
+
+func (lcd *largeChunkDecoder) getu4WithPrefix() (rune, int) {
+	lcd.ensureBytes(6)
+
+	// NOTE take a snapshot of the cursor state. If this
+	// is not a valid rune, then we need to roll back to
+	// where we were before we began consuming bytes
+	ptr := lcd.ptr
+
+	if '\\' != lcd.nextByte() {
+		return -1, lcd.ptr - ptr
+	}
+	if 'u' != lcd.nextByte() {
+		return -1, lcd.ptr - ptr
+	}
+	r := lcd.getu4()
+	return r, lcd.ptr - ptr
+}
+
+func (lcd *largeChunkDecoder) getu4() rune {
+	var r rune
+	for i := 0; i < 4; i++ {
+		c := lcd.nextByte()
+		switch {
+		case '0' <= c && c <= '9':
+			c = c - '0'
+		case 'a' <= c && c <= 'f':
+			c = c - 'a' + 10
+		case 'A' <= c && c <= 'F':
+			c = c - 'A' + 10
+		default:
+			return -1
+		}
+		r = r*16 + rune(c)
+	}
+	return r
+}
+
+func (lcd *largeChunkDecoder) nextByteNonWhitespace() byte {
+	for {
+		c := lcd.nextByte()
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return c
+		}
+	}
+	return 0
+}
+
+func (lcd *largeChunkDecoder) rewind(n int) {
+	lcd.ptr -= n
+	lcd.rem += n
+}
+
+func (lcd *largeChunkDecoder) nextByte() byte {
+	if lcd.rem == 0 {
+		if lcd.ioError != nil {
+			return 0
+		}
+
+		lcd.ptr = 0
+		lcd.rem = lcd.fillBuffer(lcd.rbuf)
+		if lcd.rem == 0 {
+			return 0
+		}
+	}
+
+	b := lcd.rbuf[lcd.ptr]
+	lcd.ptr++
+
+	lcd.rem--
+	return b
+}
+
+func (lcd *largeChunkDecoder) ensureBytes(n int) {
+	if lcd.rem <= n {
+		rbuf := make([]byte, defaultChunkBufferSize)
+		copy(rbuf, lcd.rbuf[lcd.ptr:])
+		add := lcd.fillBuffer(rbuf[lcd.ptr:])
+
+		lcd.ptr = 0
+		lcd.rem += add
+		lcd.rbuf = rbuf
+	}
+}
+
+func (lcd *largeChunkDecoder) fillBuffer(b []byte) int {
+	n, err := lcd.r.Read(b)
+	if err != nil && err != io.EOF {
+		lcd.ioError = err
+		return 0
+	} else if n <= 0 {
+		lcd.ioError = io.EOF
+		return 0
+	}
+	return n
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,145 @@
+package gosnowflake
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBadChunkData(t *testing.T) {
+	testDecodeErr(t, "")
+	testDecodeErr(t, "null")
+	testDecodeErr(t, "42")
+	testDecodeErr(t, "\"null\"")
+	testDecodeErr(t, "{}")
+
+	testDecodeErr(t, "[[]")
+	testDecodeErr(t, "[null]")
+	testDecodeErr(t, `[[hello world]]`)
+
+	testDecodeErr(t, `[[""hello world""]]`)
+	testDecodeErr(t, `[["\"hello world""]]`)
+	testDecodeErr(t, `[[""hello world\""]]`)
+	testDecodeErr(t, `[["hello world`)
+	testDecodeErr(t, `[["hello world"`)
+	testDecodeErr(t, `[["hello world"]`)
+
+	testDecodeErr(t, `[["\uQQQQ"]]`)
+
+	for b := byte(0); b < ' '; b++ {
+		testDecodeErr(t, string([]byte{
+			'[', '[', '"', b, '"', ']', ']',
+		}))
+	}
+}
+
+func TestValidChunkData(t *testing.T) {
+	testDecodeOk(t, "[]")
+	testDecodeOk(t, "[  ]")
+	testDecodeOk(t, "[[]]")
+	testDecodeOk(t, "[ [  ]   ]")
+	testDecodeOk(t, "[[],[],[],[]]")
+	testDecodeOk(t, "[[] , []  , [], []  ]")
+
+	testDecodeOk(t, "[[null]]")
+	testDecodeOk(t, "[[\n\t\r null]]")
+	testDecodeOk(t, "[[null,null]]")
+	testDecodeOk(t, "[[ null , null ]]")
+	testDecodeOk(t, "[[null],[null],[null]]")
+	testDecodeOk(t, "[[null],[ null  ] ,  [null]]")
+
+	testDecodeOk(t, `[[""]]`)
+	testDecodeOk(t, `[["false"]]`)
+	testDecodeOk(t, `[["true"]]`)
+	testDecodeOk(t, `[["42"]]`)
+
+	testDecodeOk(t, `[[""]]`)
+	testDecodeOk(t, `[["hello"]]`)
+	testDecodeOk(t, `[["hello world"]]`)
+
+	testDecodeOk(t, `[["/ ' \\ \b \t \n \f \r \""]]`)
+	testDecodeOk(t, `[["❄"]]`)
+	testDecodeOk(t, `[["\u2744"]]`)
+	testDecodeOk(t, `[["\uFfFc"]]`)       // consume replacement chars
+	testDecodeOk(t, `[["\ufffd"]]`)       // consume replacement chars
+	testDecodeOk(t, `[["\u0000"]]`)       // yes, this is valid
+	testDecodeOk(t, `[["\uD834\uDD1E"]]`) // surrogate pair
+	testDecodeOk(t, `[["\uD834\u0000"]]`) // corrupt surrogate pair
+
+	testDecodeOk(t, `[["$"]]`)      // "$"
+	testDecodeOk(t, `[["\u0024"]]`) // "$"
+
+	testDecodeOk(t, `[["\uC2A2"]]`) // "¢"
+	testDecodeOk(t, `[["¢"]]`)      // "¢"
+
+	testDecodeOk(t, `[["\u00E2\u82AC"]]`) // "€"
+	testDecodeOk(t, `[["€"]]`)            // "€"
+
+	testDecodeOk(t, `[["\uF090\u8D88"]]`) // "𐍈"
+	testDecodeOk(t, `[["𐍈"]]`)            // "𐍈"
+}
+
+func TestSmallBufferChunkData(t *testing.T) {
+	r := strings.NewReader(`[
+	  [null,"hello world"],
+	  ["foo bar", null],
+	  [null, null] ,
+	  ["foo bar",   "hello world" ]
+	]`)
+
+	lcd := largeChunkDecoder{
+		r, 0, 0,
+		0, 0,
+		make([]byte, 1),
+		bytes.NewBuffer(make([]byte, defaultStringBufferSize)),
+		nil,
+	}
+
+	if _, err := lcd.decode(); err != nil {
+		t.Fatalf("failed with small buffer: %s", err)
+	}
+}
+
+func testDecodeOk(t *testing.T, s string) {
+	var rows [][]*string
+	if err := json.Unmarshal([]byte(s), &rows); err != nil {
+		t.Fatalf("test case is not valid json / [][]*string: %s", s)
+	}
+
+	// NOTE we parse and stringify the expected result to
+	// remove superficial differences, like whitespace
+	expect, err := json.Marshal(rows)
+	if err != nil {
+		t.Fatalf("unreachable: %s", err)
+	}
+
+	rows, err = decodeLargeChunk(strings.NewReader(s), 0, 0)
+	if err != nil {
+		t.Fatalf("expected decode to succeed: %s", err)
+	}
+
+	actual, err := json.Marshal(rows)
+	if err != nil {
+		t.Fatalf("json marshal failed: %s", err)
+	}
+	if string(actual) != string(expect) {
+		t.Fatalf(`
+		result did not match expected result
+		  expect=%s
+		   bytes=(%v)
+
+		  acutal=%s
+		   bytes=(%v)`,
+			string(expect), expect,
+			string(actual), actual,
+		)
+	}
+}
+
+func testDecodeErr(t *testing.T, s string) {
+	_, err := decodeLargeChunk(strings.NewReader(s), 0, 0)
+	if err == nil {
+		t.Fatalf("expected decode to fail for input: %s", s)
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -250,6 +250,7 @@ func (sc *snowflakeConn) QueryContext(ctx context.Context, query string, args []
 		ChunkMetas:         data.Data.Chunks,
 		Total:              int64(data.Data.Total),
 		TotalRowIndex:      int64(-1),
+		CellCount:          len(data.Data.RowType),
 		Qrmk:               data.Data.Qrmk,
 		ChunkHeader:        data.Data.ChunkHeaders,
 		FuncDownload:       downloadChunk,

--- a/driver_test.go
+++ b/driver_test.go
@@ -91,6 +91,7 @@ func setup() (string, error) {
 		}
 		return defaultValue
 	}
+
 	orgSchemaname := schemaname
 	if env("TRAVIS", "") == "true" {
 		schemaname = fmt.Sprintf("TRAVIS_JOB_%v", env("TRAVIS_JOB_ID", "testschema"))
@@ -125,6 +126,10 @@ func teardown(s string) error {
 }
 
 func TestMain(m *testing.M) {
+	if value := os.Getenv("SKIP_SETUP"); value != "" {
+		os.Exit(m.Run())
+	}
+
 	orgSchemaname, err := setup()
 	if err != nil {
 		panic(err)

--- a/query.go
+++ b/query.go
@@ -30,8 +30,10 @@ type execResponseRowType struct {
 }
 
 type execResponseChunk struct {
-	URL      string `json:"url"`
-	RowCount int    `json:"rowCount"`
+	URL              string `json:"url"`
+	RowCount         int    `json:"rowCount"`
+	UncompressedSize int64  `json:"uncompressedSize"`
+	CompressedSize   int64  `json:"compressedSize"`
 }
 
 // make all data field optional

--- a/rows.go
+++ b/rows.go
@@ -3,9 +3,10 @@
 package gosnowflake
 
 import (
+	"fmt"
+
 	"context"
 	"database/sql/driver"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ const (
 )
 
 var (
-	maxChunkDownloadWorkers        = 10
+	MaxChunkDownloadWorkers        = 10
 	maxChunkDownloaderErrorCounter = 5
 )
 
@@ -47,6 +48,7 @@ type snowflakeChunkDownloader struct {
 	ctx                context.Context
 	Total              int64
 	TotalRowIndex      int64
+	CellCount          int
 	CurrentChunk       [][]*string
 	CurrentChunkIndex  int
 	CurrentChunkSize   int
@@ -147,6 +149,13 @@ func (rows *snowflakeRows) NextResultSet() error {
 	return rows.ChunkDownloader.nextResultSet()
 }
 
+func (scd *snowflakeChunkDownloader) totalUncompressedSize() (acc int64) {
+	for _, c := range scd.ChunkMetas {
+		acc += c.UncompressedSize
+	}
+	return
+}
+
 func (scd *snowflakeChunkDownloader) hasNextResultSet() bool {
 	return scd.CurrentChunkIndex < len(scd.ChunkMetas)
 }
@@ -167,16 +176,17 @@ func (scd *snowflakeChunkDownloader) start() error {
 	// start downloading chunks if exists
 	chunkMetaLen := len(scd.ChunkMetas)
 	if chunkMetaLen > 0 {
-		glog.V(2).Infof("chunks: %v", chunkMetaLen)
+		fmt.Printf("chunks: %v, total bytes: %d\n", chunkMetaLen, scd.totalUncompressedSize())
+		glog.V(2).Infof("chunks: %v, total bytes: %d", chunkMetaLen, scd.totalUncompressedSize())
 		scd.ChunksMutex = &sync.Mutex{}
 		scd.Chunks = make(map[int][][]*string)
 		scd.ChunksChan = make(chan int, chunkMetaLen)
-		scd.ChunksError = make(chan *chunkError, maxChunkDownloadWorkers)
+		scd.ChunksError = make(chan *chunkError, MaxChunkDownloadWorkers)
 		for i := 0; i < chunkMetaLen; i++ {
 			glog.V(2).Infof("add chunk to channel ChunksChan: %v", i+1)
 			scd.ChunksChan <- i
 		}
-		for i := 0; i < intMin(maxChunkDownloadWorkers, chunkMetaLen); i++ {
+		for i := 0; i < intMin(MaxChunkDownloadWorkers, chunkMetaLen); i++ {
 			scd.schedule()
 		}
 	}
@@ -346,33 +356,38 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 	defer resp.Body.Close()
 	glog.V(2).Infof("download finish chunk: %v, resp: %v", idx+1, resp)
 	if resp.StatusCode == http.StatusOK {
-		var respd [][]*string
+		start := time.Now()
 		st := &largeResultSetReader{
 			status: 0,
 			body:   resp.Body,
 		}
-		dec := json.NewDecoder(st)
-		for {
-			if err := dec.Decode(&respd); err == io.EOF {
-				break
-			} else if err != nil {
-				glog.V(1).Infof(
-					"failed to extract HTTP response body. URL: %v, err: %v", scd.ChunkMetas[idx].URL, err)
-				glog.Flush()
-				scd.ChunksError <- &chunkError{Index: idx, Error: err}
-				return
-			}
+
+		respd, err := decodeLargeChunk(st, scd.ChunkMetas[idx].RowCount, scd.CellCount)
+		if err != nil {
+			reportDownloadChunkError(err, scd, idx)
+			return
 		}
+
+		fmt.Printf(
+			"decoded %d rows w/ %d bytes in %s (chunk %v)\n",
+			scd.ChunkMetas[idx].RowCount,
+			scd.ChunkMetas[idx].UncompressedSize,
+			time.Now().Sub(start), idx+1,
+		)
+		glog.V(2).Infof(
+			"decoded %d rows w/ %d bytes in %s (chunk %v)",
+			scd.ChunkMetas[idx].RowCount,
+			scd.ChunkMetas[idx].UncompressedSize,
+			time.Now().Sub(start), idx+1,
+		)
+
 		scd.ChunksMutex.Lock()
 		scd.Chunks[idx] = respd
 		scd.ChunksMutex.Unlock()
 	} else {
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			glog.V(1).Infof(
-				"failed to extract HTTP response body. URL: %v, err: %v", scd.ChunkMetas[idx].URL, err)
-			glog.Flush()
-			scd.ChunksError <- &chunkError{Index: idx, Error: err}
+			reportDownloadChunkError(err, scd, idx)
 			return
 		}
 		glog.V(1).Infof("HTTP: %v, URL: %v, Body: %v", resp.StatusCode, scd.ChunkMetas[idx].URL, b)
@@ -387,4 +402,11 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 				MessageArgs: []interface{}{idx},
 			}}
 	}
+}
+
+func reportDownloadChunkError(err error, scd *snowflakeChunkDownloader, idx int) {
+	glog.V(1).Infof(
+		"failed to extract HTTP response body. URL: %v, err: %v", scd.ChunkMetas[idx].URL, err)
+	glog.Flush()
+	scd.ChunksError <- &chunkError{Index: idx, Error: err}
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -83,8 +83,8 @@ func downloadChunkTest(scd *snowflakeChunkDownloader, idx int) {
 func TestRowsWithChunkDownloader(t *testing.T) {
 	numChunks := 12
 	// changed the workers
-	backupMaxChunkDownloadWorkers := maxChunkDownloadWorkers
-	maxChunkDownloadWorkers = 2
+	backupMaxChunkDownloadWorkers := MaxChunkDownloadWorkers
+	MaxChunkDownloadWorkers = 2
 	glog.V(2).Info("START TESTS")
 	var i int
 	cc := make([][]*string, 0)
@@ -133,7 +133,7 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 		t.Fatalf("failed to get all results. expected:%v, got:%v", len(cc)+numChunks*rowsInChunk, cnt)
 	}
 	glog.V(2).Infof("dest: %v", dest)
-	maxChunkDownloadWorkers = backupMaxChunkDownloadWorkers
+	MaxChunkDownloadWorkers = backupMaxChunkDownloadWorkers
 	glog.V(2).Info("END TESTS")
 }
 
@@ -161,8 +161,8 @@ func downloadChunkTestError(scd *snowflakeChunkDownloader, idx int) {
 func TestRowsWithChunkDownloaderError(t *testing.T) {
 	numChunks := 12
 	// changed the workers
-	backupMaxChunkDownloadWorkers := maxChunkDownloadWorkers
-	maxChunkDownloadWorkers = 3
+	backupMaxChunkDownloadWorkers := MaxChunkDownloadWorkers
+	MaxChunkDownloadWorkers = 3
 	glog.V(2).Info("START TESTS")
 	var i int
 	cc := make([][]*string, 0)
@@ -211,7 +211,7 @@ func TestRowsWithChunkDownloaderError(t *testing.T) {
 		t.Fatalf("failed to get all results. expected:%v, got:%v", len(cc)+numChunks*rowsInChunk, cnt)
 	}
 	glog.V(2).Infof("dest: %v", dest)
-	maxChunkDownloadWorkers = backupMaxChunkDownloadWorkers
+	MaxChunkDownloadWorkers = backupMaxChunkDownloadWorkers
 	glog.V(2).Info("END TESTS")
 }
 


### PR DESCRIPTION
### Description
From the primary commit message.

>    The primary goal is to reduce to in-flight memory
    consumption to be as low as possible. This is done
    by making assumptions about the chunk structure
    and using a streaming decoder.
    
>    The secondary goal is to optimize the CPU cycles
    needed to decode the chunk. There's still more
    to do on this front, but the design in this patch
    should be conducive to future optimizations.

The impetus for this change was primarily to reduce memory pressure when downloading large `json` results. However this optimization should reduce pressure for all large results. For example, I see the following improvement for the existing large-result benchmark.

```
-- before change
BenchmarkLargeResultSet-4 1    68703150935 ns/op   6451121456 B/op    270103889 allocs/op
-- after change
BenchmarkLargeResultSet-4 1    57140518986 ns/op   3198717528 B/op    220123790 allocs/op
```

For the new `json` case, I see the following improvement. It's worth noting that I ensured my test runs used the same cached result; future comparisons may see different numbers if the cached rowset (in `S3`) is different.

```
-- before change
BenchmarkJsonResultSet-4 1  114852005941 ns/op  2964585432 B/op  149820 allocs/op
-- after change
BenchmarkJsonResultSet-4 1  68804250571 ns/op   1056399984 B/op  288150 allocs/op
```

It's worth mentioning that before hand-writing a `json` decoder, I tried a few different libraries. None of them performed as well as I would have liked, and one of the streaming libraries actually performed worse (with regards to memory pressure) than `encoding/json`. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
