### PR TITLE
Deprecate region parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Version 1.1.10
+
+- Fixed heartbeat timings. It used to start a heartbeat per query. Now it starts per connection and closes in `Close` method. #181 
+- Removed busy wait from 1) the main thread that waits for download chunk worker to finish downloads, 2) the heartbeat goroutine/thread to trigger the heartbeat to the server.
+
+## Version 1.1.9
+
+- Fixed proxy for OCSP (@brendoncarroll)
+- Disabled megacheck for Go 1.8
+- Changed the UUID dependency (@kenshaw)
+
 ## Version 1.1.8
 
 - Removed username restrition for oAuth

--- a/doc.go
+++ b/doc.go
@@ -46,10 +46,12 @@ The following connection parameters are supported:
 		assigned to your account by Snowflake. In the URL you received from
 		Snowflake, your account name is the first segment in the domain (e.g.
 		abc123 in https://abc123.snowflakecomputing.com). This parameter is
-		optional if your account is specified after the @ character.
+		optional if your account is specified after the @ character. If you are not on us-west-2 region
+        or AWS deployment, append the region and platform to the end, e.g., <account>.<region>,
+        <account>.<region>.<platform>.
 
 	* region <string>: DEPRECATED. Append a region or any sub domains before snowflakecomputing.com to the
-        end of account parameter after a dot, e.g., account=ACCOUNT.REGION
+        end of account parameter after a dot, e.g., account=<account>.<region>.
 
 	* database: Specifies the database to use by default in the client session
 		(can be changed after login).

--- a/doc.go
+++ b/doc.go
@@ -42,16 +42,14 @@ Connection Parameters
 
 The following connection parameters are supported:
 
-	* region <string>: Specifies the Snowflake region. By default, the US West region is used.
-		US East region, specify us-east-1.
-		EU (Frankfurt) region, specify eu-central-1.
-		AU (Australia) region, specify ap-southeast-2.
-
 	* account <string>: Specifies the name of your Snowflake account, where string is the name
 		assigned to your account by Snowflake. In the URL you received from
 		Snowflake, your account name is the first segment in the domain (e.g.
 		abc123 in https://abc123.snowflakecomputing.com). This parameter is
 		optional if your account is specified after the @ character.
+
+	* region <string>: DEPRECATED. Append a region or any sub domains before snowflakecomputing.com to the
+        end of account parameter after a dot, e.g., account=ACCOUNT.REGION
 
 	* database: Specifies the database to use by default in the client session
 		(can be changed after login).


### PR DESCRIPTION
### Description
Updating the doc saying region is deprecated. The parameter started confusion when the subdomain started having more than a region. Instead, `account` parameter will take everything before `snowflakecomputing.com`.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
