### PR TITLE
add a configurable retry limit

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -16,6 +16,11 @@ import (
 	"sync"
 )
 
+var (
+	// MaxRetryHTTPCount specifies the maximum number of times an HTTP request may be retried
+	MaxRetryHTTPCount = 3
+)
+
 var random *rand.Rand
 
 func init() {
@@ -96,6 +101,12 @@ func retryHTTP(
 		}
 		// cannot just return 4xx and 5xx status as the error can be sporadic. retry often helps.
 		if err != nil {
+			// bound the number of retry attempts so we don't loop forever
+			if retryCounter > MaxRetryHTTPCount {
+				glog.V(2).Infof(
+					"failed http connection. no response is returned. err: %v. retry limit exceeded\n", err)
+				break
+			}
 			glog.V(2).Infof(
 				"failed http connection. no response is returned. err: %v. retrying...\n", err)
 		} else {


### PR DESCRIPTION
### Description
We have observed cases where goroutines end up in an infinite retry loop, likely because a `context` was used that never times out. While this may sometimes be a user error, there are also a few places in this codebase where `context.Background()` or `context.TODO()` is used when issuing requests. As such, this patch is a stop-gap to ensure that _all_ retry attempts eventually terminate. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
