### PR TITLE
Timeout fix

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1531,9 +1531,9 @@ func TestResultNoRows(t *testing.T) {
 }
 
 /**
-	This test is temporary disabled since we are not able to stably pass this test on
-	Travis
- */
+This test is temporary disabled since we are not able to stably pass this test on
+Travis
+*/
 func testCancelQuery(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		ctx := context.Background()

--- a/dsn.go
+++ b/dsn.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	defaultClientTimeout  = 900 * time.Second
-	defaultLoginTimeout   = 60 * time.Second
-	defaultRequestTimeout = 0 * time.Second
+	defaultClientTimeout  = 60 * time.Second // Timeout for network round trip + read out http response
+	defaultLoginTimeout   = 60 * time.Second // Timeout for retry for login EXCLUDING clientTimeout
+	defaultRequestTimeout = 0 * time.Second  // Timeout for retry for request EXCLUDING clientTimeout
 	defaultJWTTimeout     = 60 * time.Second
 	defaultAuthenticator  = "snowflake"
 	defaultDomain         = ".snowflakecomputing.com"
@@ -41,8 +41,8 @@ type Config struct {
 	Passcode           string
 	PasscodeInPassword bool
 
-	LoginTimeout     time.Duration // Login timeout
-	RequestTimeout   time.Duration // request timeout
+	LoginTimeout     time.Duration // Login retry timeout EXCLUDING network roundtrip and read out http response
+	RequestTimeout   time.Duration // request retry timeout EXCLUDING network roundtrip and read out http response
 	JWTExpireTimeout time.Duration // JWT expire after timeout
 
 	Application  string // application name.

--- a/restful.go
+++ b/restful.go
@@ -190,7 +190,7 @@ func postRestfulQueryHelper(
 			fullURL := fmt.Sprintf(
 				"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, resultURL)
 
-			resp, err = sr.FuncGet(ctx, sr, fullURL, headers, 0)
+			resp, err = sr.FuncGet(ctx, sr, fullURL, headers, timeout)
 			respd = execResponse{} // reset the response
 			err = json.NewDecoder(resp.Body).Decode(&respd)
 			resp.Body.Close()


### PR DESCRIPTION
### Description
This PR intentions to address requirements presented in PR#193 including: 
1. Address documentations for time out explain
2. Enable configuration for RequestTimeout for result polling. Previously if we success on issuing a query but fail on one of the result chunk polling, the driver would retry forever even if the customer set the `requestTimeout` to be some finite number.

It has also shorten the network Client timeout.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
