### PR TITLE
Implement retryIDReplacer and add test cases.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -116,6 +116,7 @@ func postAuth(
 	timeout time.Duration) (
 	data *authResponse, err error) {
 	params.Add("requestId", uuid.New().String())
+	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port,
 		"/session/v1/login-request?"+params.Encode())

--- a/driver_test.go
+++ b/driver_test.go
@@ -1531,9 +1531,9 @@ func TestResultNoRows(t *testing.T) {
 }
 
 /**
-	This test is temporary disabled since we are not able to stably pass this test on
-	Travis
- */
+This test is temporary disabled since we are not able to stably pass this test on
+Travis
+*/
 func testCancelQuery(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		ctx := context.Background()

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -57,6 +57,7 @@ func (hc *heartbeat) heartbeatMain() error {
 	glog.V(2).Info("Heartbeating!")
 	params := &url.Values{}
 	params.Add("requestId", uuid.New().String())
+	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", hc.restful.Protocol, hc.restful.Host, hc.restful.Port, "/session/heartbeat?"+params.Encode())
 	headers := make(map[string]string)

--- a/restful.go
+++ b/restful.go
@@ -147,6 +147,7 @@ func postRestfulQueryHelper(
 	data *execResponse, err error) {
 	glog.V(2).Infof("params: %v", params)
 	params.Add("requestId", requestID)
+	params.Add(retryKey, uuid.New().String())
 	if sr.Token != "" {
 		headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sr.Token)
 	}
@@ -232,6 +233,7 @@ func closeSession(sr *snowflakeRestful) error {
 	params := &url.Values{}
 	params.Add("delete", "true")
 	params.Add("requestId", uuid.New().String())
+	params.Add(retryKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, "/session?"+params.Encode())
 
@@ -287,6 +289,7 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful) error {
 	glog.V(2).Info("start renew session")
 	params := &url.Values{}
 	params.Add("requestId", uuid.New().String())
+	params.Add(retryKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, "/session/token-request?"+params.Encode())
 
@@ -354,6 +357,7 @@ func cancelQuery(sr *snowflakeRestful, requestID string) error {
 	glog.V(2).Info("cancel query")
 	params := &url.Values{}
 	params.Add("requestId", uuid.New().String())
+	params.Add(retryKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, "/queries/v1/abort-request?"+params.Encode())
 

--- a/restful.go
+++ b/restful.go
@@ -147,7 +147,7 @@ func postRestfulQueryHelper(
 	data *execResponse, err error) {
 	glog.V(2).Infof("params: %v", params)
 	params.Add("requestId", requestID)
-	params.Add(retryKey, uuid.New().String())
+	params.Add(requestGUIDKey, uuid.New().String())
 	if sr.Token != "" {
 		headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sr.Token)
 	}
@@ -233,7 +233,7 @@ func closeSession(sr *snowflakeRestful) error {
 	params := &url.Values{}
 	params.Add("delete", "true")
 	params.Add("requestId", uuid.New().String())
-	params.Add(retryKey, uuid.New().String())
+	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, "/session?"+params.Encode())
 
@@ -289,7 +289,7 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful) error {
 	glog.V(2).Info("start renew session")
 	params := &url.Values{}
 	params.Add("requestId", uuid.New().String())
-	params.Add(retryKey, uuid.New().String())
+	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, "/session/token-request?"+params.Encode())
 
@@ -357,7 +357,7 @@ func cancelQuery(sr *snowflakeRestful, requestID string) error {
 	glog.V(2).Info("cancel query")
 	params := &url.Values{}
 	params.Add("requestId", uuid.New().String())
-	params.Add(retryKey, uuid.New().String())
+	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := fmt.Sprintf(
 		"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, "/queries/v1/abort-request?"+params.Encode())
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -77,17 +77,17 @@ func (c *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return ret, nil
 }
 
-func TestRetryId(t *testing.T) {
-	var ridReplacer retryIDReplacerI
+func TestRequestGUID(t *testing.T) {
+	var ridReplacer requestGUIDReplacerI
 	var testURL string
 	var actualURL string
 	retryTime := 4
 
 	// empty url
 	testURL = ""
-	ridReplacer = makeRetryIDReplacer(testURL)
+	ridReplacer = makeRequestGUIDReplacer(testURL)
 	for i := 0; i < retryTime; i++ {
-		actualURL = ridReplacer.replaceRetryID()
+		actualURL = ridReplacer.replace()
 		if actualURL != "" {
 			t.Fatalf("empty url not replaced by an empty one, got %s", actualURL)
 		}
@@ -95,9 +95,9 @@ func TestRetryId(t *testing.T) {
 
 	// url with on retry id
 	testURL = "/requestId=123-1923-9?param2=value"
-	ridReplacer = makeRetryIDReplacer(testURL)
+	ridReplacer = makeRequestGUIDReplacer(testURL)
 	for i := 0; i < retryTime; i++ {
-		actualURL = ridReplacer.replaceRetryID()
+		actualURL = ridReplacer.replace()
 
 		if actualURL != testURL {
 			t.Fatalf("url without retry id not replaced by origin one, got %s", actualURL)
@@ -106,12 +106,12 @@ func TestRetryId(t *testing.T) {
 
 	// url with retry id
 	// With both prefix and suffix
-	prefix := "/requestId=123-1923-9?" + retryKey + "="
+	prefix := "/requestId=123-1923-9?" + requestGUIDKey + "="
 	suffix := "?param2=value"
 	testURL = prefix + "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" + suffix
-	ridReplacer = makeRetryIDReplacer(testURL)
+	ridReplacer = makeRequestGUIDReplacer(testURL)
 	for i := 0; i < retryTime; i++ {
-		actualURL = ridReplacer.replaceRetryID()
+		actualURL = ridReplacer.replace()
 		if (!strings.HasPrefix(actualURL, prefix)) ||
 			(!strings.HasSuffix(actualURL, suffix)) ||
 			len(testURL) != len(actualURL) {
@@ -120,12 +120,12 @@ func TestRetryId(t *testing.T) {
 	}
 
 	// With no suffix
-	prefix = "/requestId=123-1923-9?" + retryKey + "="
+	prefix = "/requestId=123-1923-9?" + requestGUIDKey + "="
 	suffix = ""
 	testURL = prefix + "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" + suffix
-	ridReplacer = makeRetryIDReplacer(testURL)
+	ridReplacer = makeRequestGUIDReplacer(testURL)
 	for i := 0; i < retryTime; i++ {
-		actualURL = ridReplacer.replaceRetryID()
+		actualURL = ridReplacer.replace()
 		if (!strings.HasPrefix(actualURL, prefix)) ||
 			(!strings.HasSuffix(actualURL, suffix)) ||
 			len(testURL) != len(actualURL) {
@@ -134,12 +134,12 @@ func TestRetryId(t *testing.T) {
 
 	}
 	// With no prefix
-	prefix = retryKey + "="
+	prefix = requestGUIDKey + "="
 	suffix = "?param2=value"
 	testURL = prefix + "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" + suffix
-	ridReplacer = makeRetryIDReplacer(testURL)
+	ridReplacer = makeRequestGUIDReplacer(testURL)
 	for i := 0; i < retryTime; i++ {
-		actualURL = ridReplacer.replaceRetryID()
+		actualURL = ridReplacer.replace()
 		if (!strings.HasPrefix(actualURL, prefix)) ||
 			(!strings.HasSuffix(actualURL, suffix)) ||
 			len(testURL) != len(actualURL) {


### PR DESCRIPTION
### Description
For debugging reason, we want to generate an retry id every time we resend to server

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
