### PR TITLE
Respect RequestTimeout in more places

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -375,7 +375,7 @@ func cancelQuery(sr *snowflakeRestful, requestID string) error {
 		return err
 	}
 
-	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, reqByte, 0, false)
+	resp, err := sr.FuncPost(context.TODO(), sr, fullURL, headers, reqByte, sr.RequestTimeout, false)
 	if err != nil {
 		return err
 	}

--- a/rows.go
+++ b/rows.go
@@ -353,7 +353,7 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 		headers[headerSseCKey] = scd.Qrmk
 	}
 
-	resp, err := scd.FuncGet(ctx, scd, scd.ChunkMetas[idx].URL, headers, 0)
+	resp, err := scd.FuncGet(ctx, scd, scd.ChunkMetas[idx].URL, headers, scd.sc.rest.RequestTimeout)
 	if err != nil {
 		raiseDownloadError(scd, idx, err)
 		return


### PR DESCRIPTION
### Description
This is a followup PR related to the recent timeout and leaked goroutine fixes. Just patching up more places where the configured `RequestTimeout` isn't used.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
