### PR TITLE
Fix segfault led by configurable timeout.

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -28,7 +28,6 @@ var (
 	rolename         string
 	dsn              string
 	host             string
-	purehost         string
 	port             string
 	protocol         string
 	customPrivateKey bool            // Whether user has specified the private key path

--- a/rows_test.go
+++ b/rows_test.go
@@ -308,6 +308,9 @@ func TestDownloadChunkInvalidResponseBody(t *testing.T) {
 			"dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
 	scd := &snowflakeChunkDownloader{
+		sc: &snowflakeConn{
+			rest: &snowflakeRestful{RequestTimeout: defaultRequestTimeout},
+		},
 		ctx:                context.Background(),
 		ChunkMetas:         cm,
 		TotalRowIndex:      int64(-1),
@@ -347,6 +350,9 @@ func TestDownloadChunkErrorStatus(t *testing.T) {
 			"dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
 	scd := &snowflakeChunkDownloader{
+		sc: &snowflakeConn{
+			rest: &snowflakeRestful{RequestTimeout: defaultRequestTimeout},
+		},
 		ctx:                context.Background(),
 		ChunkMetas:         cm,
 		TotalRowIndex:      int64(-1),


### PR DESCRIPTION
### Description
PR #196 add in some configurable timeout value into the code and that leads to segfault in some test cases.
This PR fix those segfaults.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
