### PR TITLE
Remove unnecessary go routine and fix context cancel/timeout handling

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1546,7 +1546,7 @@ func TestCancelQuery(t *testing.T) {
 		}
 
 		if err.Error() != "context deadline exceeded" {
-			dbt.Fatal("Timeout failed")
+			dbt.Fatalf("Timeout error mismatch: expect %v, receive %v", context.DeadlineExceeded, err.Error())
 		}
 	})
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -1533,13 +1533,13 @@ func TestResultNoRows(t *testing.T) {
 This test is temporary disabled since we are not able to stably pass this test on
 Travis
 */
-func testCancelQuery(t *testing.T) {
+func TestCancelQuery(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
-		_, err := dbt.db.QueryContext(ctx, "SELECT DISTINCT 1 FROM TABLE(GENERATOR(TIMELIMIT=> 10))")
+		_, err := dbt.db.QueryContext(ctx, "SELECT DISTINCT 1 FROM TABLE(GENERATOR(TIMELIMIT=> 100))")
 
 		if err == nil {
 			dbt.Fatal("No timeout error returned")
@@ -1690,7 +1690,7 @@ func TestTimezoneSessionParameter(t *testing.T) {
 	createDSN("UTC")
 }
 
-func testLargeSetResultCancel(t *testing.T) {
+func TestLargeSetResultCancel(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		c := make(chan error)
 		ctx := context.Background()

--- a/driver_test.go
+++ b/driver_test.go
@@ -1529,10 +1529,6 @@ func TestResultNoRows(t *testing.T) {
 	})
 }
 
-/**
-This test is temporary disabled since we are not able to stably pass this test on
-Travis
-*/
 func TestCancelQuery(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		ctx := context.Background()

--- a/dsn.go
+++ b/dsn.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultClientTimeout  = 200 * time.Second // Timeout for network round trip + read out http response
+	defaultClientTimeout  = 900 * time.Second // Timeout for network round trip + read out http response
 	defaultLoginTimeout   = 60 * time.Second  // Timeout for retry for login EXCLUDING clientTimeout
 	defaultRequestTimeout = 0 * time.Second   // Timeout for retry for request EXCLUDING clientTimeout
 	defaultJWTTimeout     = 60 * time.Second

--- a/dsn.go
+++ b/dsn.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	defaultClientTimeout  = 60 * time.Second // Timeout for network round trip + read out http response
-	defaultLoginTimeout   = 60 * time.Second // Timeout for retry for login EXCLUDING clientTimeout
-	defaultRequestTimeout = 0 * time.Second  // Timeout for retry for request EXCLUDING clientTimeout
+	defaultClientTimeout  = 200 * time.Second // Timeout for network round trip + read out http response
+	defaultLoginTimeout   = 60 * time.Second  // Timeout for retry for login EXCLUDING clientTimeout
+	defaultRequestTimeout = 0 * time.Second   // Timeout for retry for request EXCLUDING clientTimeout
 	defaultJWTTimeout     = 60 * time.Second
 	defaultAuthenticator  = "snowflake"
 	defaultDomain         = ".snowflakecomputing.com"

--- a/restful.go
+++ b/restful.go
@@ -121,9 +121,8 @@ func postRestfulQuery(
 	err = sr.FuncCancelQuery(sr, requestID)
 	if err != nil {
 		return nil, err
-	} else {
-		return nil, ctx.Err()
 	}
+	return nil, ctx.Err()
 }
 
 func postRestfulQueryHelper(

--- a/restful.go
+++ b/restful.go
@@ -114,11 +114,11 @@ func postRestfulQuery(
 	data, err = sr.FuncPostQueryHelper(ctx, sr, params, headers, body, timeout, requestID)
 
 	// errors other than context timeout and cancel would be returned to upper layers
-	if err != context.Canceled || err != context.DeadlineExceeded {
+	if err != context.Canceled && err != context.DeadlineExceeded {
 		return data, err
 	}
 
-	// For cancel cases special cancel need to be sent
+	// For context cancel/timeout cases, special cancel request need to be sent
 	err = sr.FuncCancelQuery(sr, requestID)
 	if err != nil {
 		return nil, err

--- a/restful.go
+++ b/restful.go
@@ -113,7 +113,8 @@ func postRestfulQuery(
 
 	data, err = sr.FuncPostQueryHelper(ctx, sr, params, headers, body, timeout, requestID)
 
-	if err != context.Canceled {
+	// errors other than context timeout and cancel would be returned to upper layers
+	if err != context.Canceled || err != context.DeadlineExceeded {
 		return data, err
 	}
 

--- a/retry.go
+++ b/retry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -147,8 +148,8 @@ func retryHTTP(
 			req.Header.Set(k, v)
 		}
 		res, err = client.Do(req)
-		if err == nil && res.StatusCode == http.StatusOK || err == context.Canceled {
-			// exit if success or canceled
+		if err == nil && res.StatusCode == http.StatusOK {
+			// exit if success
 			break
 		}
 		if raise4XX && res != nil && res.StatusCode >= 400 && res.StatusCode < 500 {
@@ -156,6 +157,15 @@ func retryHTTP(
 			// This is currently used for Snowflake login. The caller must generate an error object based on HTTP status.
 			break
 		}
+
+		// Cancel or Timeout
+		urlError, isUrlError := err.(net.Error)
+		if err != nil && isUrlError {
+			if urlError.Timeout() {
+				return nil, urlError
+			}
+		}
+
 		// cannot just return 4xx and 5xx status as the error can be sporadic. retry often helps.
 		if err != nil {
 			glog.V(2).Infof(

--- a/retry.go
+++ b/retry.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -159,10 +159,11 @@ func retryHTTP(
 		}
 
 		// Cancel or Timeout
-		urlError, isUrlError := err.(net.Error)
-		if err != nil && isUrlError {
-			if urlError.Timeout() {
-				return nil, urlError
+		if err != nil {
+			urlError, isURLError := err.(*url.Error)
+			if isURLError &&
+				(urlError.Err == context.DeadlineExceeded || urlError.Err == context.Canceled) {
+				return res, urlError.Err
 			}
 		}
 

--- a/retry.go
+++ b/retry.go
@@ -158,7 +158,7 @@ func retryHTTP(
 			break
 		}
 
-		// Cancel or Timeout
+		// context cancel or timeout
 		if err != nil {
 			urlError, isURLError := err.(*url.Error)
 			if isURLError &&

--- a/rows.go
+++ b/rows.go
@@ -327,17 +327,9 @@ func (r *largeResultSetReader) Read(p []byte) (n int, err error) {
 func downloadChunk(scd *snowflakeChunkDownloader, idx int) {
 	glog.V(2).Infof("download start chunk: %v", idx+1)
 
-	execDownloadChan := make(chan struct{})
-
-	go func() {
-		scd.FuncDownloadHelper(scd.ctx, scd, idx)
-		close(execDownloadChan)
-	}()
-
-	select {
-	case <-scd.ctx.Done():
+	scd.FuncDownloadHelper(scd.ctx, scd, idx)
+	if scd.ctx.Err() == context.Canceled {
 		scd.ChunksError <- &chunkError{Index: idx, Error: scd.ctx.Err()}
-	case <-execDownloadChan:
 	}
 }
 

--- a/rows.go
+++ b/rows.go
@@ -328,7 +328,7 @@ func downloadChunk(scd *snowflakeChunkDownloader, idx int) {
 	glog.V(2).Infof("download start chunk: %v", idx+1)
 
 	scd.FuncDownloadHelper(scd.ctx, scd, idx)
-	if scd.ctx.Err() == context.Canceled {
+	if scd.ctx.Err() == context.Canceled || scd.ctx.Err() == context.DeadlineExceeded {
 		scd.ChunksError <- &chunkError{Index: idx, Error: scd.ctx.Err()}
 	}
 }


### PR DESCRIPTION
### Description
**Main Goal: Go-routine elimination**
This PR mainly tries to remove some of the unnecessary go routine in our code base to avoid go routine launching overhead.

**Sub Goal: correct context cancel/timeout handling**
There is a bug identified and fixed when trying to approaching the main goal of this PR: the context cancel/timeout is not handled correctly and therefore could lead to go-routine leak before the go-routine elimination, or infinite loop after the main goal is achieved.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
