### PR TITLE
do not sleep through a context timeout

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -198,7 +198,15 @@ func retryHTTP(
 		}
 		fullURL = rIDReplacer.replace()
 		glog.V(2).Infof("sleeping %v. to timeout: %v. retrying", sleepTime, totalTimeout)
-		time.Sleep(sleepTime)
+
+		await := time.NewTimer(sleepTime)
+		select {
+		case <-await.C:
+			// retry the request
+		case <-ctx.Done():
+			await.Stop()
+			return res, ctx.Err()
+		}
 	}
 	return res, err
 }


### PR DESCRIPTION
### Description
Rather than unconditionally sleeping during retry, the wait code should select on 1) the timer and 2) the context. This way a large `sleepTime` doesn't interfere with a higher-level context timeout.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
