### PR TITLE
Follow lint's new path as they enforce it.

### DIFF
--- a/gosnowflake.mak
+++ b/gosnowflake.mak
@@ -4,7 +4,7 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 setup:
 	go get -u github.com/golang/dep/cmd/dep
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 	go get github.com/Songmu/make2help/cmd/make2help
 	[[ $$(go version | awk '{print $3}' | cut -d'.' -f 2) != "8" ]] && go get honnef.co/go/tools/cmd/megacheck || true
 


### PR DESCRIPTION
### Description
Since 2018-10-11, the lint package started enforcing the new path.

This change updates the path for golint in order to avoid build failure.

See golang/lint/issues/415

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
