### PR TITLE
disable Travis test for golang v1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: go
 go:
-  - "1.8"
   - "1.9"
   - "1.10"
   - tip


### PR DESCRIPTION
### Description
Currently the test for golang v1.8 is failing due to installing golint. The error message is as:
```
go get golang.org/x/lint/golint
# golang.org/x/tools/go/internal/gcimporter
../../../golang.org/x/tools/go/internal/gcimporter/bexport.go:212: obj.IsAlias undefined (type *types.TypeName has no field or method IsAlias)
make: *** [setup] Error 2
```
Disabled the test for 1.8 for now to unblock Release.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
