### PR TITLE
Handle extra snowflake parameter 'type'

### DIFF
--- a/datatype.go
+++ b/datatype.go
@@ -93,6 +93,7 @@ type SnowflakeParameter struct {
 	SetByThreadName  string
 	SetByClass       string
 	ParameterComment string
+	Unknown          string // Reserve for added parameter
 }
 
 func populateSnowflakeParameter(colname string, p *SnowflakeParameter) interface{} {
@@ -123,6 +124,7 @@ func populateSnowflakeParameter(colname string, p *SnowflakeParameter) interface
 		return &p.ParameterComment
 	default:
 		debugPanicf("unknown type: %v", colname)
+		return &p.Unknown
 	}
 }
 

--- a/datatype.go
+++ b/datatype.go
@@ -122,7 +122,7 @@ func populateSnowflakeParameter(colname string, p *SnowflakeParameter) interface
 	case "parameter_comment":
 		return &p.ParameterComment
 	default:
-		panic("unknown type " + colname)
+		debugPanicf("unknown type: %v", colname)
 	}
 }
 

--- a/datatype.go
+++ b/datatype.go
@@ -93,6 +93,7 @@ type SnowflakeParameter struct {
 	SetByThreadName  string
 	SetByClass       string
 	ParameterComment string
+	Type             string
 	Unknown          string // Reserve for added parameter
 }
 
@@ -122,6 +123,8 @@ func populateSnowflakeParameter(colname string, p *SnowflakeParameter) interface
 		return &p.SetByClass
 	case "parameter_comment":
 		return &p.ParameterComment
+	case "type":
+		return &p.Type
 	default:
 		debugPanicf("unknown type: %v", colname)
 		return &p.Unknown

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,9 @@
+// +build sfdebug
+
+package gosnowflake
+
+import "log"
+
+func debugPanicf(fmt string, args ...interface{}) {
+	log.Panicf(fmt, args...)
+}

--- a/release.go
+++ b/release.go
@@ -1,0 +1,5 @@
+// +build !sfdebug
+
+package gosnowflake
+
+func debugPanicf(fmt string, args ...interface{}) {}


### PR DESCRIPTION
### Description
A new parameter 'type' is added on the server side. This PR align driver to that change.

Also, for backward compatibility, the panic would only thrown when sfdebug tag is on. Otherwise the unknown parameter would be attached to the `Unknown` field.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
