### PR TITLE
Perform check on error for pingpong response.

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -182,6 +182,11 @@ func postRestfulQueryHelper(
 				"%s://%s:%d%s", sr.Protocol, sr.Host, sr.Port, resultURL)
 
 			resp, err = sr.FuncGet(ctx, sr, fullURL, headers, timeout)
+			if err != nil {
+				glog.V(1).Infof("failed to get response. err: %v", err)
+				glog.Flush()
+				return nil, err
+			}
 			respd = execResponse{} // reset the response
 			err = json.NewDecoder(resp.Body).Decode(&respd)
 			resp.Body.Close()


### PR DESCRIPTION
### Description
Fix SNOW-60883: https://snowflakecomputing.atlassian.net/browse/SNOW-60883

> Observe has identified a potential defect in GoDriver.
> 
> panic: runtime error: invalid memory address or nil pointer dereference recovered
> panic: runtime error: invalid memory address or nil pointer dereference signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xacd57b
> 
> goroutine 64 running: observe/load/snowflake.(*snowflakeInserter).Insert.func1(0xc00018d4d0, 0xc001eaba78, 0xc00036d280, 0xc00018cea0) 
> /home/dev/observe/code/go/src/observe/load/snowflake/snowflake_inserter.go:57 +0x263
> panic(0xc470c0, 0x1463360) /usr/local/src/runtime/panic.go:513 +0x1b9 
> observe/vendor/github.com/snowflakedb/gosnowflake.postRestfulQueryHelper(0xeb7b80, 0xc00018cb70, 0xc000422c40, 0xc001e745a0, 0xc001d6a2d0, 0xc000332000, 0x4c2, 0x500, 0x0, 0xc0004066c0, ...) /home/dev/observe/code/go/src/observe/vendor/github.com/snowflakedb/gosnowflake/restful.go:186 +0x8cb 
> observe/vendor/github.com/snowflakedb/gosnowflake.postRestfulQuery(0xeb7b80, 0xc00018cb70, 0xc000422c40, 0xc001e745a0, 0xc001d6a2d0, 0xc000332000, 0x4c2, 0x500, 0x0, 0xc56a01, ...)
> /home/dev/observe/code/go/src/observe/vendor/github.com/snowflakedb/gosnowflake/restful.go:114 +0xf6 observe/vendor/github.com/snowflakedb/gosnowflake.(*snowflakeConn).exec(0xc000366f40, 0xeb7b80, 0xc00018cb70, 0xc000397080, 0x292, 0x6f0000, 0xc0004b85a0, 0xc, 0xc, 0xc001eab128, ...) 
> /home/dev/observe/code/go/src/observe/vendor/github.com/snowflakedb/gosnowflake/connection.go:98 +0x32d
> observe/vendor/github.com/snowflakedb/gosnowflake.(*snowflakeConn).ExecContext(0xc000366f40, 0xeb7b80, 0xc00018cb70, 0xc000397080, 0x292, 0xc0004b85a0, 0xc, 0xc, 0xbeae80, 0xc000feeef0, ...) /home/dev/observe/code/go/src/observe/vendor/github.com/snowflakedb/gosnowflake/connection.go:206 +0x137
> As per the customer:
> 
> The Snowflake code in question starts at restful.go:184:
> 
> resp, err = sr.FuncGet(ctx, sr, fullURL, headers, timeout)
> respd = execResponse{} // reset the response
> err = json.NewDecoder(resp.Body).Decode(&respd)
> 
> The crash happens when cancelling the context. That is, we pass a context.Context into Snowflake that has been created with context.WithCancel() and eventually call cancel() to abort the query (because it had been blocked on a lock attempt for a very long time).
> 
> I assume that sr.FuncGet() bails out and returns a nil resp. Trying to access resp.Body at line 186 then hits the nil pointer dereference.
> 
> The code needs to check for err != nil and not access resp in that case.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
