### PR TITLE
Fixing TIMESTAMP_LTZ serialization issues

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -113,12 +113,7 @@ func valueToString(v driver.Value, tsmode string) (*string, error) {
 				s := fmt.Sprintf("%d",
 					(tm.Hour()*3600+tm.Minute()*60+tm.Second())*1e9+tm.Nanosecond())
 				return &s, nil
-			case "TIMESTAMP_NTZ":
-				s := fmt.Sprintf("%d", tm.UnixNano())
-				return &s, nil
-			case "TIMESTAMP_LTZ":
-				_, offset := tm.Zone()
-				tm = tm.Add(time.Second * time.Duration(offset))
+			case "TIMESTAMP_NTZ", "TIMESTAMP_LTZ":
 				s := fmt.Sprintf("%d", tm.UnixNano())
 				return &s, nil
 			case "TIMESTAMP_TZ":
@@ -202,10 +197,7 @@ func stringToValue(dest *driver.Value, srcColumnMeta execResponseRowType, srcVal
 		if err != nil {
 			return err
 		}
-		tt := time.Unix(sec, nsec)
-		zone, offset := tt.Zone() // get timezone for the given datetime
-		glog.V(2).Infof("local: %v, %v", zone, offset)
-		*dest = tt.Add(time.Second * time.Duration(-offset))
+		*dest = time.Unix(sec, nsec)
 		return nil
 	case "timestamp_tz":
 		glog.V(2).Infof("tz: %v", *srcValue)


### PR DESCRIPTION
### Description
Currently, values of TIMESTAMP_LTZ columns are not being correctly deserialized into time.Time when local environment's timezone is not UTC. Also, values of time.Time are being incorrectly serialized when used as query parameters with TIMESTAMP_LTZ columns.

### Deserialization example:

#### Before the fix:
```
CREATE TABLE example (t1 TIMESTAMP_LTZ, t2 TIMESTAMP_LTZ);
INSERT INTO example VALUES ('2019-02-06 21:24:52 -00:00', '2019-02-06 13:25:12 -08:00');
SELECT * FROM example;

+-------------------------------+-------------------------------+
| T1                            | T2                            |
|-------------------------------+-------------------------------|
| 2019-02-06 13:24:52.000 -0800 | 2019-02-06 13:25:12.000 -0800 |
+-------------------------------+-------------------------------+
```
☝️both converted into America/Los_Angeles as expected

But when you query it from Go on a system in America/Los_Angeles timezone:
```
	rows, err := db.Query("SELECT * FROM example")
	if err != nil {
		panic(err.Error())
	}

	var t1, t2 time.Time
	for rows.Next() {
		if err := rows.Scan(&t1, &t2); err != nil {
			panic(err.Error())
		}

		fmt.Printf("t1=%s, t2=%s", t1.Format(time.RFC3339), t2.Format(time.RFC3339))
	}
```

It prints out:
```t1=2019-02-06T21:24:52-08:00, t2=2019-02-06T21:25:12-08:00```

☝️both timestamps have values as if they were in UTC, but they're annotated with the local timezone.

#### After the fix:
```t1=2019-02-06T13:24:52-08:00, t2=2019-02-06T13:25:12-08:00```

### Serialization example:

#### Before the fix:
Timestamps inserted into the same table with this go code:
```
db.Exec("INSERT INTO example VALUES (?, ?)", gosnowflake.DataTypeTimestampLtz, time.Now(), gosnowflake.DataTypeTimestampLtz, time.Now().UTC())
```
look in the database like this:
```
+-------------------------------+-------------------------------+
| T1                            | T2                            |
|-------------------------------+-------------------------------|
| 2019-02-06 06:59:54.751 -0800 | 2019-02-06 14:59:54.751 -0800 |
+-------------------------------+-------------------------------+
```
☝️T1 is 8 hours behind

After the fix:
```
+-------------------------------+-------------------------------+
| T1                            | T2                            |
|-------------------------------+-------------------------------|
| 2019-02-06 15:02:53.319 -0800 | 2019-02-06 15:02:53.319 -0800 |
+-------------------------------+-------------------------------+
```

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [?] All tests passing
- [/] Extended the README / documentation, if necessary
