### PR TITLE
SNOW-69546 disable 0000-00-00 date test

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -1003,8 +1003,6 @@ func TestDateTime(t *testing.T) {
 		{"DATE", format[:10], []timeTest{
 			{t: time.Date(2011, 11, 20, 0, 0, 0, 0, time.UTC)},
 			{t: time.Date(2, 8, 2, 0, 0, 0, 0, time.UTC), s: "0002-08-02"},
-			// 0000-00-00 is not supported but returns a consistent result
-			{t: time.Date(2, 11, 30, 0, 0, 0, 0, time.UTC), s: "0000-00-00"},
 		}},
 		{"TIME", format[11:19], []timeTest{
 			{t: afterTime(t0, "12345s")},


### PR DESCRIPTION
### Description
The behavior of SELECT 0000-00-00::DATE has changed due to server side change. Disable the test case given that the change is not finalized yet.

See https://snowflakecomputing.atlassian.net/browse/SNOW-66957 for detail.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
