### PR TITLE
Disabling tip test for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
   - go: '1.10'
   - go: 1.11.x
-  - go: tip
   - go: 1.11.x
     env: SNOWFLAKE_AZURE=true
 install:


### PR DESCRIPTION
### Description
Disabling tip test for now to mitigate megacache issue on go dev version.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
