### PR TITLE
SNOW-66129 Add SERVICE_NAME support to Golang

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -27,11 +27,12 @@ const (
 )
 
 type snowflakeConn struct {
-	cfg            *Config
-	rest           *snowflakeRestful
-	SequeceCounter uint64
-	QueryID        string
-	SQLState       string
+	cfg             *Config
+	rest            *snowflakeRestful
+	SequenceCounter uint64
+	ServiceName     string
+	QueryID         string
+	SQLState        string
 }
 
 // isDml returns true if the statement type code is in the range of DML.
@@ -49,7 +50,7 @@ func (sc *snowflakeConn) exec(
 	ctx context.Context,
 	query string, noResult bool, isInternal bool, parameters []driver.NamedValue) (*execResponse, error) {
 	var err error
-	counter := atomic.AddUint64(&sc.SequeceCounter, 1) // query sequence counter
+	counter := atomic.AddUint64(&sc.SequenceCounter, 1) // query sequence counter
 
 	req := execRequest{
 		SQLText:    query,

--- a/connection.go
+++ b/connection.go
@@ -24,13 +24,13 @@ const (
 
 const (
 	sessionClientSessionKeepAlive = "client_session_keep_alive"
+	serviceName                   = "service_name"
 )
 
 type snowflakeConn struct {
 	cfg             *Config
 	rest            *snowflakeRestful
 	SequenceCounter uint64
-	ServiceName     string
 	QueryID         string
 	SQLState        string
 }
@@ -89,6 +89,9 @@ func (sc *snowflakeConn) exec(
 	headers["Content-Type"] = headerContentTypeApplicationJSON
 	headers["accept"] = headerAcceptTypeApplicationSnowflake // TODO v1.1: change to JSON in case of PUT/GET
 	headers["User-Agent"] = userAgent
+	if serviceName, ok := sc.cfg.Params[serviceName]; ok {
+		headers["X-Snowflake-Service"] = *serviceName
+	}
 
 	jsonBody, err := json.Marshal(req)
 	if err != nil {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,62 @@
+package gosnowflake
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+)
+
+const serviceNameStub = "SV"
+const serviceNameAppend = "a"
+
+// postQueryMock would generate a response based on the X-Snowflake-Service header, to generate a response
+// with the SERVICE_NAME field appending a character at the end of the header
+// This way it could test both the send and receive logic
+func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration) (*execResponse, error) {
+	var serviceName string
+	if serviceHeader, ok := headers["X-Snowflake-Service"]; ok {
+		serviceName = serviceHeader + serviceNameAppend
+	} else {
+		serviceName = serviceNameStub
+	}
+
+	dd := &execResponseData{
+		Parameters: []nameValueParameter{{"SERVICE_NAME", serviceName}},
+	}
+	return &execResponse{
+		Data:    *dd,
+		Message: "",
+		Code:    "0",
+		Success: true,
+	}, nil
+}
+
+// TestServiceName tests two things:
+// 1. request header would contain X-Snowflake-Service if the cfg parameters contains SERVICE_NAME
+// 2. SERVICE_NAME would be update by response payload
+// It is achieved through an interactive postQueryMock that would generate response based on header
+func TestServiceName(t *testing.T) {
+	sr := &snowflakeRestful{
+		FuncPostQuery: postQueryMock,
+	}
+
+	sc := &snowflakeConn{
+		cfg:  &Config{Params: map[string]*string{}},
+		rest: sr,
+	}
+
+	expectServiceName := serviceNameStub
+	for i := 0; i < 5; i++ {
+		sc.exec(context.TODO(), "", false, false, nil)
+		if actualServiceName, ok := sc.cfg.Params[serviceName]; ok {
+			if *actualServiceName != expectServiceName {
+				t.Errorf("service name mis-match. expected %v, actual %v", expectServiceName, actualServiceName)
+			}
+		} else {
+			t.Error("No service name in the response")
+		}
+
+		expectServiceName += serviceNameAppend
+	}
+}

--- a/driver.go
+++ b/driver.go
@@ -17,7 +17,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	glog.V(2).Info("Open")
 	var err error
 	sc := &snowflakeConn{
-		SequeceCounter: 0,
+		SequenceCounter: 0,
 	}
 	sc.cfg, err = ParseDSN(dsn)
 	if err != nil {


### PR DESCRIPTION
### Description
Add SERVICE_NAME support by leveraging parameter field. Unit test is added in connection_test.go

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
