### PR TITLE
Fixing TIMESTAMP_LTZ serialization issues + Add test case

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -113,12 +113,7 @@ func valueToString(v driver.Value, tsmode string) (*string, error) {
 				s := fmt.Sprintf("%d",
 					(tm.Hour()*3600+tm.Minute()*60+tm.Second())*1e9+tm.Nanosecond())
 				return &s, nil
-			case "TIMESTAMP_NTZ":
-				s := fmt.Sprintf("%d", tm.UnixNano())
-				return &s, nil
-			case "TIMESTAMP_LTZ":
-				_, offset := tm.Zone()
-				tm = tm.Add(time.Second * time.Duration(offset))
+			case "TIMESTAMP_NTZ", "TIMESTAMP_LTZ":
 				s := fmt.Sprintf("%d", tm.UnixNano())
 				return &s, nil
 			case "TIMESTAMP_TZ":
@@ -202,10 +197,7 @@ func stringToValue(dest *driver.Value, srcColumnMeta execResponseRowType, srcVal
 		if err != nil {
 			return err
 		}
-		tt := time.Unix(sec, nsec)
-		zone, offset := tt.Zone() // get timezone for the given datetime
-		glog.V(2).Infof("local: %v, %v", zone, offset)
-		*dest = tt.Add(time.Second * time.Duration(-offset))
+		*dest = time.Unix(sec, nsec)
 		return nil
 	case "timestamp_tz":
 		glog.V(2).Infof("tz: %v", *srcValue)

--- a/driver_test.go
+++ b/driver_test.go
@@ -942,7 +942,7 @@ func (tt timeTest) run(t *testing.T, dbt *DBTest, dbtype, tlayout string) {
 			str,
 		)
 	case time.Time:
-		if val == tt.t {
+		if val.UnixNano() == tt.t.UnixNano() {
 			return
 		}
 		t.Logf("source:%v, expected: %v, got:%v", tt.s, tt.t, val)
@@ -1055,6 +1055,10 @@ func TestTimestampLTZ(t *testing.T) {
 	format := "2006-01-02 15:04:05.999999999"
 	// Set session time zone in Los Angeles, same as machine
 	createDSN("America/Los_Angeles")
+	location, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Error(err)
+	}
 	testcases := []tcDateTimeTimestamp{
 		{
 			dbtype:  "TIMESTAMP_LTZ(9)",
@@ -1062,27 +1066,27 @@ func TestTimestampLTZ(t *testing.T) {
 			tests: []timeTest{
 				{
 					s: "2016-12-30 05:02:03",
-					t: time.Date(2016, 12, 30, 5, 2, 3, 0, time.Local),
+					t: time.Date(2016, 12, 30, 5, 2, 3, 0, location),
 				},
 				{
 					s: "2016-12-30 05:02:03 -00:00",
-					t: time.Date(2016, 12, 29, 21, 2, 3, 0, time.Local),
+					t: time.Date(2016, 12, 30, 5, 2, 3, 0, time.UTC),
 				},
 				{
 					s: "2017-05-12 00:51:42",
-					t: time.Date(2017, 5, 12, 0, 51, 42, 0, time.Local),
+					t: time.Date(2017, 5, 12, 0, 51, 42, 0, location),
 				},
 				{
 					s: "2017-03-12 01:00:00",
-					t: time.Date(2017, 3, 12, 1, 0, 0, 0, time.Local),
+					t: time.Date(2017, 3, 12, 1, 0, 0, 0, location),
 				},
 				{
 					s: "2017-03-13 04:00:00",
-					t: time.Date(2017, 3, 13, 4, 0, 0, 0, time.Local),
+					t: time.Date(2017, 3, 13, 4, 0, 0, 0, location),
 				},
 				{
 					s: "2017-03-13 04:00:00.123456789",
-					t: time.Date(2017, 3, 13, 4, 0, 0, 123456789, time.Local),
+					t: time.Date(2017, 3, 13, 4, 0, 0, 123456789, location),
 				},
 			},
 		},
@@ -1092,7 +1096,7 @@ func TestTimestampLTZ(t *testing.T) {
 			tests: []timeTest{
 				{
 					s: "2017-03-13 04:00:00.123456789",
-					t: time.Date(2017, 3, 13, 4, 0, 0, 123456780, time.Local),
+					t: time.Date(2017, 3, 13, 4, 0, 0, 123456780, location),
 				},
 			},
 		},

--- a/driver_test.go
+++ b/driver_test.go
@@ -576,6 +576,7 @@ func TestUint64Placeholder(t *testing.T) {
 }
 
 func TestDateTimeTimestampPlaceholder(t *testing.T) {
+	createDSN("America/Los_Angeles")
 	runTests(t, dsn, func(dbt *DBTest) {
 		expected := time.Now()
 		dbt.mustExec(
@@ -642,6 +643,8 @@ func TestDateTimeTimestampPlaceholder(t *testing.T) {
 		}
 		dbt.mustExec("DROP TABLE tztest")
 	})
+
+	createDSN("UTC")
 }
 
 func TestBinaryPlaceholder(t *testing.T) {
@@ -1050,6 +1053,8 @@ func TestDateTime(t *testing.T) {
 
 func TestTimestampLTZ(t *testing.T) {
 	format := "2006-01-02 15:04:05.999999999"
+	// Set session time zone in Los Angeles, same as machine
+	createDSN("America/Los_Angeles")
 	testcases := []tcDateTimeTimestamp{
 		{
 			dbtype:  "TIMESTAMP_LTZ(9)",
@@ -1058,6 +1063,10 @@ func TestTimestampLTZ(t *testing.T) {
 				{
 					s: "2016-12-30 05:02:03",
 					t: time.Date(2016, 12, 30, 5, 2, 3, 0, time.Local),
+				},
+				{
+					s: "2016-12-30 05:02:03 -00:00",
+					t: time.Date(2016, 12, 29, 21, 2, 3, 0, time.Local),
 				},
 				{
 					s: "2017-05-12 00:51:42",
@@ -1099,6 +1108,8 @@ func TestTimestampLTZ(t *testing.T) {
 			}
 		}
 	})
+	// Revert timezone to UTC, which is default for the test suit
+	createDSN("UTC")
 }
 
 func TestTimestampTZ(t *testing.T) {


### PR DESCRIPTION
### Description
This is a redo for #218 with some end to end test case added: 
With #218 the test case would fail on machines in a timezone other than UTC/GMT

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
