### PR TITLE
Fix okta authentication

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -27,13 +27,86 @@ const (
 	clientType = "Go"
 )
 
+// AuthType indicates the type of authentication in Snowflake
+type AuthType int
+
 const (
-	authenticatorExternalBrowser = "EXTERNALBROWSER"
-	authenticatorOAuth           = "OAUTH"
-	authenticatorSnowflake       = "SNOWFLAKE"
-	authenticatorOkta            = "OKTA"
-	authenticatorJWT             = "SNOWFLAKE_JWT"
+	// AuthTypeSnowflake is the general username password authentication
+	AuthTypeSnowflake AuthType = iota
+	// AuthTypeOAuth is the OAuth authentication
+	AuthTypeOAuth
+	// AuthTypeExternalBrowser is to use a browser to access an Fed and perform SSO authentication
+	AuthTypeExternalBrowser
+	// AuthTypeOkta is to use a native okta URL to perform SSO authentication on Okta
+	AuthTypeOkta
+	// AuthTypeJwt is to use Jwt to perform authentication
+	AuthTypeJwt
 )
+
+func determineAuthenticatorType(cfg *Config, value string) error {
+	upperCaseValue := strings.ToUpper(value)
+	lowerCaseValue := strings.ToLower(value)
+	if strings.Trim(value, " ") == "" || upperCaseValue == AuthTypeSnowflake.String() {
+		cfg.Authenticator = AuthTypeSnowflake
+		return nil
+	} else if upperCaseValue == AuthTypeOAuth.String() {
+		cfg.Authenticator = AuthTypeOAuth
+		return nil
+	} else if upperCaseValue == AuthTypeJwt.String() {
+		cfg.Authenticator = AuthTypeJwt
+		return nil
+	} else if upperCaseValue == AuthTypeExternalBrowser.String() {
+		cfg.Authenticator = AuthTypeExternalBrowser
+		return nil
+	} else {
+		// possibly Okta case
+		oktaURLString, err := url.QueryUnescape(lowerCaseValue)
+		if err != nil {
+			return &SnowflakeError{
+				Number:      ErrCodeFailedToParseAuthenticator,
+				Message:     errMsgFailedToParseAuthenticator,
+				MessageArgs: []interface{}{lowerCaseValue},
+			}
+		}
+
+		oktaURL, err := url.Parse(oktaURLString)
+		if err != nil {
+			return &SnowflakeError{
+				Number:      ErrCodeFailedToParseAuthenticator,
+				Message:     errMsgFailedToParseAuthenticator,
+				MessageArgs: []interface{}{oktaURLString},
+			}
+		}
+
+		if oktaURL.Scheme != "https" || !strings.HasSuffix(oktaURL.Host, "okta.com") {
+			return &SnowflakeError{
+				Number:      ErrCodeFailedToParseAuthenticator,
+				Message:     errMsgFailedToParseAuthenticator,
+				MessageArgs: []interface{}{oktaURLString},
+			}
+		}
+		cfg.OktaURL = oktaURL
+		cfg.Authenticator = AuthTypeOkta
+	}
+	return nil
+}
+
+func (authType AuthType) String() string {
+	switch authType {
+	case AuthTypeSnowflake:
+		return "SNOWFLAKE"
+	case AuthTypeOAuth:
+		return "OAUTH"
+	case AuthTypeExternalBrowser:
+		return "EXTERNALBROWSER"
+	case AuthTypeOkta:
+		return "OKTA"
+	case AuthTypeJwt:
+		return "SNOWFLAKE_JWT"
+	default:
+		return "UNKNOWN"
+	}
+}
 
 // platform consists of compiler and architecture type in string
 var platform = fmt.Sprintf("%v-%v", runtime.Compiler, runtime.GOARCH)
@@ -209,31 +282,27 @@ func authenticate(
 		ClientEnvironment: clientEnvironment,
 	}
 
-	authenticator := strings.ToUpper(sc.cfg.Authenticator)
-	switch authenticator {
-	case authenticatorExternalBrowser:
+	switch sc.cfg.Authenticator {
+	case AuthTypeExternalBrowser:
 		requestMain.ProofKey = string(proofKey)
 		requestMain.Token = string(samlResponse)
 		requestMain.LoginName = sc.cfg.User
-		requestMain.Authenticator = authenticatorExternalBrowser
-	case authenticatorOAuth:
+		requestMain.Authenticator = AuthTypeExternalBrowser.String()
+	case AuthTypeOAuth:
 		requestMain.LoginName = sc.cfg.User
-		requestMain.Authenticator = authenticatorOAuth
+		requestMain.Authenticator = AuthTypeOAuth.String()
 		requestMain.Token = sc.cfg.Token
-	case authenticatorOkta:
+	case AuthTypeOkta:
 		requestMain.RawSAMLResponse = string(samlResponse)
-	case authenticatorJWT:
-		requestMain.Authenticator = authenticatorJWT
+	case AuthTypeJwt:
+		requestMain.Authenticator = AuthTypeJwt.String()
 
 		jwtTokenInBytes, err := prepareJWTToken(sc.cfg)
 		if err != nil {
 			return nil, err
 		}
 		requestMain.Token = string(jwtTokenInBytes)
-
-	case authenticatorSnowflake:
-		fallthrough
-	default:
+	case AuthTypeSnowflake:
 		glog.V(2).Info("Username and password")
 		requestMain.LoginName = sc.cfg.User
 		requestMain.Password = sc.cfg.Password
@@ -269,7 +338,7 @@ func authenticate(
 	}
 
 	glog.V(2).Infof("PARAMS for Auth: %v, %v, %v, %v, %v, %v",
-		params, sc.rest.Protocol, sc.rest.Host, sc.rest.Port, sc.rest.LoginTimeout, sc.rest.Authenticator)
+		params, sc.rest.Protocol, sc.rest.Host, sc.rest.Port, sc.rest.LoginTimeout, sc.cfg.Authenticator.String())
 
 	respd, err := sc.rest.FuncPostAuth(sc.rest, params, headers, jsonBody, sc.rest.LoginTimeout)
 	if err != nil {

--- a/auth_test.go
+++ b/auth_test.go
@@ -125,7 +125,7 @@ func postAuthCheckOAuth(
 	if err := json.Unmarshal(jsonBody, &ar); err != nil {
 		return nil, err
 	}
-	if ar.Data.Authenticator != authenticatorOAuth {
+	if ar.Data.Authenticator != AuthTypeOAuth.String() {
 		return nil, errors.New("Authenticator is not OAUTH")
 	}
 	if ar.Data.Token == "" {
@@ -193,7 +193,7 @@ func postAuthCheckJWTToken(_ *snowflakeRestful, _ *url.Values, _ map[string]stri
 	if err := json.Unmarshal(jsonBody, &ar); err != nil {
 		return nil, err
 	}
-	if ar.Data.Authenticator != authenticatorJWT {
+	if ar.Data.Authenticator != AuthTypeJwt.String() {
 		return nil, errors.New("Authenticator is not JWT")
 	}
 
@@ -311,7 +311,11 @@ func TestUnitAuthenticateSaml(t *testing.T) {
 		FuncPostAuth: postAuthCheckSAMLResponse,
 	}
 	sc := getDefaultSnowflakeConn()
-	sc.cfg.Authenticator = authenticatorOkta
+	sc.cfg.Authenticator = AuthTypeOkta
+	sc.cfg.OktaURL = &url.URL{
+		Scheme: "https",
+		Host:   "blah.okta.com",
+	}
 	sc.rest = sr
 	_, err = authenticate(sc, []byte("HTML data in bytes from"), []byte{})
 	if err != nil {
@@ -327,7 +331,7 @@ func TestUnitAuthenticateOAuth(t *testing.T) {
 	}
 	sc := getDefaultSnowflakeConn()
 	sc.cfg.Token = "oauthToken"
-	sc.cfg.Authenticator = authenticatorOAuth
+	sc.cfg.Authenticator = AuthTypeOAuth
 	sc.rest = sr
 	_, err = authenticate(sc, []byte{}, []byte{})
 	if err != nil {
@@ -365,7 +369,7 @@ func TestUnitAuthenticateJWT(t *testing.T) {
 		FuncPostAuth: postAuthCheckJWTToken,
 	}
 	sc := getDefaultSnowflakeConn()
-	sc.cfg.Authenticator = authenticatorJWT
+	sc.cfg.Authenticator = AuthTypeJwt
 	sc.cfg.JWTExpireTimeout = defaultJWTTimeout
 	sc.cfg.PrivateKey = testPrivKey
 	sc.rest = sr

--- a/authokta_test.go
+++ b/authokta_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestUnitPostBackURL(t *testing.T) {
 	c := `<html><form id="1" action="https&#x3a;&#x2f;&#x2f;abc.com&#x2f;"></form></html>`
-	urlp, err := postBackURL([]byte(c))
+	pbURL, err := postBackURL([]byte(c))
 	if err != nil {
 		t.Fatalf("failed to get URL. err: %v, %v", err, c)
 	}
-	if urlp != "https://abc.com/" {
-		t.Errorf("failed to get URL. got: %v, %v", urlp, c)
+	if pbURL.String() != "https://abc.com/" {
+		t.Errorf("failed to get URL. got: %v, %v", pbURL, c)
 	}
 	c = `<html></html>`
 	_, err = postBackURL([]byte(c))
@@ -34,40 +34,6 @@ func TestUnitPostBackURL(t *testing.T) {
 	_, err = postBackURL([]byte(c))
 	if err == nil {
 		t.Fatalf("should have failed")
-	}
-}
-
-type tcIsPrefixEqual struct {
-	url1   string
-	url2   string
-	result bool
-	err    error
-}
-
-func TestUnitIsPrefixEqual(t *testing.T) {
-	testcases := []tcIsPrefixEqual{
-		{url1: "https://abc.com/", url2: "https://abc.com", result: true},
-		{url1: "https://def.com/", url2: "https://abc.com", result: false},
-		{url1: "http://def.com", url2: "https://def.com", result: false},
-		{url1: "afdafdafadfs", url2: "https://def.com", result: false},
-		{url1: "http://def.com", url2: "afdafafd", result: false},
-		{url1: "https://abc.com", url2: "https://abc.com:443/", result: true},
-	}
-	for _, test := range testcases {
-		r, err := isPrefixEqual(test.url1, test.url2)
-		if test.err != nil {
-			if err == nil {
-				t.Errorf("should have failed. url1: %v, url2: %v, got: %v, expected err: %v", test.url1, test.url2, r, test.err)
-			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("failed. url1: %v, url2: %v, expected: %v, err: %v", test.url1, test.url2, test.result, err)
-		} else {
-			if r && !test.result || !r && test.result {
-				t.Errorf("failed. url1: %v, url2: %v, expected: %v, got: %v", test.url1, test.url2, test.result, r)
-			}
-		}
 	}
 }
 
@@ -209,7 +175,10 @@ func getSSOSuccess(_ *snowflakeRestful, _ *url.Values, _ map[string]string, _ st
 }
 
 func TestUnitAuthenticateBySAML(t *testing.T) {
-	authenticator := "https://abc.com/"
+	authenticator := &url.URL{
+		Scheme: "https",
+		Host:   "abc.com",
+	}
 	application := "testapp"
 	account := "testaccount"
 	user := "u"

--- a/cmd/externalbrowser/externalbrowser.go
+++ b/cmd/externalbrowser/externalbrowser.go
@@ -12,7 +12,7 @@ import (
 )
 
 // getDSN constructs a DSN based on the test connection parameters
-func getDSN(authenticator string) (string, *sf.Config, error) {
+func getDSN() (string, *sf.Config, error) {
 	env := func(k string, failOnMissing bool) string {
 		if value := os.Getenv(k); value != "" {
 			return value
@@ -31,7 +31,7 @@ func getDSN(authenticator string) (string, *sf.Config, error) {
 
 	portStr, _ := strconv.Atoi(port)
 	cfg := &sf.Config{
-		Authenticator: authenticator,
+		Authenticator: sf.AuthTypeExternalBrowser,
 		Account:       account,
 		User:          user,
 		Host:          host,
@@ -51,7 +51,7 @@ func main() {
 		// enable glog for Go Snowflake Driver
 		flag.Parse()
 	}
-	dsn, cfg, err := getDSN("EXTERNALBROWSER")
+	dsn, cfg, err := getDSN()
 
 	if err != nil {
 		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)

--- a/driver.go
+++ b/driver.go
@@ -42,7 +42,6 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 			Timeout:   defaultClientTimeout,
 			Transport: st,
 		},
-		Authenticator:       sc.cfg.Authenticator,
 		LoginTimeout:        sc.cfg.LoginTimeout,
 		RequestTimeout:      sc.cfg.RequestTimeout,
 		FuncPost:            postRestful,
@@ -61,13 +60,12 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	var samlResponse []byte
 	var proofKey []byte
 
-	authenticator := strings.ToUpper(sc.cfg.Authenticator)
-	glog.V(2).Infof("Authenticating via %v", authenticator)
-	switch authenticator {
-	case authenticatorExternalBrowser:
+	glog.V(2).Infof("Authenticating via %v", sc.cfg.Authenticator.String())
+	switch sc.cfg.Authenticator {
+	case AuthTypeExternalBrowser:
 		samlResponse, proofKey, err = authenticateByExternalBrowser(
 			sc.rest,
-			sc.cfg.Authenticator,
+			sc.cfg.Authenticator.String(),
 			sc.cfg.Application,
 			sc.cfg.Account,
 			sc.cfg.User,
@@ -76,16 +74,10 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 			sc.cleanup()
 			return nil, err
 		}
-	case authenticatorOAuth:
-	case authenticatorSnowflake:
-	case authenticatorJWT:
-		// Nothing to do, parameters needed for auth should be already set in sc.cfg
-		break
-	default:
-		// this is actually okta, which is something misleading
+	case AuthTypeOkta:
 		samlResponse, err = authenticateBySAML(
 			sc.rest,
-			sc.cfg.Authenticator,
+			sc.cfg.OktaURL,
 			sc.cfg.Application,
 			sc.cfg.Account,
 			sc.cfg.User,
@@ -126,7 +118,7 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 func (d SnowflakeDriver) validateDefaultParameters(sessionValue string, defaultValue *string) error {
-	if *defaultValue != "" && strings.ToLower(*defaultValue) != strings.ToLower(sessionValue) {
+	if *defaultValue != "" && !strings.EqualFold(*defaultValue, sessionValue) {
 		return &SnowflakeError{
 			Number:      ErrCodeObjectNotExists,
 			SQLState:    SQLStateConnectionFailure,

--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,8 @@ const (
 	ErrCodeObjectNotExists = 260009
 	// ErrCodePrivateKeyParseError is an error code for the case where the private key is not parsed correctly
 	ErrCodePrivateKeyParseError = 260010
+	// ErrCodeFailedToParseAuthenticator is an error code for the case where a DNS includes an invalid authenticator
+	ErrCodeFailedToParseAuthenticator = 260011
 
 	/* network */
 
@@ -115,6 +117,7 @@ const (
 const (
 	errMsgFailedToParseHost                  = "failed to parse a host name. host: %v"
 	errMsgFailedToParsePort                  = "failed to parse a port number. port: %v"
+	errMsgFailedToParseAuthenticator         = "failed to parse an authenticator: %v"
 	errMsgInvalidOffsetStr                   = "offset must be a string consist of sHHMI where one sign character '+'/'-' followed by zero filled hours and minutes: %v"
 	errMsgInvalidByteArray                   = "invalid byte array: %v"
 	errMsgIdpConnectionError                 = "failed to verify URLs. authenticator: %v, token URL:%v, SSO URL:%v"

--- a/priv_key_test.go
+++ b/priv_key_test.go
@@ -62,7 +62,7 @@ func setupPrivateKey() {
 func appendPrivateKeyString(dsn *string, key *rsa.PrivateKey) string {
 	var b bytes.Buffer
 	b.WriteString(*dsn)
-	b.WriteString(fmt.Sprintf("&authenticator=%v", authenticatorJWT))
+	b.WriteString(fmt.Sprintf("&authenticator=%v", AuthTypeJwt.String()))
 	b.WriteString(fmt.Sprintf("&privateKey=%s", generatePKCS8StringSupress(key)))
 	return b.String()
 }

--- a/restful.go
+++ b/restful.go
@@ -33,7 +33,6 @@ type snowflakeRestful struct {
 	Protocol       string
 	LoginTimeout   time.Duration // Login timeout
 	RequestTimeout time.Duration // request timeout
-	Authenticator  string
 
 	Client      *http.Client
 	Token       string
@@ -54,6 +53,13 @@ type snowflakeRestful struct {
 	FuncPostAuthSAML func(*snowflakeRestful, map[string]string, []byte, time.Duration) (*authResponse, error)
 	FuncPostAuthOKTA func(*snowflakeRestful, map[string]string, []byte, string, time.Duration) (*authOKTAResponse, error)
 	FuncGetSSO       func(*snowflakeRestful, *url.Values, map[string]string, string, time.Duration) ([]byte, error)
+}
+
+func (sr *snowflakeRestful) getURL() *url.URL {
+	return &url.URL{
+		Scheme: sr.Protocol,
+		Host:   sr.Host + ":" + strconv.Itoa(sr.Port),
+	}
 }
 
 type renewSessionResponse struct {


### PR DESCRIPTION
### Description
This PR is from #228, where a previous change mix the okta URL and the okta type.
To avoid having this issue again, I refactor the code to separate an authenticator and the okta url stored internally.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
