### PR TITLE
snow-81842 Use Standard Connection Fields for Global URL

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -51,7 +51,10 @@ The following connection parameters are supported:
 		after the account name, e.g. “<account>.<region>”. If you are not on
 		AWS deployment, then append not only the region, but also the platform,
 		e.g., “<account>.<region>.<platform>”. Account, region, and platform
-		should be separated by a period (“.”), as shown above.
+		should be separated by a period (“.”), as shown above. If you are using
+		a global url, then append connection group and "global",
+		e.g., "account-<connection_group>.global". Account and connection group are
+		separated by a dash ("-"), as shown above.
 
 	* region <string>: DEPRECATED. You may specify a region, such as
 		“eu-central-1”, with this parameter. However, since this parameter

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -73,6 +73,35 @@ func TestParseDSN(t *testing.T) {
 			err:      nil,
 		},
 		{
+			dsn: "user:pass@ac-laksdnflaf.global/db/schema",
+			config: &Config{
+				Account: "ac", User: "user", Password: "pass",
+				Protocol: "https", Host: "ac-laksdnflaf.global.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "schema",
+			},
+			err: nil,
+		},
+		{
+			dsn: "user:pass@ac-1-laksdnflaf.global/db/schema",
+			config: &Config{
+				Account: "ac-1", User: "user", Password: "pass",
+				Protocol: "https", Host: "ac-1-laksdnflaf.global.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "schema",
+			},
+			err: nil,
+		},
+		{
+			dsn: "user:pass@ac.global/db/schema",
+			config: &Config{
+				Account: "ac", User: "user", Password: "pass",
+				Protocol: "https", Host: "ac-laksdnflaf.global.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "schema",
+			},
+			err: &SnowflakeError{
+				Number: ErrCodeFailedToParseAccount,
+			},
+		},
+		{
 			dsn: "user@host:123/db/schema?account=ac&protocol=http",
 			config: &Config{
 				Account: "ac", User: "user", Password: "pass",
@@ -439,6 +468,25 @@ func TestDSN(t *testing.T) {
 				Account:  "a",
 			},
 			dsn: "u:p@a.snowflakecomputing.com:443",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a-aofnadsf.global",
+			},
+			dsn: "u:p@a-aofnadsf.global.snowflakecomputing.com:443",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.global",
+			},
+			dsn: "u:p@a.global.snowflakecomputing.com:443",
+			err: &SnowflakeError{
+				Number: ErrCodeFailedToParseAccount,
+			},
 		},
 		{
 			cfg: &Config{

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -78,8 +78,10 @@ func TestParseDSN(t *testing.T) {
 				Account: "ac", User: "user", Password: "pass",
 				Protocol: "https", Host: "ac-laksdnflaf.global.snowflakecomputing.com", Port: 443,
 				Database: "db", Schema: "schema",
+				OCSPFailOpen: ocspFailOpenTrue,
 			},
-			err: nil,
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
 		},
 		{
 			dsn: "user:pass@ac-1-laksdnflaf.global/db/schema",
@@ -87,8 +89,10 @@ func TestParseDSN(t *testing.T) {
 				Account: "ac-1", User: "user", Password: "pass",
 				Protocol: "https", Host: "ac-1-laksdnflaf.global.snowflakecomputing.com", Port: 443,
 				Database: "db", Schema: "schema",
+				OCSPFailOpen: ocspFailOpenTrue,
 			},
-			err: nil,
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
 		},
 		{
 			dsn: "user:pass@ac.global/db/schema",
@@ -96,7 +100,9 @@ func TestParseDSN(t *testing.T) {
 				Account: "ac", User: "user", Password: "pass",
 				Protocol: "https", Host: "ac-laksdnflaf.global.snowflakecomputing.com", Port: 443,
 				Database: "db", Schema: "schema",
+				OCSPFailOpen: ocspFailOpenTrue,
 			},
+			ocspMode: ocspModeFailOpen,
 			err: &SnowflakeError{
 				Number: ErrCodeFailedToParseAccount,
 			},

--- a/errors.go
+++ b/errors.go
@@ -60,6 +60,8 @@ const (
 	ErrCodePrivateKeyParseError = 260010
 	// ErrCodeFailedToParseAuthenticator is an error code for the case where a DNS includes an invalid authenticator
 	ErrCodeFailedToParseAuthenticator = 260011
+	// ErrCodeFailedToParseAccount is an error code for the case where a DNS includes an invalid host name
+	ErrCodeFailedToParseAccount = 260012
 
 	/* network */
 
@@ -118,6 +120,7 @@ const (
 	errMsgFailedToParseHost                  = "failed to parse a host name. host: %v"
 	errMsgFailedToParsePort                  = "failed to parse a port number. port: %v"
 	errMsgFailedToParseAuthenticator         = "failed to parse an authenticator: %v"
+	errMsgFailedToParseAccount               = "failed to parse an account name. account: %v"
 	errMsgInvalidOffsetStr                   = "offset must be a string consist of sHHMI where one sign character '+'/'-' followed by zero filled hours and minutes: %v"
 	errMsgInvalidByteArray                   = "invalid byte array: %v"
 	errMsgIdpConnectionError                 = "failed to verify URLs. authenticator: %v, token URL:%v, SSO URL:%v"


### PR DESCRIPTION
### Description
Use account to parse global URL

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
