### PR TITLE
Fail open fix

### DIFF
--- a/ocsp.go
+++ b/ocsp.go
@@ -512,18 +512,18 @@ func isValidOCSPStatus(status ocspStatusCode) bool {
 // verifyPeerCertificate verifies all of certificate revocation status
 func verifyPeerCertificate(verifiedChains [][]*x509.Certificate) (err error) {
 	for i := 0; i < len(verifiedChains); i++ {
-		n := len(verifiedChains[i]) - 1
-		if !verifiedChains[i][n].IsCA || string(verifiedChains[i][n].RawIssuer) != string(verifiedChains[i][n].RawSubject) {
+		numberOfNoneRootCA := len(verifiedChains[i]) - 1
+		if !verifiedChains[i][numberOfNoneRootCA].IsCA || string(verifiedChains[i][numberOfNoneRootCA].RawIssuer) != string(verifiedChains[i][numberOfNoneRootCA].RawSubject) {
 			// if the last certificate is not root CA, add it to the list
-			rca := caRoot[string(verifiedChains[i][n].RawIssuer)]
+			rca := caRoot[string(verifiedChains[i][numberOfNoneRootCA].RawIssuer)]
 			if rca == nil {
-				return fmt.Errorf("failed to find root CA. pkix.name: %v", verifiedChains[i][n].Issuer)
+				return fmt.Errorf("failed to find root CA. pkix.name: %v", verifiedChains[i][numberOfNoneRootCA].Issuer)
 			}
 			verifiedChains[i] = append(verifiedChains[i], rca)
-			n++
+			numberOfNoneRootCA++
 		}
 		results := getAllRevocationStatus(verifiedChains[i])
-		if r := canEarlyExitForOCSP(results, len(verifiedChains[i])); r != nil {
+		if r := canEarlyExitForOCSP(results, numberOfNoneRootCA); r != nil {
 			return r.err
 		}
 	}

--- a/ocsp.go
+++ b/ocsp.go
@@ -515,7 +515,8 @@ func verifyPeerCertificate(verifiedChains [][]*x509.Certificate) (err error) {
 		// Certificate signed by Root CA. This should be one before the last in the Certificate Chain
 		numberOfNoneRootCerts := len(verifiedChains[i]) - 1
 		if !verifiedChains[i][numberOfNoneRootCerts].IsCA || string(verifiedChains[i][numberOfNoneRootCerts].RawIssuer) != string(verifiedChains[i][numberOfNoneRootCerts].RawSubject) {
-			// if the last certificate is not root CA, add it to the list
+			// Check if the last Non Root Cert is also a CA or is self signed.
+			// if the last certificate is not, add it to the list
 			rca := caRoot[string(verifiedChains[i][numberOfNoneRootCerts].RawIssuer)]
 			if rca == nil {
 				return fmt.Errorf("failed to find root CA. pkix.name: %v", verifiedChains[i][numberOfNoneRootCerts].Issuer)


### PR DESCRIPTION
### Description
There is a size gap between response and overall certificate chain when the chain contains root CA, leading to our code letting go revoked certificate.

https://snowflakecomputing.atlassian.net/browse/SNOW-90763
### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
