### PR TITLE
SNOW-86744 Add client information to USER-AGENT HTTP header

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -115,7 +115,13 @@ var platform = fmt.Sprintf("%v-%v", runtime.Compiler, runtime.GOARCH)
 var operatingSystem = runtime.GOOS
 
 // userAgent shows up in User-Agent HTTP header
-var userAgent = fmt.Sprintf("%v/%v/%v/%v", clientType, SnowflakeGoDriverVersion, runtime.Version(), platform)
+var userAgent = fmt.Sprintf("%v/%v/%v/%v/%v-%v",
+	clientType,
+	SnowflakeGoDriverVersion,
+	runtime.Compiler,
+	runtime.Version(),
+	operatingSystem,
+	runtime.GOARCH)
 
 type authRequestClientEnvironment struct {
 	Application string `json:"APPLICATION"`


### PR DESCRIPTION
### Description
Refine the userAgent field as connector_name/connector_version/language_implementation/language_version/os-platform_info

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
