### PR TITLE
SNOW-92880: Reuse the same requestID after session token is renewed.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"github.com/google/uuid"
 	"net/url"
 	"strconv"
 	"strings"
@@ -100,7 +101,9 @@ func (sc *snowflakeConn) exec(
 	}
 
 	var data *execResponse
-	data, err = sc.rest.FuncPostQuery(ctx, sc.rest, &url.Values{}, headers, jsonBody, sc.rest.RequestTimeout)
+
+	requestID := uuid.New()
+	data, err = sc.rest.FuncPostQuery(ctx, sc.rest, &url.Values{}, headers, jsonBody, sc.rest.RequestTimeout, &requestID)
 	if err != nil {
 		return nil, err
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,6 +2,7 @@ package gosnowflake
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"net/url"
 	"testing"
 	"time"
@@ -13,7 +14,7 @@ const serviceNameAppend = "a"
 // postQueryMock would generate a response based on the X-Snowflake-Service header, to generate a response
 // with the SERVICE_NAME field appending a character at the end of the header
 // This way it could test both the send and receive logic
-func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration) (*execResponse, error) {
+func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ *uuid.UUID) (*execResponse, error) {
 	var serviceName string
 	if serviceHeader, ok := headers["X-Snowflake-Service"]; ok {
 		serviceName = serviceHeader + serviceNameAppend

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -37,8 +37,8 @@ func cleanup() {
 	unsetenv(ocspTestNoOCSPURLEnv)
 }
 
-// TestOCSPFailOpen just confirms OCSPFailOpenTrue works.
-func TestOCSPFailOpen(t *testing.T) {
+// TestOCSPFailOpeNOP just confirms OCSPFailOpenTrue works.
+func TestOCSPFailOpeNOP(t *testing.T) {
 	cleanup()
 	defer cleanup()
 

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -37,8 +37,8 @@ func cleanup() {
 	unsetenv(ocspTestNoOCSPURLEnv)
 }
 
-// TestOCSPFailOpeNOP just confirms OCSPFailOpenTrue works.
-func TestOCSPFailOpeNOP(t *testing.T) {
+// TestOCSPFailOpen just confirms OCSPFailOpenTrue works.
+func TestOCSPFailOpen(t *testing.T) {
 	cleanup()
 	defer cleanup()
 


### PR DESCRIPTION
### Description
Reuse the same requestID after session token is renewed.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
