### PR TITLE
Fix tests for go1.13

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -136,6 +136,7 @@ func teardown() error {
 }
 
 func TestMain(m *testing.M) {
+	flag.Parse()
 	signal.Ignore(syscall.SIGQUIT)
 	if value := os.Getenv("SKIP_SETUP"); value != "" {
 		os.Exit(m.Run())
@@ -1965,10 +1966,4 @@ func TestClientSessionKeepAliveParameter(t *testing.T) {
 		t.Errorf("failed to run a query: %v", err)
 	}
 	defer rows.Close()
-}
-
-func init() {
-	if !flag.Parsed() {
-		flag.Parse()
-	}
 }

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -275,13 +275,13 @@ func TestUnitEncodeCertID(t *testing.T) {
 }
 
 func getCert(addr string) []*x509.Certificate {
-	tcpConn, err := net.DialTimeout("tcp", addr, 4*time.Second)
+	tcpConn, err := net.DialTimeout("tcp", addr, 40*time.Second)
 	if err != nil {
 		panic(err)
 	}
 	defer tcpConn.Close()
 
-	err = tcpConn.SetDeadline(time.Now().Add(1 * time.Second))
+	err = tcpConn.SetDeadline(time.Now().Add(10 * time.Second))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
See https://github.com/golang/go/issues/31859#issuecomment-532415187

Also increase timeouts in `TestUnitEncodeCertIDGood` as the aggressive
timeouts there make the test flaky.