### PR TITLE
time precision is returned in ColumnTypes()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,6 +15,7 @@
   version = "1.1"
 
 [[projects]]
+  branch = "master"
   digest = "1:6b98cc8ee2df9bbb5190f1cea00285ea625109667574d16853ba82eaf48d47fd"
   name = "github.com/golang/glog"
   packages = ["."]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,7 +15,6 @@
   version = "1.1"
 
 [[projects]]
-  branch = "master"
   digest = "1:6b98cc8ee2df9bbb5190f1cea00285ea625109667574d16853ba82eaf48d47fd"
   name = "github.com/golang/glog"
   packages = ["."]

--- a/driver_test.go
+++ b/driver_test.go
@@ -1967,3 +1967,34 @@ func TestClientSessionKeepAliveParameter(t *testing.T) {
 	}
 	defer rows.Close()
 }
+
+func TestTimePrecision(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	if db, err = sql.Open("snowflake", dsn); err != nil {
+		t.Fatalf("failed to open db. %v, err: %v", dsn, err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("create or replace table z3 (t1 time(5))")
+	if err != nil {
+		t.Errorf("error while executing query. err : %v", err)
+	}
+	res, err := db.Query("select * from z3")
+	if err != nil {
+		t.Errorf("error while executing query. err : %v", err)
+	}
+
+	cols, _ := res.ColumnTypes()
+	pres, _, _ := cols[0].DecimalSize()
+	if pres != 5 {
+		t.Fatalf("Wrong value returned. Got %v instead of 5.", pres)
+	}
+}
+
+func init() {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1992,9 +1992,3 @@ func TestTimePrecision(t *testing.T) {
 		t.Fatalf("Wrong value returned. Got %v instead of 5.", pres)
 	}
 }
-
-func init() {
-	if !flag.Parsed() {
-		flag.Parse()
-	}
-}

--- a/query.go
+++ b/query.go
@@ -24,8 +24,8 @@ type execResponseRowType struct {
 	ByteLength int64  `json:"byteLength"`
 	Length     int64  `json:"length"`
 	Type       string `json:"type"`
-	Scale      int64  `json:"scale"`
 	Precision  int64  `json:"precision"`
+	Scale      int64  `json:"scale"`
 	Nullable   bool   `json:"nullable"`
 }
 

--- a/rows.go
+++ b/rows.go
@@ -106,6 +106,10 @@ func (rows *snowflakeRows) ColumnTypePrecisionScale(index int) (precision, scale
 	switch rows.RowType[index].Type {
 	case "fixed":
 		return rows.RowType[index].Precision, rows.RowType[index].Scale, true
+	case "time":
+		return rows.RowType[index].Scale, 0, true
+	case "timestamp":
+		return rows.RowType[index].Scale, 0, true
 	}
 	return 0, 0, false
 }


### PR DESCRIPTION
### Description
When there is a precision value for a time or timestamp column, a user is now able to retrieve that value using the ColumnTypes() function. A test created in driver_test.go confirms that it works.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
