### PR TITLE
SNOW-127316 Add doc to use private key in Golang

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -346,8 +346,8 @@ To generate the valid key pair, one can do the following command on the shell sc
     	-out rsa-2048-public-key.spki
 
 Note: As of Feb 2020, Golang's official library does not support passcode-encrypted PKCS8 private key.
-For security purpose, we highly recommended users to store passcode-encrypted private key in the disk and decrypt the
-key in application using a library you trust.
+For security purposes, Snowflake highly recommends that you store the passcode-encrypted private key on the disk and
+decrypt the key in your application using a library you trust.
 
 Limitations
 

--- a/doc.go
+++ b/doc.go
@@ -338,7 +338,7 @@ To generate the valid key pair, one can do the following command on the shell sc
 	openssl genpkey -algorithm RSA \
     	-pkeyopt rsa_keygen_bits:2048 \
     	-pkeyopt rsa_keygen_pubexp:65537 | \
-  		openssl pkcs8 -topk8 -nocrypt -outform der > rsa-2048-private-key.p8
+  		openssl pkcs8 -topk8 -outform der > rsa-2048-private-key.p8
 
 	# extravt 2048-bit PKI encoded RSA public key from the private key
 	openssl pkey -pubout -inform der -outform der \
@@ -347,7 +347,7 @@ To generate the valid key pair, one can do the following command on the shell sc
 
 Note: As of Feb 2020, Golang's official library does not support passcode-encrypted PKCS8 private key.
 For security purpose, we highly recommended users to store passcode-encrypted private key in the disk and decrypt the
-key in application only.
+key in application using a library you trust.
 
 Limitations
 

--- a/doc.go
+++ b/doc.go
@@ -345,6 +345,10 @@ To generate the valid key pair, one can do the following command on the shell sc
     	-in rsa-2048-private-key.p8 \
     	-out rsa-2048-public-key.spki
 
+Note: As of Feb 2020, Golang's official library does not support passcode-encrypted PKCS8 private key.
+For security purpose, we highly recommended users to store passcode-encrypted private key in the disk and decrypt the
+key in application only.
+
 Limitations
 
 GET and PUT operations are unsupported.


### PR DESCRIPTION
### Description
I do not mention any go library to use to decrypt PKCS8 key since we don't want to give an impression to the user that the library's security level is validated by Snowflake.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
