### PR TITLE
remove 1.12 support ad add 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ sudo: false
 language: go
 matrix:
   include:
-  - go: 1.12.x
   - go: 1.13.x
-  - go: 1.13.x
+  - go: 1.14.x
+  - go: 1.14.x
     env: SNOWFLAKE_AZURE=true
-  - go: 1.13.x
+  - go: 1.14.x
     env: SNOWFLAKE_GCP=true
 install:
 - "./scripts/install.sh"

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ The following software packages are required to use the Go Snowflake Driver.
 Go
 ----------------------------------------------------------------------
 
-The latest driver requires the `Go language <https://golang.org/>`_ 1.12 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
+The latest driver requires the `Go language <https://golang.org/>`_ 1.13 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
 
 
 Installation


### PR DESCRIPTION
### Description
Go has the last two versions support policy. As 1.14 was released in Feb 2012, they dropped the 1.12 support. We want to align with their policy for golang driver.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
