### PR TITLE
Handle deprecated region dsn parameter conflict

### DIFF
--- a/datatype.go
+++ b/datatype.go
@@ -97,6 +97,7 @@ type SnowflakeParameter struct {
 	IsExpired                 string
 	ExpiresAt                 string
 	SetByControllingParameter string
+	ActivateVersion           string
 	Unknown                   string // Reserve for added parameter
 }
 
@@ -134,6 +135,8 @@ func populateSnowflakeParameter(colname string, p *SnowflakeParameter) interface
 		return &p.ExpiresAt
 	case "set_by_controlling_parameter":
 		return &p.SetByControllingParameter
+	case "activate_version":
+		return &p.ActivateVersion
 	default:
 		debugPanicf("unknown type: %v", colname)
 		return &p.Unknown

--- a/dsn.go
+++ b/dsn.go
@@ -88,6 +88,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	hasHost := true
 	if cfg.Host == "" {
 		hasHost = false
+		if cfg.Region == "us-west-2" {
+			cfg.Region = ""
+		}
 		if cfg.Region == "" {
 			cfg.Host = cfg.Account + defaultDomain
 		} else {
@@ -97,10 +100,12 @@ func DSN(cfg *Config) (dsn string, err error) {
 	// in case account includes region
 	posDot := strings.Index(cfg.Account, ".")
 	if posDot > 0 {
+		if cfg.Region != "" {
+			return "", ErrInvalidRegion
+		}
 		cfg.Region = cfg.Account[posDot+1:]
 		cfg.Account = cfg.Account[:posDot]
 	}
-
 	err = fillMissingConfigParameters(cfg)
 	if err != nil {
 		return "", err

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -574,9 +574,45 @@ func TestDSN(t *testing.T) {
 			cfg: &Config{
 				User:     "u",
 				Password: "p",
+				Account:  "a-aofnadsf.global",
+				Region:   "us-west-2",
+			},
+			dsn: "u:p@a-aofnadsf.global.snowflakecomputing.com:443?ocspFailOpen=true&region=global&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a-aofnadsf.global",
+				Region:   "r",
+			},
+			err: ErrInvalidRegion,
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
 				Account:  "a",
 			},
 			dsn: "u:p@a.snowflakecomputing.com:443?ocspFailOpen=true&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a",
+				Region:   "us-west-2",
+			},
+			dsn: "u:p@a.snowflakecomputing.com:443?ocspFailOpen=true&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a",
+				Region:   "r",
+			},
+			dsn: "u:p@a.r.snowflakecomputing.com:443?ocspFailOpen=true&region=r&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{
@@ -609,6 +645,24 @@ func TestDSN(t *testing.T) {
 				Account:  "a.e",
 			},
 			dsn: "u:p@a.e.snowflakecomputing.com:443?ocspFailOpen=true&region=e&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.e",
+				Region:   "us-west-2",
+			},
+			dsn: "u:p@a.e.snowflakecomputing.com:443?ocspFailOpen=true&region=e&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.e",
+				Region:   "r",
+			},
+			err: ErrInvalidRegion,
 		},
 		{
 			cfg: &Config{
@@ -724,6 +778,24 @@ func TestDSN(t *testing.T) {
 				Account:  "a.b.c",
 			},
 			dsn: "u:p@a.b.c.snowflakecomputing.com:443?ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.b.c",
+				Region:   "us-west-2",
+			},
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "a.b.c",
+				Region:   "r",
+			},
+			err: ErrInvalidRegion,
 		},
 	}
 	for _, test := range testcases {

--- a/errors.go
+++ b/errors.go
@@ -54,7 +54,7 @@ const (
 	ErrCodeServiceUnavailable = 260007
 	// ErrCodeFailedToConnect is an error code for the case where a DB connection failed due to wrong account name
 	ErrCodeFailedToConnect = 260008
-	// ErrCodeRegionMismatch is an error code for the case where a region is specified despite an account region present
+	// ErrCodeRegionOverlap is an error code for the case where a region is specified despite an account region present
 	ErrCodeRegionOverlap = 260009
 	// ErrCodePrivateKeyParseError is an error code for the case where the private key is not parsed correctly
 	ErrCodePrivateKeyParseError = 260010
@@ -174,6 +174,7 @@ var (
 		Number:  ErrCodeEmptyPasswordCode,
 		Message: "password is empty"}
 
+	// ErrInvalidRegion is returned if a DSN's implicit region from account parameter and explicit region parameter conflict.
 	ErrInvalidRegion = &SnowflakeError{
 		Number:  ErrCodeRegionOverlap,
 		Message: "two regions specified"}

--- a/errors.go
+++ b/errors.go
@@ -54,6 +54,8 @@ const (
 	ErrCodeServiceUnavailable = 260007
 	// ErrCodeFailedToConnect is an error code for the case where a DB connection failed due to wrong account name
 	ErrCodeFailedToConnect = 260008
+	// ErrCodeRegionMismatch is an error code for the case where a region is specified despite an account region present
+	ErrCodeRegionOverlap = 260009
 	// ErrCodePrivateKeyParseError is an error code for the case where the private key is not parsed correctly
 	ErrCodePrivateKeyParseError = 260010
 	// ErrCodeFailedToParseAuthenticator is an error code for the case where a DNS includes an invalid authenticator
@@ -171,4 +173,8 @@ var (
 	ErrEmptyPassword = &SnowflakeError{
 		Number:  ErrCodeEmptyPasswordCode,
 		Message: "password is empty"}
+
+	ErrInvalidRegion = &SnowflakeError{
+		Number:  ErrCodeRegionOverlap,
+		Message: "two regions specified"}
 )


### PR DESCRIPTION
### Description
Handle conflict between specified region (deprecated) and implicit region from dsn account

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
