### PR TITLE
SNOW-186535 Fix arrow chunk decoding

### DIFF
--- a/chunk_arrow.go
+++ b/chunk_arrow.go
@@ -32,7 +32,7 @@ func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType) ([]
 
 		numRows := int(record.NumRows())
 		columns := record.Columns()
-		chunkRows = make([]chunkRowType, numRows)
+		tmpRows := make([]chunkRowType, numRows)
 
 		for colIdx, col := range columns {
 			destcol := make([]snowflakeValue, numRows)
@@ -43,11 +43,12 @@ func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType) ([]
 
 			for rowIdx := 0; rowIdx < numRows; rowIdx++ {
 				if colIdx == 0 {
-					chunkRows[rowIdx] = chunkRowType{ArrowRow: make([]snowflakeValue, len(columns))}
+					tmpRows[rowIdx] = chunkRowType{ArrowRow: make([]snowflakeValue, len(columns))}
 				}
-				chunkRows[rowIdx].ArrowRow[colIdx] = destcol[rowIdx]
+				tmpRows[rowIdx].ArrowRow[colIdx] = destcol[rowIdx]
 			}
 		}
+		chunkRows = append(chunkRows, tmpRows...)
 		arc.rowCount += numRows
 	}
 }


### PR DESCRIPTION
### Description
A single chunk can contain multiple fragmented records whilst we were assuming a one-to-one mapping previously.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
