### PR TITLE
SNOW-160505 Async Support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -77,7 +77,7 @@ func (sc *snowflakeConn) exec(
 			req.Parameters = map[string]interface{}{string(MultiStatementCount): key}
 		}
 	}
-	glog.V(2).Infof("parameters: %v", req.Parameters)
+	logger.WithContext(ctx).Infof("parameters: %v", req.Parameters)
 
 	tsmode := "TIMESTAMP_NTZ"
 	idx := 1
@@ -109,16 +109,7 @@ func (sc *snowflakeConn) exec(
 			}
 		}
 	}
-<<<<<<< HEAD
-	multiCount := ctx.Value(MultiStatementCount)
-	if multiCount != nil {
-		req.Parameters = map[string]interface{}{string(MultiStatementCount): multiCount}
-	}
 	logger.WithContext(ctx).Infof("bindings: %v", req.Bindings)
-	logger.WithContext(ctx).Infof("parameters: %v", req.Parameters)
-=======
-	glog.V(2).Infof("bindings: %v", req.Bindings)
->>>>>>> 13a25c6... add async support
 
 	headers := make(map[string]string)
 	headers["Content-Type"] = headerContentTypeApplicationJSON

--- a/driver.go
+++ b/driver.go
@@ -31,8 +31,8 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 	var err error
 	sc := &snowflakeConn{
 		SequenceCounter: 0,
-		ctx: ctx,
-		cfg: &config,
+		ctx:             ctx,
+		cfg:             &config,
 	}
 	var st http.RoundTripper = SnowflakeTransport
 	if sc.cfg.Transporter == nil {

--- a/driver.go
+++ b/driver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Snowflake Computing Inc. All right reserved.
+// Copyright (c) 2017-2021 Snowflake Computing Inc. All right reserved.
 
 package gosnowflake
 
@@ -126,4 +126,5 @@ var logger = CreateDefaultLogger()
 
 func init() {
 	sql.Register("snowflake", &SnowflakeDriver{})
+	logger.SetLogLevel("error")
 }

--- a/query.go
+++ b/query.go
@@ -71,7 +71,8 @@ type execResponseData struct {
 	QueryResultFormat string        `json:"queryResultFormat,omitempty"`
 
 	// async response placeholders
-	AsyncRows *snowflakeRows `json:"asyncRows,omitempty"`
+	AsyncResult *snowflakeResult `json:"asyncResult,omitempty"`
+	AsyncRows   *snowflakeRows   `json:"asyncRows,omitempty"`
 }
 
 type execResponse struct {

--- a/query.go
+++ b/query.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Snowflake Computing Inc. All right reserved.
+// Copyright (c) 2017-2021 Snowflake Computing Inc. All right reserved.
 
 package gosnowflake
 
@@ -69,6 +69,9 @@ type execResponseData struct {
 	ResultIDs         string        `json:"resultIds,omitempty"`
 	ResultTypes       string        `json:"resultTypes,omitempty"`
 	QueryResultFormat string        `json:"queryResultFormat,omitempty"`
+
+	// async response placeholders
+	AsyncRows *snowflakeRows `json:"asyncRows,omitempty"`
 }
 
 type execResponse struct {

--- a/restful.go
+++ b/restful.go
@@ -210,16 +210,16 @@ func postRestfulQueryHelper(
 			// placeholder object to return to user while retrieving results
 			rows := new(snowflakeRows)
 			res := new(snowflakeResult)
-			switch resType, _ := ctx.Value(resultType).(string); resType {
-			case "exec":
+			switch resType := getResultType(ctx); resType {
+			case execResultType:
 				res.queryID = respd.Data.QueryID
 				res.status = QueryStatusInProgress
-				res.statusChannel = make(chan queryEvent)
+				res.errChannel = make(chan error)
 				respd.Data.AsyncResult = res
-			case "query":
+			case queryResultType:
 				rows.queryID = respd.Data.QueryID
 				rows.status = QueryStatusInProgress
-				rows.statusChannel = make(chan queryEvent)
+				rows.errChannel = make(chan error)
 				respd.Data.AsyncRows = rows
 			default:
 				return &respd, nil

--- a/result.go
+++ b/result.go
@@ -1,16 +1,33 @@
-// Copyright (c) 2017-2019 Snowflake Computing Inc. All right reserved.
+// Copyright (c) 2017-2021 Snowflake Computing Inc. All right reserved.
 
 package gosnowflake
 
+type queryStatus string
+
+const (
+	/* query status */
+
+	// QueryStatusWaiting denotes a query execution waiting to happen
+	QueryStatusWaiting queryStatus = "queryStatusWaiting"
+	// QueryStatusInProgress denotes a query execution in progress
+	QueryStatusInProgress queryStatus = "queryStatusInProgress"
+	// QueryStatusComplete denotes a completed query execution
+	QueryStatusComplete queryStatus = "queryStatusComplete"
+	// QueryFailed denotes a failed query
+	QueryFailed queryStatus = "queryFailed"
+)
+
 // SnowflakeResult provides the associated query ID
 type SnowflakeResult interface {
-	QueryID() string
+	GetQueryID() string
+	GetStatus() queryStatus
 }
 
 type snowflakeResult struct {
 	affectedRows int64
 	insertID     int64 // Snowflake doesn't support last insert id
 	queryID      string
+	status       queryStatus
 }
 
 func (res *snowflakeResult) LastInsertId() (int64, error) {
@@ -21,6 +38,10 @@ func (res *snowflakeResult) RowsAffected() (int64, error) {
 	return res.affectedRows, nil
 }
 
-func (res *snowflakeResult) QueryID() string {
+func (res *snowflakeResult) GetQueryID() string {
 	return res.queryID
+}
+
+func (res *snowflakeResult) GetStatus() queryStatus {
+	return res.status
 }

--- a/statement.go
+++ b/statement.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Snowflake Computing Inc. All right reserved.
+// Copyright (c) 2017-2020 Snowflake Computing Inc. All right reserved.
 
 package gosnowflake
 
@@ -12,6 +12,14 @@ type paramKey string
 const (
 	// MultiStatementCount controls the number of queries to execute in a single API call
 	MultiStatementCount paramKey = "MULTI_STATEMENT_COUNT"
+	// AsyncMode controls
+	AsyncMode paramKey = "ASYNC_MODE_QUERY"
+	// QueryIDChan controls
+	QueryIDChan paramKey = "QUERY_ID_CHAN"
+	// ResumeQueryID controls
+	ResumeQueryID paramKey = "RESUME_QUERY_ID"
+	// IsInternal controls
+	IsInternal paramKey = "INTERNAL_QUERY"
 )
 
 type snowflakeStmt struct {
@@ -54,4 +62,14 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 // WithMultiStatement returns a context that allows the user to execute the desired number of sql queries in one query
 func WithMultiStatement(ctx context.Context, num int) (context.Context, error) {
 	return context.WithValue(ctx, MultiStatementCount, num), nil
+}
+
+// WithAsyncMode returns a context
+func WithAsyncMode(ctx context.Context) (context.Context, error) {
+	return context.WithValue(ctx, AsyncMode, true), nil
+}
+
+// WithInternal returns a context
+func WithInternal(ctx context.Context) (context.Context, error) {
+	return context.WithValue(ctx, IsInternal, true), nil
 }

--- a/statement.go
+++ b/statement.go
@@ -14,10 +14,6 @@ const (
 	MultiStatementCount paramKey = "MULTI_STATEMENT_COUNT"
 	// AsyncMode tells the server to not block the request on executing the entire query
 	AsyncMode paramKey = "ASYNC_MODE_QUERY"
-	// QueryIDChan is the channel to receive the query ID from
-	QueryIDChan paramKey = "QUERY_ID_CHANNEL"
-	// ResumeQueryID is the received query ID to resume execution
-	ResumeQueryID paramKey = "RESUME_QUERY_ID"
 )
 
 type snowflakeStmt struct {
@@ -65,14 +61,4 @@ func WithMultiStatement(ctx context.Context, num int) (context.Context, error) {
 // WithAsyncMode returns a context that allows execution of query in async mode
 func WithAsyncMode(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, AsyncMode, true), nil
-}
-
-// WithResumeQueryID returns a context that embeds the query ID to retrieve from async mode
-func WithResumeQueryID(ctx context.Context, queryID string) context.Context {
-	return context.WithValue(ctx, ResumeQueryID, queryID)
-}
-
-// WithQueryIDChan returns a context that contains the channel to receive the query ID
-func WithQueryIDChan(ctx context.Context, c chan<- string) context.Context {
-	return context.WithValue(ctx, QueryIDChan, c)
 }

--- a/statement.go
+++ b/statement.go
@@ -67,6 +67,11 @@ func WithAsyncMode(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, AsyncMode, true), nil
 }
 
+// WithResumeQueryID returns a context that embeds the query ID to retrieve from async mode
+func WithResumeQueryID(ctx context.Context, queryID string) context.Context {
+	return context.WithValue(ctx, ResumeQueryID, queryID)
+}
+
 // WithQueryIDChan returns a context that contains the channel to receive the query ID
 func WithQueryIDChan(ctx context.Context, c chan<- string) context.Context {
 	return context.WithValue(ctx, QueryIDChan, c)

--- a/statement.go
+++ b/statement.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Snowflake Computing Inc. All right reserved.
+// Copyright (c) 2017-2021 Snowflake Computing Inc. All right reserved.
 
 package gosnowflake
 
@@ -14,9 +14,9 @@ const (
 	MultiStatementCount paramKey = "MULTI_STATEMENT_COUNT"
 	// AsyncMode tells the server to not block the request on executing the entire query
 	AsyncMode paramKey = "ASYNC_MODE_QUERY"
-	// QueryIDChan controls
-	QueryIDChan paramKey = "QUERY_ID_CHAN"
-	// ResumeQueryID controls
+	// QueryIDChan is the channel to receive the query ID from
+	QueryIDChan paramKey = "QUERY_ID_CHANNEL"
+	// ResumeQueryID is the received query ID to resume execution
 	ResumeQueryID paramKey = "RESUME_QUERY_ID"
 )
 
@@ -62,7 +62,12 @@ func WithMultiStatement(ctx context.Context, num int) (context.Context, error) {
 	return context.WithValue(ctx, MultiStatementCount, num), nil
 }
 
-// WithAsyncMode returns a context
+// WithAsyncMode returns a context that allows execution of query in async mode
 func WithAsyncMode(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, AsyncMode, true), nil
+}
+
+// WithQueryIDChan returns a context that contains the channel to receive the query ID
+func WithQueryIDChan(ctx context.Context, c chan<- string) context.Context {
+	return context.WithValue(ctx, QueryIDChan, c)
 }

--- a/statement.go
+++ b/statement.go
@@ -12,14 +12,12 @@ type paramKey string
 const (
 	// MultiStatementCount controls the number of queries to execute in a single API call
 	MultiStatementCount paramKey = "MULTI_STATEMENT_COUNT"
-	// AsyncMode controls
+	// AsyncMode tells the server to not block the request on executing the entire query
 	AsyncMode paramKey = "ASYNC_MODE_QUERY"
 	// QueryIDChan controls
 	QueryIDChan paramKey = "QUERY_ID_CHAN"
 	// ResumeQueryID controls
 	ResumeQueryID paramKey = "RESUME_QUERY_ID"
-	// IsInternal controls
-	IsInternal paramKey = "INTERNAL_QUERY"
 )
 
 type snowflakeStmt struct {
@@ -67,9 +65,4 @@ func WithMultiStatement(ctx context.Context, num int) (context.Context, error) {
 // WithAsyncMode returns a context
 func WithAsyncMode(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, AsyncMode, true), nil
-}
-
-// WithInternal returns a context
-func WithInternal(ctx context.Context) (context.Context, error) {
-	return context.WithValue(ctx, IsInternal, true), nil
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -443,6 +443,32 @@ func TestMultiStatementCountMismatch(t *testing.T) {
 	}
 }
 
+func TestWithAsyncMode(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	if db, err = sql.Open("snowflake", dsn); err != nil {
+		t.Fatalf("failed to open db. %v, err: %v", dsn, err)
+	}
+	defer db.Close()
+
+	ctx, _ := WithAsyncMode(context.Background())
+	query := "SELECT SEQ8(), RANDSTR(1000, RANDOM()) FROM TABLE(GENERATOR(ROWCOUNT=>1000000))"
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		t.Error("failed query")
+	}
+	rows.Close()
+	var idx int
+	var v string
+	for rows.Next() {
+		err := rows.Scan(&idx, &v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestGetQueryID(t *testing.T) {
 	var db *sql.DB
 	var err error

--- a/statement_test.go
+++ b/statement_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestMultiStatementExecuteNoResultSet(t *testing.T) {
@@ -517,6 +518,65 @@ func TestAsyncMode(t *testing.T) {
 	var idx int
 	var v string
 	// Next() will block and wait until results are available
+	for rows.Next() {
+		err := rows.Scan(&idx, &v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cnt++
+	}
+	logger.Infof("NextResultSet: %v", rows.NextResultSet())
+
+	if cnt != numrows {
+		t.Errorf("number of rows didn't match. expected: %v, got: %v", numrows, cnt)
+	}
+}
+
+func TestAsyncModeWithQueryID(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	if db, err = sql.Open("snowflake", dsn); err != nil {
+		t.Fatalf("failed to open db. %v, err: %v", dsn, err)
+	}
+	defer db.Close()
+
+	numrows := 100000
+	queryIDChan := make(chan string, 1)
+	ctx := WithQueryIDChan(context.Background(), queryIDChan)
+	ctx, _ = WithAsyncMode(ctx)
+	conn, _ := db.Conn(ctx)
+	var queryID string
+
+	err = conn.Raw(func(x interface{}) error {
+		stmt, err := x.(driver.ConnPrepareContext).PrepareContext(ctx, fmt.Sprintf("SELECT SEQ8(), RANDSTR(1000, RANDOM()) FROM TABLE(GENERATOR(ROWCOUNT=>%v))", numrows))
+		if err != nil {
+			return err
+		}
+		rows, err := stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
+		if err != nil {
+			return err
+		}
+		if queryID = rows.(SnowflakeResult).GetQueryID(); queryID == "" {
+			// if query ID not available, wait using channel passed in
+			queryID = <-queryIDChan
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to execute query. err: %v", err)
+	}
+
+	time.Sleep(time.Second * 15)
+
+	// use retrieved query ID to check query status
+	ctx = WithResumeQueryID(context.Background(), queryID)
+	rows, _ := db.QueryContext(ctx, "") // query here does not matter
+	defer rows.Close()
+
+	cnt := 0
+	var idx int
+	var v string
 	for rows.Next() {
 		err := rows.Scan(&idx, &v)
 		if err != nil {

--- a/statement_test.go
+++ b/statement_test.go
@@ -570,10 +570,10 @@ func TestAsyncQueryFail(t *testing.T) {
 			return err
 		}
 		rows, err := stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
-		defer rows.Close()
 		if err != nil {
 			t.Fatal("asynchronous query should always return nil error")
 		}
+		defer rows.Close()
 
 		dest := make([]driver.Value, 1)
 		err = rows.Next(dest)


### PR DESCRIPTION
### Description
This PR allows asynchronous querying by enabling the AsyncExec parameter to be set via the driver, which, when sent to the server, will not block waiting for the entire query to finish.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
