### PR TITLE
Fix table in package doc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -245,7 +245,7 @@ This table shows the data types:
   Representation | Snowflake Data Type                | for Scan()  | Types for  | Footnotes
                  |                                    | interface{} | Scan()     |
                  |                                    | (JSON)      | (JSON)     |
-  ==============================================================================================
+  =============================================================================================
   BOOLEAN        | BOOLEAN                            | string      | bool       |
   TEXT           | VARCHAR/STRING                     | string      | string     |
   REAL           | REAL/DOUBLE                        | string      | float64    | [1]  [2]


### PR DESCRIPTION
### Description
Fix header border length in the *data types* table in the package doc so that it matches the length of the other header border.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
