### PR TITLE
SNOW-183506 Drop support of Go 1.13

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.15', '1.14', '1.13' ]
+                go: [ '1.15', '1.14' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Ubuntu
         steps:
             - uses: actions/checkout@v1
@@ -42,7 +42,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.15', '1.14', '1.13' ]
+                go: [ '1.15', '1.14' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Mac
         steps:
             - uses: actions/checkout@v1
@@ -66,7 +66,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.15', '1.14', '1.13' ]
+                go: [ '1.15', '1.14' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Windows
         steps:
             - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ The following software packages are required to use the Go Snowflake Driver.
 Go
 ----------------------------------------------------------------------
 
-The latest driver requires the `Go language <https://golang.org/>`_ 1.13 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
+The latest driver requires the `Go language <https://golang.org/>`_ 1.14 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
 
 
 Installation


### PR DESCRIPTION
### Description
Removed Go 1.13 tests in line with dropping support for Go 1.13.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
