### PR TITLE
SNOW-206590 allow specifying the snowflake request id via context

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -195,7 +195,7 @@ func postAuth(
 	body []byte,
 	timeout time.Duration) (
 	data *authResponse, err error) {
-	params.Add(requestIDKey, uuid.New().String())
+	params.Add(requestIDKey, getRequestID(ctx))
 	params.Add(requestGUIDKey, uuid.New().String())
 
 	fullURL := sr.getFullURL(loginRequestPath, params)

--- a/authokta.go
+++ b/authokta.go
@@ -13,8 +13,6 @@ import (
 	"net/url"
 	"strconv"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type authOKTARequest struct {
@@ -208,7 +206,7 @@ func postAuthSAML(
 	data *authResponse, err error) {
 
 	params := &url.Values{}
-	params.Add(requestIDKey, uuid.New().String())
+	params.Add(requestIDKey, getRequestID(ctx))
 	fullURL := sr.getFullURL(authenticatorRequestPath, params)
 
 	glog.V(2).Infof("fullURL: %v", fullURL)

--- a/connection.go
+++ b/connection.go
@@ -127,8 +127,8 @@ func (sc *snowflakeConn) exec(
 
 	var data *execResponse
 
-	requestID := uuid.New()
-	data, err = sc.rest.FuncPostQuery(ctx, sc.rest, &url.Values{}, headers, jsonBody, sc.rest.RequestTimeout, &requestID)
+	requestID := getRequestID(ctx)
+	data, err = sc.rest.FuncPostQuery(ctx, sc.rest, &url.Values{}, headers, jsonBody, sc.rest.RequestTimeout, requestID)
 	if err != nil {
 		return data, err
 	}
@@ -525,7 +525,7 @@ func (sc *snowflakeConn) getQueryResult(ctx context.Context, resultPath string) 
 		headers["X-Snowflake-Service"] = *serviceName
 	}
 	param := make(url.Values)
-	param.Add(requestIDKey, uuid.New().String())
+	param.Add(requestIDKey, getRequestID(ctx))
 	param.Add("clientStartTime", strconv.FormatInt(time.Now().Unix(), 10))
 	param.Add(requestGUIDKey, uuid.New().String())
 	if sc.rest.Token != "" {

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,7 +2,6 @@ package gosnowflake
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"net/url"
 	"testing"
 	"time"
@@ -14,7 +13,7 @@ const serviceNameAppend = "a"
 // postQueryMock would generate a response based on the X-Snowflake-Service header, to generate a response
 // with the SERVICE_NAME field appending a character at the end of the header
 // This way it could test both the send and receive logic
-func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ *uuid.UUID) (*execResponse, error) {
+func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ string) (*execResponse, error) {
 	var serviceName string
 	if serviceHeader, ok := headers["X-Snowflake-Service"]; ok {
 		serviceName = serviceHeader + serviceNameAppend

--- a/restful.go
+++ b/restful.go
@@ -56,14 +56,14 @@ type snowflakeRestful struct {
 	HeartBeat   *heartbeat
 
 	Connection          *snowflakeConn
-	FuncPostQuery       func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration, *uuid.UUID) (*execResponse, error)
-	FuncPostQueryHelper func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration, *uuid.UUID) (*execResponse, error)
+	FuncPostQuery       func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration, string) (*execResponse, error)
+	FuncPostQueryHelper func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration, string) (*execResponse, error)
 	FuncPost            func(context.Context, *snowflakeRestful, *url.URL, map[string]string, []byte, time.Duration, bool) (*http.Response, error)
 	FuncGet             func(context.Context, *snowflakeRestful, *url.URL, map[string]string, time.Duration) (*http.Response, error)
 	FuncRenewSession    func(context.Context, *snowflakeRestful, time.Duration) error
 	FuncPostAuth        func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration) (*authResponse, error)
 	FuncCloseSession    func(context.Context, *snowflakeRestful, time.Duration) error
-	FuncCancelQuery     func(context.Context, *snowflakeRestful, *uuid.UUID, time.Duration) error
+	FuncCancelQuery     func(context.Context, *snowflakeRestful, string, time.Duration) error
 
 	FuncPostAuthSAML func(context.Context, *snowflakeRestful, map[string]string, []byte, time.Duration) (*authResponse, error)
 	FuncPostAuthOKTA func(context.Context, *snowflakeRestful, map[string]string, []byte, string, time.Duration) (*authOKTAResponse, error)
@@ -142,7 +142,7 @@ func postRestfulQuery(
 	headers map[string]string,
 	body []byte,
 	timeout time.Duration,
-	requestID *uuid.UUID) (
+	requestID string) (
 	data *execResponse, err error) {
 
 	data, err = sr.FuncPostQueryHelper(ctx, sr, params, headers, body, timeout, requestID)
@@ -166,10 +166,10 @@ func postRestfulQueryHelper(
 	headers map[string]string,
 	body []byte,
 	timeout time.Duration,
-	requestID *uuid.UUID) (
+	requestID string) (
 	data *execResponse, err error) {
 	glog.V(2).Infof("params: %v", params)
-	params.Add(requestIDKey, requestID.String())
+	params.Add(requestIDKey, getRequestID(ctx))
 	params.Add("clientStartTime", strconv.FormatInt(time.Now().Unix(), 10))
 	params.Add(requestGUIDKey, uuid.New().String())
 	if sr.Token != "" {
@@ -258,7 +258,7 @@ func closeSession(ctx context.Context, sr *snowflakeRestful, timeout time.Durati
 	glog.V(2).Info("close session")
 	params := &url.Values{}
 	params.Add("delete", "true")
-	params.Add(requestIDKey, uuid.New().String())
+	params.Add(requestIDKey, getRequestID(ctx))
 	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := sr.getFullURL(sessionRequestPath, params)
 
@@ -313,7 +313,7 @@ func closeSession(ctx context.Context, sr *snowflakeRestful, timeout time.Durati
 func renewRestfulSession(ctx context.Context, sr *snowflakeRestful, timeout time.Duration) error {
 	glog.V(2).Info("start renew session")
 	params := &url.Values{}
-	params.Add(requestIDKey, uuid.New().String())
+	params.Add(requestIDKey, getRequestID(ctx))
 	params.Add(requestGUIDKey, uuid.New().String())
 	fullURL := sr.getFullURL(tokenRequestPath, params)
 
@@ -377,10 +377,10 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful, timeout time
 	}
 }
 
-func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID *uuid.UUID, timeout time.Duration) error {
+func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID string, timeout time.Duration) error {
 	glog.V(2).Info("cancel query")
 	params := &url.Values{}
-	params.Add(requestIDKey, uuid.New().String())
+	params.Add(requestIDKey, getRequestID(ctx))
 	params.Add(requestGUIDKey, uuid.New().String())
 
 	fullURL := sr.getFullURL(abortRequestPath, params)
@@ -392,7 +392,7 @@ func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID *uuid.UUID
 	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sr.Token)
 
 	req := make(map[string]string)
-	req[requestIDKey] = requestID.String()
+	req[requestIDKey] = requestID
 
 	reqByte, err := json.Marshal(req)
 	if err != nil {

--- a/restful.go
+++ b/restful.go
@@ -169,7 +169,7 @@ func postRestfulQueryHelper(
 	requestID string) (
 	data *execResponse, err error) {
 	glog.V(2).Infof("params: %v", params)
-	params.Add(requestIDKey, getRequestID(ctx))
+	params.Add(requestIDKey, requestID)
 	params.Add("clientStartTime", strconv.FormatInt(time.Now().Unix(), 10))
 	params.Add(requestGUIDKey, uuid.New().String())
 	if sr.Token != "" {

--- a/restful_test.go
+++ b/restful_test.go
@@ -121,36 +121,6 @@ func renewSessionTestError(_ context.Context, _ *snowflakeRestful, _ time.Durati
 	return errors.New("failed to renew session in tests")
 }
 
-func TestUnitPostQueryWithSpecificRequestID(t *testing.T) {
-	var err error
-	origRequestID := "specific-snowflake-request-id"
-	ctx := context.WithValue(context.Background(), SnowflakeRequestIDKey, origRequestID)
-	postQueryTest := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID string) (*execResponse, error) {
-		// ensure the same requestID is used after the session token is renewed.
-		if requestID != origRequestID {
-			t.Fatal("requestID doesn't match")
-		}
-		dd := &execResponseData{}
-		return &execResponse{
-			Data:    *dd,
-			Message: "",
-			Code:    "0",
-			Success: true,
-		}, nil
-	}
-	sr := &snowflakeRestful{
-		Token:            "token",
-		FuncPost:         postTestRenew,
-		FuncPostQuery:    postQueryTest,
-		FuncRenewSession: renewSessionTest,
-	}
-
-	_, err = postRestfulQueryHelper(ctx, sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, origRequestID)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-}
-
 func TestUnitPostQueryHelperRenewSession(t *testing.T) {
 	var err error
 	origRequestID := uuid.New().String()

--- a/retry.go
+++ b/retry.go
@@ -51,9 +51,9 @@ type requestGUIDReplacer interface {
 
 // Get the request ID from the context if specified, otherwise generate one
 func getRequestID(ctx context.Context) string {
-	requestId, ok := ctx.Value(SnowflakeRequestIDKey).(string)
-	if ok && requestId != "" {
-		return requestId
+	requestID, ok := ctx.Value(SnowflakeRequestIDKey).(string)
+	if ok && requestID != "" {
+		return requestID
 	}
 	return uuid.New().String()
 }

--- a/retry.go
+++ b/retry.go
@@ -26,6 +26,11 @@ func init() {
 	random = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
+type contextKey string
+
+// SnowflakeRequestIDKey is optional context key to specify request id
+const SnowflakeRequestIDKey contextKey = "SNOWFLAKE_REQUEST_ID"
+
 // requestGUIDKey is attached to every request against Snowflake
 const requestGUIDKey string = "request_guid"
 
@@ -34,9 +39,6 @@ const retryCounterKey string = "retryCounter"
 
 // requestIDKey is attached to all requests to Snowflake
 const requestIDKey string = "requestId"
-
-// SnowflakeRequestIDKey is optional context key to specify request id
-const SnowflakeRequestIDKey = "SNOWFLAKE_REQUEST_ID"
 
 // This class takes in an url during construction and replace the
 // value of request_guid every time the replace() is called

--- a/retry.go
+++ b/retry.go
@@ -35,6 +35,9 @@ const retryCounterKey string = "retryCounter"
 // requestIDKey is attached to all requests to Snowflake
 const requestIDKey string = "requestId"
 
+// SnowflakeRequestIDKey is optional context key to specify request id
+const SnowflakeRequestIDKey = "SNOWFLAKE_REQUEST_ID"
+
 // This class takes in an url during construction and replace the
 // value of request_guid every time the replace() is called
 // When the url does not contain request_guid, just return the original
@@ -42,6 +45,14 @@ const requestIDKey string = "requestId"
 type requestGUIDReplacer interface {
 	// replace the url with new ID
 	replace() *url.URL
+}
+
+func getRequestID(ctx context.Context) string {
+	requestId, ok := ctx.Value(SnowflakeRequestIDKey).(string)
+	if ok && requestId != "" {
+		return requestId
+	}
+	return uuid.New().String()
 }
 
 // Make requestGUIDReplacer given a url string

--- a/retry.go
+++ b/retry.go
@@ -47,6 +47,7 @@ type requestGUIDReplacer interface {
 	replace() *url.URL
 }
 
+// Get the request ID from the context if specified, otherwise generate one
 func getRequestID(ctx context.Context) string {
 	requestId, ok := ctx.Value(SnowflakeRequestIDKey).(string)
 	if ok && requestId != "" {


### PR DESCRIPTION
### Description
Allow specific request ID to be set via the context key `SNOWFLAKE_REQUEST_ID`.
If the key is not specified or value is empty, fallback to existing behavior of generating UUID.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
