### PR TITLE
SNOW-208979 Add option to trigger Github Action Build/Test manually

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,14 @@ on:
             - master
     schedule:
       - cron:  '7 3 * * *'
+    workflow_dispatch:
+        inputs:
+          logLevel:
+            default: warning
+            description: "Log level"
+            required: true
+          tags:
+            description: "Test scenario tags"
 
 jobs:
     build-test-linux:


### PR DESCRIPTION
### Description
This will add a button for build-test workflow to run it manually . This will be useful for Releng team to run GoLang tests on master or any other branch as part of pre-release of server release is done to ensure it does not break GoLang connector

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
