### PR TITLE
SNOW-209089 Add HTTP transport override to support future token accessor

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Snowflake Computing Inc. All right reserved.
+
+package gosnowflake
+
+import (
+	"context"
+	"database/sql/driver"
+)
+
+// InternalSnowflakeDriver is the interface for an internal Snowflake driver
+type InternalSnowflakeDriver interface {
+	Open(dsn string) (driver.Conn, error)
+	OpenWithConfig(ctx context.Context, config Config) (driver.Conn, error)
+}
+
+// Connector creates Driver with the specified Config
+type Connector struct {
+	driver InternalSnowflakeDriver
+	cfg    Config
+}
+
+// NewConnector creates a new connector with the given SnowflakeDriver and Config.
+func NewConnector(driver InternalSnowflakeDriver, config Config) Connector {
+	return Connector{driver, config}
+}
+
+// Connect creates a new connection.
+func (t Connector) Connect(ctx context.Context) (driver.Conn, error) {
+	cfg := t.cfg
+	err := fillMissingConfigParameters(&cfg)
+	if err != nil {
+		return nil, err
+	}
+	return t.driver.OpenWithConfig(ctx, cfg)
+}
+
+// Driver creates a new driver.
+func (t Connector) Driver() driver.Driver {
+	return t.driver
+}

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Snowflake Computing Inc. All right reserved.
+
+package gosnowflake
+
+import (
+	"context"
+	"database/sql/driver"
+	"reflect"
+	"testing"
+)
+
+type noopTestDriver struct {
+	config Config
+	conn   *snowflakeConn
+}
+
+func (d noopTestDriver) Open(_ string) (driver.Conn, error) {
+	return nil, nil
+}
+
+func (d noopTestDriver) OpenWithConfig(_ context.Context, config Config) (driver.Conn, error) {
+	d.config = config
+	return d.conn, nil
+}
+
+func TestConnector(t *testing.T) {
+	conn := snowflakeConn{}
+	mock := noopTestDriver{conn: &conn}
+	createDSN("UTC")
+	config, err := ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("Failed to parse dsn %s", dsn)
+	}
+	connector := NewConnector(mock, *config)
+	connection, err := connector.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect error %s", err)
+	}
+	if connection != &conn {
+		t.Fatalf("Connection mismatch %s", connection)
+	}
+	fillMissingConfigParameters(config)
+	if reflect.DeepEqual(config, mock.config) {
+		t.Fatalf("Config should be equal, expected %v, actual %v", config, mock.config)
+	}
+	if connector.Driver() == nil {
+		t.Fatalf("Missing driver")
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -125,6 +125,8 @@ A complete connection string looks similar to the following:
 Session-level parameters can also be set by using the SQL command "ALTER SESSION"
 (https://docs.snowflake.com/en/sql-reference/sql/alter-session.html).
 
+Alternatively, use OpenWithConfig() function to create a database handle with the specified Config.
+
 Proxy
 
 The Go Snowflake Driver honors the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY for the forward proxy setting.

--- a/driver.go
+++ b/driver.go
@@ -17,16 +17,22 @@ type SnowflakeDriver struct {
 // Open creates a new connection.
 func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 	logger.Info("Open")
+	ctx := context.TODO()
+	cfg, err := ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return d.OpenWithConfig(ctx, *cfg)
+}
+
+// OpenWithConfig creates a new connection with the given Config.
+func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (driver.Conn, error) {
+	logger.Info("OpenWithConfig")
 	var err error
 	sc := &snowflakeConn{
 		SequenceCounter: 0,
-		ctx:             context.TODO(),
-	}
-
-	sc.cfg, err = ParseDSN(dsn)
-	if err != nil {
-		sc.cleanup()
-		return nil, err
+		ctx: ctx,
+		cfg: &config,
 	}
 	st := SnowflakeTransport
 	if sc.cfg.InsecureMode {

--- a/driver.go
+++ b/driver.go
@@ -34,15 +34,20 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 		ctx: ctx,
 		cfg: &config,
 	}
-	st := SnowflakeTransport
-	if sc.cfg.InsecureMode {
-		// no revocation check with OCSP. Think twice when you want to enable this option.
-		st = snowflakeInsecureTransport
+	var st http.RoundTripper = SnowflakeTransport
+	if sc.cfg.Transporter == nil {
+		if sc.cfg.InsecureMode {
+			// no revocation check with OCSP. Think twice when you want to enable this option.
+			st = snowflakeInsecureTransport
+		} else {
+			// set OCSP fail open mode
+			ocspResponseCacheLock.Lock()
+			atomic.StoreUint32((*uint32)(&ocspFailOpen), uint32(sc.cfg.OCSPFailOpen))
+			ocspResponseCacheLock.Unlock()
+		}
 	} else {
-		// set OCSP fail open mode
-		ocspResponseCacheLock.Lock()
-		atomic.StoreUint32((*uint32)(&ocspFailOpen), uint32(sc.cfg.OCSPFailOpen))
-		ocspResponseCacheLock.Unlock()
+		// use the custom transport
+		st = sc.cfg.Transporter
 	}
 	// authenticate
 	sc.rest = &snowflakeRestful{

--- a/driver_test.go
+++ b/driver_test.go
@@ -2388,6 +2388,19 @@ func TestPingInvalidHost(t *testing.T) {
 	}
 }
 
+func TestOpenWithConfig(t *testing.T) {
+	config, err := ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse dsn. dsn: %v, err: %v", dsn, err)
+	}
+	driver := SnowflakeDriver{}
+	db, err := driver.OpenWithConfig(context.Background(), *config)
+	if err != nil {
+		t.Fatalf("failed to open with config. config: %v, err: %v", config, err)
+	}
+	db.Close()
+}
+
 func createDSNWithClientSessionKeepAlive() {
 	dsn = fmt.Sprintf("%s:%s@%s/%s/%s", user, pass, host, dbname, schemaname)
 

--- a/dsn.go
+++ b/dsn.go
@@ -413,7 +413,7 @@ func fillMissingConfigParameters(cfg *Config) error {
 	return nil
 }
 
-// transformAccountToHost transforms host to accout name
+// transformAccountToHost transforms host to account name
 func transformAccountToHost(cfg *Config) (err error) {
 	if cfg.Port == 0 && !strings.HasSuffix(cfg.Host, defaultDomain) && cfg.Host != "" {
 		// account name is specified instead of host:port

--- a/dsn.go
+++ b/dsn.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -70,6 +71,8 @@ type Config struct {
 	Token string // Token to use for OAuth other forms of token based auth
 
 	PrivateKey *rsa.PrivateKey // Private key used to sign JWT
+
+	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 }
 
 // ocspMode returns the OCSP mode in string INSECURE, FAIL_OPEN, FAIL_CLOSED


### PR DESCRIPTION
SNOW-209089

### Description
In order to support manual auth token accessor / management, we
need a clean way to intercept HTTP requests and responses and manually
set AUTH header, retry, and reauth.

Add an optional value to the config so that an override Http transport
can be specified. When the Transport is specified, the REST client will
use this transport instead of the default snowflake transport.

Testing
Added unit test to verify that config transport is indeed the one
used by the snowflake restful http client

This is built upon https://github.com/snowflakedb/gosnowflake/pull/343 which allows
opening connection with custom Config

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
