### PR TITLE
SNOW-209082 Introduce TokenAccessor to manage tokens and sessions

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -172,7 +172,7 @@ type authResponseMain struct {
 	RemMeValidity       time.Duration           `json:"remMeValidityInSeconds"`
 	HealthCheckInterval time.Duration           `json:"healthCheckInterval"`
 	NewClientForUpgrade string                  `json:"newClientForUpgrade"`
-	SessionID           int                     `json:"sessionId"`
+	SessionID           int                     `json:"sessionID"`
 	Parameters          []nameValueParameter    `json:"parameters"`
 	SessionInfo         authResponseSessionInfo `json:"sessionInfo"`
 	TokenURL            string                  `json:"tokenUrl,omitempty"`

--- a/auth.go
+++ b/auth.go
@@ -352,9 +352,7 @@ func authenticate(
 	}
 	if !respd.Success {
 		logger.Errorln("Authentication FAILED")
-		sc.rest.Token = ""
-		sc.rest.MasterToken = ""
-		sc.rest.SessionID = -1
+		sc.rest.TokenAccessor.SetTokens("", "", -1)
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
 			code = -1
@@ -367,9 +365,7 @@ func authenticate(
 		}
 	}
 	logger.Info("Authentication SUCCESS")
-	sc.rest.Token = respd.Data.Token
-	sc.rest.MasterToken = respd.Data.MasterToken
-	sc.rest.SessionID = respd.Data.SessionID
+	sc.rest.TokenAccessor.SetTokens(respd.Data.Token, respd.Data.MasterToken, respd.Data.SessionID)
 	return &respd.Data, nil
 }
 

--- a/auth.go
+++ b/auth.go
@@ -263,7 +263,6 @@ func authenticate(
 	samlResponse []byte,
 	proofKey []byte,
 ) (resp *authResponseMain, err error) {
-
 	headers := getHeaders()
 	clientEnvironment := authRequestClientEnvironment{
 		Application: sc.cfg.Application,

--- a/auth.go
+++ b/auth.go
@@ -172,7 +172,7 @@ type authResponseMain struct {
 	RemMeValidity       time.Duration           `json:"remMeValidityInSeconds"`
 	HealthCheckInterval time.Duration           `json:"healthCheckInterval"`
 	NewClientForUpgrade string                  `json:"newClientForUpgrade"`
-	SessionID           int                     `json:"sessionID"`
+	SessionID           int                     `json:"sessionId"`
 	Parameters          []nameValueParameter    `json:"parameters"`
 	SessionInfo         authResponseSessionInfo `json:"sessionInfo"`
 	TokenURL            string                  `json:"tokenUrl,omitempty"`

--- a/auth_test.go
+++ b/auth_test.go
@@ -19,7 +19,7 @@ import (
 func TestUnitPostAuth(t *testing.T) {
 	sr := &snowflakeRestful{
 		TokenAccessor: getSimpleTokenAccessor(),
-		FuncPost: postTestAfterRenew,
+		FuncPost:      postTestAfterRenew,
 	}
 	var err error
 	_, err = postAuth(context.TODO(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0)
@@ -241,7 +241,9 @@ func getDefaultSnowflakeConn() *snowflakeConn {
 		Passcode:           "",
 		Application:        "testapp",
 	}
-	sr := &snowflakeRestful{}
+	sr := &snowflakeRestful{
+		TokenAccessor: getSimpleTokenAccessor(),
+	}
 	sc := &snowflakeConn{
 		rest: sr,
 		cfg:  &cfg,
@@ -256,7 +258,8 @@ func TestUnitAuthenticate(t *testing.T) {
 
 	sc := getDefaultSnowflakeConn()
 	sr := &snowflakeRestful{
-		FuncPostAuth: postAuthFailServiceIssue,
+		FuncPostAuth:  postAuthFailServiceIssue,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	sc.rest = sr
 
@@ -314,7 +317,8 @@ func TestUnitAuthenticate(t *testing.T) {
 func TestUnitAuthenticateSaml(t *testing.T) {
 	var err error
 	sr := &snowflakeRestful{
-		FuncPostAuth: postAuthCheckSAMLResponse,
+		FuncPostAuth:  postAuthCheckSAMLResponse,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	sc := getDefaultSnowflakeConn()
 	sc.cfg.Authenticator = AuthTypeOkta
@@ -333,7 +337,8 @@ func TestUnitAuthenticateSaml(t *testing.T) {
 func TestUnitAuthenticateOAuth(t *testing.T) {
 	var err error
 	sr := &snowflakeRestful{
-		FuncPostAuth: postAuthCheckOAuth,
+		FuncPostAuth:  postAuthCheckOAuth,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	sc := getDefaultSnowflakeConn()
 	sc.cfg.Token = "oauthToken"
@@ -348,7 +353,8 @@ func TestUnitAuthenticateOAuth(t *testing.T) {
 func TestUnitAuthenticatePasscode(t *testing.T) {
 	var err error
 	sr := &snowflakeRestful{
-		FuncPostAuth: postAuthCheckPasscode,
+		FuncPostAuth:  postAuthCheckPasscode,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	sc := getDefaultSnowflakeConn()
 	sc.cfg.Passcode = "987654321"
@@ -372,7 +378,8 @@ func TestUnitAuthenticateJWT(t *testing.T) {
 	var err error
 
 	sr := &snowflakeRestful{
-		FuncPostAuth: postAuthCheckJWTToken,
+		FuncPostAuth:  postAuthCheckJWTToken,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	sc := getDefaultSnowflakeConn()
 	sc.cfg.Authenticator = AuthTypeJwt

--- a/auth_test.go
+++ b/auth_test.go
@@ -256,10 +256,11 @@ func TestUnitAuthenticate(t *testing.T) {
 	var driverErr *SnowflakeError
 	var ok bool
 
+	ta := getSimpleTokenAccessor()
 	sc := getDefaultSnowflakeConn()
 	sr := &snowflakeRestful{
 		FuncPostAuth:  postAuthFailServiceIssue,
-		TokenAccessor: getSimpleTokenAccessor(),
+		TokenAccessor: ta,
 	}
 	sc.rest = sr
 
@@ -289,19 +290,29 @@ func TestUnitAuthenticate(t *testing.T) {
 	if !ok || driverErr.Number != ErrFailedToAuth {
 		t.Fatalf("Snowflake error is expected. err: %v", driverErr)
 	}
+	ta.SetTokens("bad-token", "bad-master-token", 1)
 	sr.FuncPostAuth = postAuthSuccessWithErrorCode
 	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
 	}
+	newToken, newMasterToken, newSessionID := ta.GetTokens()
+	if newToken != "" || newMasterToken != "" || newSessionID != -1 {
+		t.Fatalf("failed auth should have reset tokens: %v %v %v", newToken, newMasterToken, newSessionID)
+	}
 	driverErr, ok = err.(*SnowflakeError)
 	if !ok || driverErr.Number != 98765 {
 		t.Fatalf("Snowflake error is expected. err: %v", driverErr)
 	}
+	ta.SetTokens("bad-token", "bad-master-token", 1)
 	sr.FuncPostAuth = postAuthSuccessWithInvalidErrorCode
 	_, err = authenticate(context.TODO(), sc, []byte{}, []byte{})
 	if err == nil {
 		t.Fatal("should have failed.")
+	}
+	oldToken, oldMasterToken, oldSessionID := ta.GetTokens()
+	if oldToken != "" || oldMasterToken != "" || oldSessionID != -1 {
+		t.Fatalf("failed auth should have reset tokens: %v %v %v", oldToken, oldMasterToken, oldSessionID)
 	}
 	sr.FuncPostAuth = postAuthSuccess
 	var resp *authResponseMain
@@ -311,6 +322,16 @@ func TestUnitAuthenticate(t *testing.T) {
 	}
 	if resp.SessionInfo.DatabaseName != "dbn" {
 		t.Fatalf("failed to get response from auth")
+	}
+	newToken, newMasterToken, newSessionID = ta.GetTokens()
+	if newToken == oldToken {
+		t.Fatalf("new token was not set: %v", newToken)
+	}
+	if newMasterToken == oldMasterToken {
+		t.Fatalf("new master token was not set: %v", newMasterToken)
+	}
+	if newSessionID == oldSessionID {
+		t.Fatalf("new session id was not set: %v", newSessionID)
 	}
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestUnitPostAuth(t *testing.T) {
 	sr := &snowflakeRestful{
-		Token:    "token",
+		TokenAccessor: getSimpleTokenAccessor(),
 		FuncPost: postTestAfterRenew,
 	}
 	var err error

--- a/authokta.go
+++ b/authokta.go
@@ -90,9 +90,7 @@ func authenticateBySAML(
 	}
 	if !respd.Success {
 		logger.Errorln("Authentication FAILED")
-		sr.Token = ""
-		sr.MasterToken = ""
-		sr.SessionID = -1
+		sr.TokenAccessor.SetTokens("", "", -1)
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
 			code = -1

--- a/authokta_test.go
+++ b/authokta_test.go
@@ -60,7 +60,8 @@ func getTestHTMLSuccess(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ ma
 
 func TestUnitPostAuthSAML(t *testing.T) {
 	sr := &snowflakeRestful{
-		FuncPost: postTestError,
+		FuncPost:      postTestError,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	var err error
 	_, err = postAuthSAML(context.TODO(), sr, make(map[string]string), []byte{}, 0)
@@ -81,7 +82,8 @@ func TestUnitPostAuthSAML(t *testing.T) {
 
 func TestUnitPostAuthOKTA(t *testing.T) {
 	sr := &snowflakeRestful{
-		FuncPost: postTestError,
+		FuncPost:      postTestError,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	var err error
 	_, err = postAuthOKTA(context.TODO(), sr, make(map[string]string), []byte{}, "hahah", 0)
@@ -102,7 +104,8 @@ func TestUnitPostAuthOKTA(t *testing.T) {
 
 func TestUnitGetSSO(t *testing.T) {
 	sr := &snowflakeRestful{
-		FuncGet: getTestError,
+		FuncGet:       getTestError,
+		TokenAccessor: getSimpleTokenAccessor(),
 	}
 	var err error
 	_, err = getSSO(context.TODO(), sr, &url.Values{}, make(map[string]string), "hahah", 0)
@@ -188,6 +191,7 @@ func TestUnitAuthenticateBySAML(t *testing.T) {
 		Host:             "abc.com",
 		Port:             443,
 		FuncPostAuthSAML: postAuthSAMLError,
+		TokenAccessor:    getSimpleTokenAccessor(),
 	}
 	var err error
 	_, err = authenticateBySAML(context.TODO(), sr, authenticator, application, account, user, password)

--- a/connection.go
+++ b/connection.go
@@ -635,7 +635,8 @@ func getAsync(
 		sfError.QueryID = rows.queryID
 	}
 	defer close(errChannel)
-	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sr.Token)
+	token, _, _ := sr.TokenAccessor.GetTokens()
+	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
 	resp, err := sr.FuncGet(ctx, sr, URL, headers, timeout)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to get response. err: %v", err)

--- a/connection.go
+++ b/connection.go
@@ -581,8 +581,9 @@ func (sc *snowflakeConn) getQueryResult(ctx context.Context, resultPath string) 
 	param.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx).String())
 	param.Add("clientStartTime", strconv.FormatInt(time.Now().Unix(), 10))
 	param.Add(requestGUIDKey, uuid.New().String())
-	if sc.rest.Token != "" {
-		headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, sc.rest.Token)
+	token, _, _ := sc.rest.TokenAccessor.GetTokens()
+	if token != "" {
+		headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
 	}
 	url := sc.rest.getFullURL(resultPath, &param)
 	res, err := sc.rest.FuncGet(ctx, sc.rest, url, headers, sc.rest.RequestTimeout)

--- a/driver.go
+++ b/driver.go
@@ -50,7 +50,7 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 		st = sc.cfg.Transporter
 	}
 	var tokenAccessor TokenAccessor
-	if sc.cfg.TokenAccessor == nil {
+	if sc.cfg.TokenAccessor != nil {
 		tokenAccessor = sc.cfg.TokenAccessor
 	} else {
 		tokenAccessor = getSimpleTokenAccessor()

--- a/driver.go
+++ b/driver.go
@@ -49,6 +49,12 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 		// use the custom transport
 		st = sc.cfg.Transporter
 	}
+	var tokenAccessor TokenAccessor
+	if sc.cfg.TokenAccessor == nil {
+		tokenAccessor = sc.cfg.TokenAccessor
+	} else {
+		tokenAccessor = getSimpleTokenAccessor()
+	}
 	// authenticate
 	sc.rest = &snowflakeRestful{
 		Host:     sc.cfg.Host,
@@ -59,6 +65,7 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 			Timeout:   sc.cfg.ClientTimeout,
 			Transport: st,
 		},
+		TokenAccessor:       tokenAccessor,
 		LoginTimeout:        sc.cfg.LoginTimeout,
 		RequestTimeout:      sc.cfg.RequestTimeout,
 		FuncPost:            postRestful,

--- a/dsn.go
+++ b/dsn.go
@@ -71,7 +71,8 @@ type Config struct {
 	InsecureMode bool             // driver doesn't check certificate revocation status
 	OCSPFailOpen OCSPFailOpenMode // OCSP Fail Open
 
-	Token string // Token to use for OAuth other forms of token based auth
+	Token         string        // Token to use for OAuth other forms of token based auth
+	TokenAccessor TokenAccessor // Optional token accessor to use
 
 	PrivateKey *rsa.PrivateKey // Private key used to sign JWT
 

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -62,7 +62,8 @@ func (hc *heartbeat) heartbeatMain() error {
 	headers["Content-Type"] = headerContentTypeApplicationJSON
 	headers["accept"] = headerAcceptTypeApplicationSnowflake
 	headers["User-Agent"] = userAgent
-	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, hc.restful.Token)
+	token, _, _ := hc.restful.TokenAccessor.GetTokens()
+	headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
 
 	fullURL := hc.restful.getFullURL(heartBeatPath, params)
 	timeout := hc.restful.RequestTimeout

--- a/restful.go
+++ b/restful.go
@@ -99,7 +99,7 @@ type renewSessionResponseMain struct {
 	ValidityInSecondsST time.Duration `json:"validityInSecondsST"`
 	MasterToken         string        `json:"masterToken"`
 	ValidityInSecondsMT time.Duration `json:"validityInSecondsMT"`
-	SessionID           int           `json:"sessionID"`
+	SessionID           int           `json:"sessionId"`
 }
 
 type cancelQueryResponse struct {

--- a/restful.go
+++ b/restful.go
@@ -99,7 +99,7 @@ type renewSessionResponseMain struct {
 	ValidityInSecondsST time.Duration `json:"validityInSecondsST"`
 	MasterToken         string        `json:"masterToken"`
 	ValidityInSecondsMT time.Duration `json:"validityInSecondsMT"`
-	SessionID           int           `json:"sessionId"`
+	SessionID           int           `json:"sessionID"`
 }
 
 type cancelQueryResponse struct {

--- a/restful_test.go
+++ b/restful_test.go
@@ -91,7 +91,7 @@ func postTestAfterRenew(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ ma
 
 func TestUnitPostQueryHelperError(t *testing.T) {
 	sr := &snowflakeRestful{
-		Token:    "token",
+		TokenAccessor: getSimpleTokenAccessor(),
 		FuncPost: postTestError,
 	}
 	var err error
@@ -140,7 +140,7 @@ func TestUnitPostQueryHelperRenewSession(t *testing.T) {
 		}, nil
 	}
 	sr := &snowflakeRestful{
-		Token:            "token",
+		TokenAccessor: getSimpleTokenAccessor(),
 		FuncPost:         postTestRenew,
 		FuncPostQuery:    postQueryTest,
 		FuncRenewSession: renewSessionTest,
@@ -159,8 +159,7 @@ func TestUnitPostQueryHelperRenewSession(t *testing.T) {
 
 func TestUnitRenewRestfulSession(t *testing.T) {
 	sr := &snowflakeRestful{
-		MasterToken: "mtoken",
-		Token:       "token",
+		TokenAccessor: getSimpleTokenAccessor(),
 		FuncPost:    postTestAfterRenew,
 	}
 	err := renewRestfulSession(context.Background(), sr, time.Second)

--- a/restful_test.go
+++ b/restful_test.go
@@ -130,7 +130,7 @@ func TestUnitPostQueryHelperUsesToken(t *testing.T) {
 	accessor.SetTokens(token, "", 0)
 
 	var err error
-	postQueryTest := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ string) (*execResponse, error) {
+	postQueryTest := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ uuid.UUID, _ *Config) (*execResponse, error) {
 		if headers[headerAuthorizationKey] != fmt.Sprintf(headerSnowflakeToken, token) {
 			t.Fatalf("authorization key doesn't match, %v vs %v", headers[headerAuthorizationKey], fmt.Sprintf(headerSnowflakeToken, token))
 		}
@@ -148,7 +148,7 @@ func TestUnitPostQueryHelperUsesToken(t *testing.T) {
 		FuncRenewSession: renewSessionTest,
 		TokenAccessor:    accessor,
 	}
-	_, err = postRestfulQueryHelper(context.Background(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, "")
+	_, err = postRestfulQueryHelper(context.Background(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, uuid.New(), &Config{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/util.go
+++ b/util.go
@@ -109,19 +109,19 @@ type TokenAccessor interface {
 type simpleTokenAccessor struct {
 	token       string
 	masterToken string
-	sessionId   int
+	sessionID   int
 }
 
 func getSimpleTokenAccessor() TokenAccessor {
-	return &simpleTokenAccessor{sessionId: -1}
+	return &simpleTokenAccessor{sessionID: -1}
 }
 
 func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionId int) {
-	return sta.token, sta.masterToken, sta.sessionId
+	return sta.token, sta.masterToken, sta.sessionID
 }
 
 func (sta *simpleTokenAccessor) SetTokens(token string, masterToken string, sessionId int) {
 	sta.token = token
 	sta.masterToken = masterToken
-	sta.sessionId = sessionId
+	sta.sessionID = sessionId
 }

--- a/util.go
+++ b/util.go
@@ -102,8 +102,8 @@ func toNamedValues(values []driver.Value) []driver.NamedValue {
 
 // TokenAccessor manages the session token and master token
 type TokenAccessor interface {
-	GetTokens() (token string, masterToken string, sessionId int)
-	SetTokens(token string, masterToken string, sessionId int)
+	GetTokens() (token string, masterToken string, sessionID int)
+	SetTokens(token string, masterToken string, sessionID int)
 }
 
 type simpleTokenAccessor struct {
@@ -116,12 +116,12 @@ func getSimpleTokenAccessor() TokenAccessor {
 	return &simpleTokenAccessor{sessionID: -1}
 }
 
-func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionId int) {
+func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionID int) {
 	return sta.token, sta.masterToken, sta.sessionID
 }
 
-func (sta *simpleTokenAccessor) SetTokens(token string, masterToken string, sessionId int) {
+func (sta *simpleTokenAccessor) SetTokens(token string, masterToken string, sessionID int) {
 	sta.token = token
 	sta.masterToken = masterToken
-	sta.sessionID = sessionId
+	sta.sessionID = sessionID
 }

--- a/util.go
+++ b/util.go
@@ -99,3 +99,28 @@ func toNamedValues(values []driver.Value) []driver.NamedValue {
 	}
 	return namedValues
 }
+
+type TokenAccessor interface {
+	GetTokens() (token string, masterToken string, sessionId int)
+	SetTokens(token string, masterToken string, sessionId int)
+}
+
+type simpleTokenAccessor struct {
+	token string
+	masterToken string
+	sessionId int
+}
+
+func getSimpleTokenAccessor() TokenAccessor {
+	return &simpleTokenAccessor{sessionId: -1}
+}
+
+func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionId int) {
+	return sta.token, sta.masterToken, sta.sessionId
+}
+
+func (sta *simpleTokenAccessor) SetTokens(token string, masterToken string, sessionId int) {
+	sta.token = token
+	sta.masterToken = masterToken
+	sta.sessionId = sessionId
+}

--- a/util.go
+++ b/util.go
@@ -107,9 +107,9 @@ type TokenAccessor interface {
 }
 
 type simpleTokenAccessor struct {
-	token string
+	token       string
 	masterToken string
-	sessionId int
+	sessionId   int
 }
 
 func getSimpleTokenAccessor() TokenAccessor {

--- a/util.go
+++ b/util.go
@@ -100,6 +100,7 @@ func toNamedValues(values []driver.Value) []driver.NamedValue {
 	return namedValues
 }
 
+// TokenAccessor manages the session token and master token
 type TokenAccessor interface {
 	GetTokens() (token string, masterToken string, sessionId int)
 	SetTokens(token string, masterToken string, sessionId int)

--- a/util_test.go
+++ b/util_test.go
@@ -17,6 +17,33 @@ type tcIntMinMax struct {
 	out int
 }
 
+func TestSimpleTokenAccessor(t *testing.T) {
+	accessor := getSimpleTokenAccessor()
+	token, masterToken, sessionId := accessor.GetTokens()
+	if token != "" {
+		t.Errorf("unexpected token %v", token)
+	}
+	if masterToken != "" {
+		t.Errorf("unexpected master token %v", masterToken)
+	}
+	if sessionId != -1 {
+		t.Errorf("unexpected session id %v", sessionId)
+	}
+
+	expectedToken, expectedMasterToken, expectedSessionId := "token123", "master123", 123
+	accessor.SetTokens(expectedToken, expectedMasterToken, expectedSessionId)
+	token, masterToken, sessionId = accessor.GetTokens()
+	if token != expectedToken {
+		t.Errorf("unexpected token %v", token)
+	}
+	if masterToken != expectedMasterToken {
+		t.Errorf("unexpected master token %v", masterToken)
+	}
+	if sessionId != expectedSessionId {
+		t.Errorf("unexpected session id %v", sessionId)
+	}
+}
+
 func TestGetRequestIDFromContext(t *testing.T) {
 	expectedRequestID := uuid.New()
 	ctx := WithRequestID(context.Background(), expectedRequestID)

--- a/util_test.go
+++ b/util_test.go
@@ -19,28 +19,28 @@ type tcIntMinMax struct {
 
 func TestSimpleTokenAccessor(t *testing.T) {
 	accessor := getSimpleTokenAccessor()
-	token, masterToken, sessionId := accessor.GetTokens()
+	token, masterToken, sessionID := accessor.GetTokens()
 	if token != "" {
 		t.Errorf("unexpected token %v", token)
 	}
 	if masterToken != "" {
 		t.Errorf("unexpected master token %v", masterToken)
 	}
-	if sessionId != -1 {
-		t.Errorf("unexpected session id %v", sessionId)
+	if sessionID != -1 {
+		t.Errorf("unexpected session id %v", sessionID)
 	}
 
-	expectedToken, expectedMasterToken, expectedSessionId := "token123", "master123", 123
-	accessor.SetTokens(expectedToken, expectedMasterToken, expectedSessionId)
-	token, masterToken, sessionId = accessor.GetTokens()
+	expectedToken, expectedMasterToken, expectedSessionID := "token123", "master123", 123
+	accessor.SetTokens(expectedToken, expectedMasterToken, expectedSessionID)
+	token, masterToken, sessionID = accessor.GetTokens()
 	if token != expectedToken {
 		t.Errorf("unexpected token %v", token)
 	}
 	if masterToken != expectedMasterToken {
 		t.Errorf("unexpected master token %v", masterToken)
 	}
-	if sessionId != expectedSessionId {
-		t.Errorf("unexpected session id %v", sessionId)
+	if sessionID != expectedSessionID {
+		t.Errorf("unexpected session id %v", sessionID)
 	}
 }
 


### PR DESCRIPTION
### Description
Introduce the concept of a token accessor interface that can be used to
manage the lifecycle of token & master token & session ID.

Currently, token, master token, and session ID are tied directly to `snowflakeRestful`.
Instead, allow a `TokenAccessor` to be defined in the `Config` and let the token accessor
manage setting, and retrieving the token to use when making REST calls.

Added new unit tests and updated existing tests to make sure queries carry
the token from the token accessor, and session renewals set the token back into the accessor.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
