### PR TITLE
SNOW-212952 Emit Query ID

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -644,7 +644,6 @@ func getAsync(
 		if resType == execResultType {
 			res.affectedRows, _ = updateRows(respd.Data)
 			res.insertID = -1
-			res.queryID = respd.Data.QueryID
 			res.errChannel <- nil // mark exec status complete
 		} else {
 			sc := &snowflakeConn{rest: sr}
@@ -669,7 +668,6 @@ func getAsync(
 					RowSetBase64: respd.Data.RowSetBase64,
 				},
 			}
-			rows.queryID = respd.Data.QueryID
 			rows.ChunkDownloader.start()
 			rows.errChannel <- nil // mark query status complete
 		}
@@ -690,6 +688,15 @@ func getAsync(
 			QueryID:  respd.Data.QueryID,
 		}
 	}
+}
+
+func getQueryIDChan(ctx context.Context) chan<- string {
+	v := ctx.Value(QueryIDChan)
+	if v == nil {
+		return nil
+	}
+	c, _ := v.(chan<- string)
+	return c
 }
 
 func populateChunkDownloader(ctx context.Context, sc *snowflakeConn, data execResponseData) *snowflakeChunkDownloader {

--- a/restful.go
+++ b/restful.go
@@ -201,6 +201,12 @@ func postRestfulQueryHelper(
 			return sr.FuncPostQuery(ctx, sr, params, headers, body, timeout, requestID)
 		}
 
+		if queryIDChan := getQueryIDChan(ctx); queryIDChan != nil {
+			queryIDChan <- respd.Data.QueryID
+			close(queryIDChan)
+			ctx = WithQueryIDChan(ctx, nil)
+		}
+
 		var resultURL string
 		isSessionRenewed := false
 		noResult, _ := isAsyncMode(ctx)

--- a/statement.go
+++ b/statement.go
@@ -14,6 +14,8 @@ const (
 	MultiStatementCount paramKey = "MULTI_STATEMENT_COUNT"
 	// AsyncMode tells the server to not block the request on executing the entire query
 	AsyncMode paramKey = "ASYNC_MODE_QUERY"
+	// QueryIDChan is the channel to receive the query ID from
+	QueryIDChan paramKey = "QUERY_ID_CHANNEL"
 )
 
 type snowflakeStmt struct {
@@ -61,4 +63,9 @@ func WithMultiStatement(ctx context.Context, num int) (context.Context, error) {
 // WithAsyncMode returns a context that allows execution of query in async mode
 func WithAsyncMode(ctx context.Context) (context.Context, error) {
 	return context.WithValue(ctx, AsyncMode, true), nil
+}
+
+// WithQueryIDChan returns a context that contains the channel to receive the query ID
+func WithQueryIDChan(ctx context.Context, c chan<- string) context.Context {
+	return context.WithValue(ctx, QueryIDChan, c)
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"io"
 	"testing"
 )
 
@@ -629,4 +630,66 @@ func retrieveRows(rows *sql.Rows, ch chan string) {
 	}
 	ch <- s
 	close(ch)
+}
+
+func TestEmitQueryID(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	if db, err = sql.Open("snowflake", dsn); err != nil {
+		t.Fatalf("failed to open db. %v, err: %v", dsn, err)
+	}
+	defer db.Close()
+
+	queryIDChan := make(chan string, 1)
+	numrows := 100000
+	ctx, _ := WithAsyncMode(context.Background())
+	ctx = WithQueryIDChan(ctx, queryIDChan)
+	conn, _ := db.Conn(ctx)
+
+	var queryID string
+	dest := make([]driver.Value, 2)
+
+	err = conn.Raw(func(x interface{}) error {
+		stmt, err := x.(driver.ConnPrepareContext).PrepareContext(ctx, fmt.Sprintf("SELECT SEQ8(), RANDSTR(1000, RANDOM()) FROM TABLE(GENERATOR(ROWCOUNT=>%v))", numrows))
+		if err != nil {
+			return err
+		}
+		rows, err := stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		if err != nil {
+			return err
+		}
+		if queryID = rows.(SnowflakeResult).GetQueryID(); queryID == "" {
+			// if query ID not available, wait using channel passed in
+			queryID = <-queryIDChan
+		}
+		if queryID == "" {
+			t.Fatal("expected a nonempty query ID")
+		}
+
+		cnt := 0
+		for {
+			err = rows.Next(dest)
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+			cnt++
+		}
+		if cnt != numrows {
+			t.Errorf("number of rows didn't match. expected: %v, got: %v", numrows, cnt)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to execute query. err: %v", err)
+	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -666,10 +666,6 @@ func TestEmitQueryID(t *testing.T) {
 		}
 		defer rows.Close()
 
-		if err != nil {
-			return err
-		}
-
 		cnt := 0
 		for {
 			err = rows.Next(dest)


### PR DESCRIPTION
### Description
Interface to capture query ID as soon as it's ready using a channel passed through a context.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
