### PR TITLE
feat: allow users to configure the logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -3,11 +3,12 @@ package gosnowflake
 import (
 	"context"
 	"fmt"
-	rlog "github.com/sirupsen/logrus"
 	"io"
 	"path"
 	"runtime"
 	"time"
+
+	rlog "github.com/sirupsen/logrus"
 )
 
 //SFSessionIDKey is context key of session id
@@ -52,14 +53,18 @@ func (log *defaultLogger) WithContext(ctx context.Context) *rlog.Entry {
 	return log.inner.WithFields(*fields)
 }
 
-//CreateDefaultLogger return a new instance of SFLogger with default config
+// CreateDefaultLogger return a new instance of SFLogger with default config
 func CreateDefaultLogger() SFLogger {
 	var rLogger = rlog.New()
 	var formatter = rlog.TextFormatter{CallerPrettyfier: SFCallerPrettyfier}
 	rLogger.SetReportCaller(true)
 	rLogger.SetFormatter(&formatter)
-	var ret = defaultLogger{inner: rLogger}
-	return &ret //(&ret).(*SFLogger)
+	return CreateLogger(rLogger)
+}
+
+// CreateLogger return a new instance of SFLogger with provided logrus Logger
+func CreateLogger(rLogger *rlog.Logger) SFLogger {
+	return &defaultLogger{inner: rLogger}
 }
 
 // WithField allocates a new entry and adds a field to it.


### PR DESCRIPTION
### Description
The default logger is using a configuration that might not suit every user. 

This MR adds the ability for users to use their own Logrus logger instead of the default one.

Example :
```go
mylogger := logrus.New()
mylogger.SetOutput(os.Stdout) // change output
mylogger.Add(mySentryHook) // add hooks
mylogger.SetFormatter(&logrus.JSONFormatter{}) // use json formatter

logger := sf.CreateLogger(mylogger)
sf.SetLogger(&logger)
```

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
