### PR TITLE
SNOW-273060: Added ability to set the transport timeout (ClientTimeout)

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -56,7 +56,7 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 		Protocol: sc.cfg.Protocol,
 		Client: &http.Client{
 			// request timeout including reading response body
-			Timeout:   defaultClientTimeout,
+			Timeout:   sc.cfg.ClientTimeout,
 			Transport: st,
 		},
 		LoginTimeout:        sc.cfg.LoginTimeout,

--- a/dsn.go
+++ b/dsn.go
@@ -63,6 +63,7 @@ type Config struct {
 	LoginTimeout     time.Duration // Login retry timeout EXCLUDING network roundtrip and read out http response
 	RequestTimeout   time.Duration // request retry timeout EXCLUDING network roundtrip and read out http response
 	JWTExpireTimeout time.Duration // JWT expire after timeout
+	ClientTimeout    time.Duration // Timeout for network round trip + read out http response
 
 	Application  string           // application name.
 	InsecureMode bool             // driver doesn't check certificate revocation status
@@ -393,6 +394,9 @@ func fillMissingConfigParameters(cfg *Config) error {
 	}
 	if cfg.JWTExpireTimeout == 0 {
 		cfg.JWTExpireTimeout = defaultJWTTimeout
+	}
+	if cfg.ClientTimeout == 0 {
+		cfg.ClientTimeout = defaultClientTimeout
 	}
 	if strings.Trim(cfg.Application, " ") == "" {
 		cfg.Application = clientType


### PR DESCRIPTION
### Description
Gave the ability to set http Client timeout rather than hard coded default. Useful when you are using this library for testing a Snowflake deployment and know it should respond quickly and need it to fail fast in the case where the deployment is not ready (which is the case for Deployment Automation)

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
