### PR TITLE
SNOW-274063 QueryRowContext hangs on bad request

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -195,7 +195,7 @@ func postAuth(
 	body []byte,
 	timeout time.Duration) (
 	data *authResponse, err error) {
-	params.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx))
+	params.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx).String())
 	params.Add(requestGUIDKey, uuid.New().String())
 
 	fullURL := sr.getFullURL(loginRequestPath, params)

--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,9 @@ package gosnowflake
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -16,10 +19,6 @@ import (
 
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/google/uuid"
-
-	"crypto/sha256"
-	"crypto/x509"
-	"encoding/base64"
 )
 
 const (

--- a/auth_test.go
+++ b/auth_test.go
@@ -9,10 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/form3tech-oss/jwt-go"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/form3tech-oss/jwt-go"
 )
 
 func TestUnitPostAuth(t *testing.T) {

--- a/authokta.go
+++ b/authokta.go
@@ -205,7 +205,7 @@ func postAuthSAML(
 	data *authResponse, err error) {
 
 	params := &url.Values{}
-	params.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx))
+	params.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx).String())
 	fullURL := sr.getFullURL(authenticatorRequestPath, params)
 
 	logger.Infof("fullURL: %v", fullURL)

--- a/connection.go
+++ b/connection.go
@@ -560,7 +560,7 @@ func (sc *snowflakeConn) getQueryResult(ctx context.Context, resultPath string) 
 		headers["X-Snowflake-Service"] = *serviceName
 	}
 	param := make(url.Values)
-	param.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx))
+	param.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx).String())
 	param.Add("clientStartTime", strconv.FormatInt(time.Now().Unix(), 10))
 	param.Add(requestGUIDKey, uuid.New().String())
 	if sc.rest.Token != "" {

--- a/connection.go
+++ b/connection.go
@@ -8,13 +8,14 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,6 +2,7 @@ package gosnowflake
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"net/url"
 	"testing"
 	"time"
@@ -33,8 +34,8 @@ func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, header
 }
 
 func TestExecWithEmptyRequestID(t *testing.T) {
-	ctx := WithRequestID(context.Background(), "")
-	postQueryMock := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID string) (*execResponse, error) {
+	ctx := WithRequestID(context.Background(), uuid.Nil)
+	postQueryMock := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID uuid.UUID) (*execResponse, error) {
 		// ensure the same requestID from context is used
 		if len(requestID) == 0 {
 			t.Fatal("requestID is empty")
@@ -63,9 +64,9 @@ func TestExecWithEmptyRequestID(t *testing.T) {
 }
 
 func TestExecWithSpecificRequestID(t *testing.T) {
-	origRequestID := "specific-snowflake-request-id"
+	origRequestID := uuid.New()
 	ctx := WithRequestID(context.Background(), origRequestID)
-	postQueryMock := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID string) (*execResponse, error) {
+	postQueryMock := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID uuid.UUID) (*execResponse, error) {
 		// ensure the same requestID from context is used
 		if requestID != origRequestID {
 			t.Fatal("requestID doesn't match")

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,10 +2,11 @@ package gosnowflake
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const serviceNameStub = "SV"

--- a/connection_test.go
+++ b/connection_test.go
@@ -14,7 +14,7 @@ const serviceNameAppend = "a"
 // postQueryMock would generate a response based on the X-Snowflake-Service header, to generate a response
 // with the SERVICE_NAME field appending a character at the end of the header
 // This way it could test both the send and receive logic
-func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ string) (*execResponse, error) {
+func postQueryMock(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ uuid.UUID) (*execResponse, error) {
 	var serviceName string
 	if serviceHeader, ok := headers["X-Snowflake-Service"]; ok {
 		serviceName = serviceHeader + serviceNameAppend

--- a/doc.go
+++ b/doc.go
@@ -158,7 +158,8 @@ Query request ID
 Specific query request ID can be set in the context and will be passed through
 in place of the default randomized request ID. For example:
 
-	ctxWithID := WithRequestID(ctx, "app-request-id-...")
+	requestID := uuid.MustParse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	ctxWithID := WithRequestID(ctx, requestID)
 	rows, err := db.QueryContext(ctxWithID, query)
 
 Canceling Query by CtrlC

--- a/driver_test.go
+++ b/driver_test.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	"github.com/google/uuid"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -20,6 +19,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 var (

--- a/driver_test.go
+++ b/driver_test.go
@@ -414,6 +414,23 @@ func TestEmptyQuery(t *testing.T) {
 	})
 }
 
+func TestEmptyQueryWithRequestID(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		query := "select 1"
+		ctx := WithRequestID(context.Background(), "96305d47")
+		rows := dbt.db.QueryRowContext(ctx, query)
+		if rows.Err() == nil {
+			dbt.Errorf("should have failed due to malformed request id")
+		}
+
+		ctx = WithRequestID(context.Background(), "96305d47-6797-4103-8a9f-d0ca46cd062d")
+		rows = dbt.db.QueryRowContext(ctx, query)
+		if rows.Err() != nil {
+			dbt.Errorf("should not have failed with valid request id. err: %v", rows.Err())
+		}
+	})
+}
+
 func TestCRUD(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		// Create Table

--- a/driver_test.go
+++ b/driver_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"github.com/google/uuid"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -417,16 +418,12 @@ func TestEmptyQuery(t *testing.T) {
 func TestEmptyQueryWithRequestID(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		query := "select 1"
-		ctx := WithRequestID(context.Background(), "96305d47")
+		ctx := WithRequestID(context.Background(), uuid.New())
 		rows := dbt.db.QueryRowContext(ctx, query)
-		if rows.Err() == nil {
-			dbt.Errorf("should have failed due to malformed request id")
-		}
-
-		ctx = WithRequestID(context.Background(), "96305d47-6797-4103-8a9f-d0ca46cd062d")
-		rows = dbt.db.QueryRowContext(ctx, query)
-		if rows.Err() != nil {
-			dbt.Errorf("should not have failed with valid request id. err: %v", rows.Err())
+		var v1 interface{}
+		err := rows.Scan(&v1)
+		if err != nil {
+			dbt.Errorf("should not have failed with valid request id. err: %v", err)
 		}
 	})
 }

--- a/restful.go
+++ b/restful.go
@@ -178,7 +178,7 @@ func postRestfulQueryHelper(
 
 	var resp *http.Response
 	fullURL := sr.getFullURL(queryRequestPath, params)
-	resp, err = sr.FuncPost(ctx, sr, fullURL, headers, body, timeout, false)
+	resp, err = sr.FuncPost(ctx, sr, fullURL, headers, body, timeout, true)
 
 	if err != nil {
 		return nil, err

--- a/restful_test.go
+++ b/restful_test.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/google/uuid"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func postTestError(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {

--- a/restful_test.go
+++ b/restful_test.go
@@ -93,20 +93,20 @@ func TestUnitPostQueryHelperError(t *testing.T) {
 		FuncPost: postTestError,
 	}
 	var err error
-	var requestID string
-	requestID = uuid.New().String()
+	var requestID uuid.UUID
+	requestID = uuid.New()
 	_, err = postRestfulQueryHelper(context.Background(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, requestID)
 	if err == nil {
 		t.Fatalf("should have failed to post")
 	}
 	sr.FuncPost = postTestAppBadGatewayError
-	requestID = uuid.New().String()
+	requestID = uuid.New()
 	_, err = postRestfulQueryHelper(context.Background(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, requestID)
 	if err == nil {
 		t.Fatalf("should have failed to post")
 	}
 	sr.FuncPost = postTestSuccessButInvalidJSON
-	requestID = uuid.New().String()
+	requestID = uuid.New()
 	_, err = postRestfulQueryHelper(context.Background(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, requestID)
 	if err == nil {
 		t.Fatalf("should have failed to post")
@@ -123,8 +123,8 @@ func renewSessionTestError(_ context.Context, _ *snowflakeRestful, _ time.Durati
 
 func TestUnitPostQueryHelperRenewSession(t *testing.T) {
 	var err error
-	origRequestID := uuid.New().String()
-	postQueryTest := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID string) (*execResponse, error) {
+	origRequestID := uuid.New()
+	postQueryTest := func(_ context.Context, _ *snowflakeRestful, _ *url.Values, _ map[string]string, _ []byte, _ time.Duration, requestID uuid.UUID) (*execResponse, error) {
 		// ensure the same requestID is used after the session token is renewed.
 		if requestID != origRequestID {
 			t.Fatal("requestID doesn't match")

--- a/util.go
+++ b/util.go
@@ -5,8 +5,9 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type contextKey string
@@ -22,7 +23,7 @@ func WithRequestID(ctx context.Context, requestID uuid.UUID) context.Context {
 // Get the request ID from the context if specified, otherwise generate one
 func getOrGenerateRequestIDFromContext(ctx context.Context) uuid.UUID {
 	requestID, ok := ctx.Value(SnowflakeRequestIDKey).(uuid.UUID)
-	if ok  && requestID != uuid.Nil{
+	if ok && requestID != uuid.Nil {
 		return requestID
 	}
 	return uuid.New()

--- a/util.go
+++ b/util.go
@@ -15,17 +15,17 @@ type contextKey string
 const SnowflakeRequestIDKey contextKey = "SNOWFLAKE_REQUEST_ID"
 
 // WithRequestID returns a new context with the specified snowflake request id
-func WithRequestID(ctx context.Context, requestID string) context.Context {
+func WithRequestID(ctx context.Context, requestID uuid.UUID) context.Context {
 	return context.WithValue(ctx, SnowflakeRequestIDKey, requestID)
 }
 
 // Get the request ID from the context if specified, otherwise generate one
-func getOrGenerateRequestIDFromContext(ctx context.Context) string {
-	requestID, ok := ctx.Value(SnowflakeRequestIDKey).(string)
-	if ok && requestID != "" {
+func getOrGenerateRequestIDFromContext(ctx context.Context) uuid.UUID {
+	requestID, ok := ctx.Value(SnowflakeRequestIDKey).(uuid.UUID)
+	if ok  && requestID != uuid.Nil{
 		return requestID
 	}
-	return uuid.New().String()
+	return uuid.New()
 }
 
 // integer min

--- a/util_test.go
+++ b/util_test.go
@@ -5,6 +5,7 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
+	"github.com/google/uuid"
 	"testing"
 	"time"
 )
@@ -16,11 +17,16 @@ type tcIntMinMax struct {
 }
 
 func TestGetRequestIDFromContext(t *testing.T) {
-	expectedRequestID := "snowflake-request-id"
+	expectedRequestID := uuid.New()
 	ctx := WithRequestID(context.Background(), expectedRequestID)
 	requestID := getOrGenerateRequestIDFromContext(ctx)
 	if requestID != expectedRequestID {
-		t.Errorf("unexpected request id")
+		t.Errorf("unexpected request id: %v, expected: %v", requestID, expectedRequestID)
+	}
+	ctx = WithRequestID(context.Background(), uuid.Nil)
+	requestID = getOrGenerateRequestIDFromContext(ctx)
+	if requestID == uuid.Nil {
+		t.Errorf("unexpected request id, should not be nil")
 	}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -5,9 +5,10 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
-	"github.com/google/uuid"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type tcIntMinMax struct {


### PR DESCRIPTION

### Description
GS rest endpoint requires UUID in the V1 endpoint.
It will return a bad request if the request ID is not UUID.

On HTTP400, the http retry logic still kicks in and end up
causing a hang due to retrying a bad query.

To fix this, I'm proposing the following changes:
1. Make request ID always UUID type, and check against UUID.nil
2. postQueryHelper should not retry on 4xx error, any 4xx error should be bubbled up

Testing
Added new unit test

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
