### PR TITLE
SNOW-257769 Multi Column Result Sets

### DIFF
--- a/chunk_test.go
+++ b/chunk_test.go
@@ -183,7 +183,13 @@ func (f *mockStreamChunkFetcher) fetch(url string, stream chan<- []*string) erro
 func TestStreamChunkDownloaderFirstRows(t *testing.T) {
 	fetcher := &mockStreamChunkFetcher{}
 	firstRows := generateStreamChunkRows(10, 4)
-	downloader := newStreamChunkDownloader(context.Background(), fetcher, int64(len(firstRows)), firstRows, []execResponseChunk{})
+	downloader := newStreamChunkDownloader(
+		context.Background(),
+		fetcher,
+		int64(len(firstRows)),
+		[]execResponseRowType{},
+		firstRows,
+		[]execResponseChunk{})
 	if err := downloader.start(); err != nil {
 		t.Fatalf("chunk download start failed. err: %v", err)
 	}
@@ -220,7 +226,13 @@ func TestStreamChunkDownloaderChunks(t *testing.T) {
 	chunks, responseChunks := generateStreamChunkDownloaderChunks([]string{"foo", "bar"}, 4, 4)
 	fetcher := &mockStreamChunkFetcher{chunks}
 	firstRows := generateStreamChunkRows(2, 4)
-	downloader := newStreamChunkDownloader(context.Background(), fetcher, int64(len(firstRows)), firstRows, responseChunks)
+	downloader := newStreamChunkDownloader(
+		context.Background(),
+		fetcher,
+		int64(len(firstRows)),
+		[]execResponseRowType{},
+		firstRows,
+		responseChunks)
 	if err := downloader.start(); err != nil {
 		t.Fatalf("chunk download start failed. err: %v", err)
 	}

--- a/connection.go
+++ b/connection.go
@@ -337,7 +337,6 @@ func (sc *snowflakeConn) QueryContext(ctx context.Context, query string, args []
 
 	rows := new(snowflakeRows)
 	rows.sc = sc
-	rows.RowType = data.Data.RowType
 	rows.ChunkDownloader = populateChunkDownloader(ctx, sc, data.Data)
 	rows.queryID = sc.QueryID
 
@@ -683,7 +682,6 @@ func getAsync(
 			res.errChannel <- nil // mark exec status complete
 		} else {
 			rows.sc = sc
-			rows.RowType = respd.Data.RowType
 			rows.ChunkDownloader = populateChunkDownloader(ctx, sc, respd.Data)
 			rows.queryID = respd.Data.QueryID
 			if sc.isMultiStmt(respd.Data) {
@@ -736,7 +734,7 @@ func populateChunkDownloader(ctx context.Context, sc *snowflakeConn, data execRe
 			headers:  data.ChunkHeaders,
 			qrmk:     data.Qrmk,
 		}
-		return newStreamChunkDownloader(ctx, fetcher, data.Total, data.RowSet, data.Chunks)
+		return newStreamChunkDownloader(ctx, fetcher, data.Total, data.RowType, data.RowSet, data.Chunks)
 	}
 
 	return &snowflakeChunkDownloader{

--- a/rows_test.go
+++ b/rows_test.go
@@ -33,7 +33,6 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 	cm := []execResponseChunk{}
 	rows := new(snowflakeRows)
 	rows.sc = nil
-	rows.RowType = rt
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:                 nil,
 		ctx:                context.Background(),
@@ -43,10 +42,9 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 		Qrmk:               "",
 		FuncDownload:       nil,
 		FuncDownloadHelper: nil,
-		RowSet:             rowSetType{JSON: cc},
+		RowSet:             rowSetType{RowType: rt, JSON: cc},
 	}
 	rows.ChunkDownloader.start()
-	// var dest []driver.Value
 	dest := make([]driver.Value, 2)
 	for i = 0; i < len(cc); i++ {
 		err := rows.Next(dest)
@@ -105,7 +103,6 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 	}
 	rows := new(snowflakeRows)
 	rows.sc = nil
-	rows.RowType = rt
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:            nil,
 		ctx:           context.Background(),
@@ -114,7 +111,7 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 		TotalRowIndex: int64(-1),
 		Qrmk:          "HAHAHA",
 		FuncDownload:  downloadChunkTest,
-		RowSet:        rowSetType{JSON: cc},
+		RowSet:        rowSetType{RowType: rt, JSON: cc},
 	}
 	rows.ChunkDownloader.start()
 	cnt := 0
@@ -128,7 +125,6 @@ func TestRowsWithChunkDownloader(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get value. err: %v", err)
 		}
-		// fmt.Printf("data: %v\n", dest)
 		cnt++
 	}
 	if cnt != len(cc)+numChunks*rowsInChunk {
@@ -186,7 +182,6 @@ func TestRowsWithChunkDownloaderError(t *testing.T) {
 	}
 	rows := new(snowflakeRows)
 	rows.sc = nil
-	rows.RowType = rt
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:            nil,
 		ctx:           context.Background(),
@@ -195,7 +190,7 @@ func TestRowsWithChunkDownloaderError(t *testing.T) {
 		TotalRowIndex: int64(-1),
 		Qrmk:          "HOHOHO",
 		FuncDownload:  downloadChunkTestError,
-		RowSet:        rowSetType{JSON: cc},
+		RowSet:        rowSetType{RowType: rt, JSON: cc},
 	}
 	rows.ChunkDownloader.start()
 	cnt := 0
@@ -265,7 +260,6 @@ func TestRowsWithChunkDownloaderErrorFail(t *testing.T) {
 	}
 	rows := new(snowflakeRows)
 	rows.sc = nil
-	rows.RowType = rt
 	rows.ChunkDownloader = &snowflakeChunkDownloader{
 		sc:            nil,
 		ctx:           context.Background(),
@@ -274,7 +268,7 @@ func TestRowsWithChunkDownloaderErrorFail(t *testing.T) {
 		TotalRowIndex: int64(-1),
 		Qrmk:          "HOHOHO",
 		FuncDownload:  downloadChunkTestErrorFail,
-		RowSet:        rowSetType{JSON: cc},
+		RowSet:        rowSetType{RowType: rt, JSON: cc},
 	}
 	rows.ChunkDownloader.start()
 	cnt := 0
@@ -290,7 +284,6 @@ func TestRowsWithChunkDownloaderErrorFail(t *testing.T) {
 				"failure was expected by the number of rows is wrong. expected: %v, got: %v", 715, cnt)
 			break
 		}
-		// fmt.Printf("data: %v\n", dest)
 		cnt++
 	}
 }


### PR DESCRIPTION
### Description
Add support for processing multi-column result sets by modifying the RowType per chunk downloader, necessary for multi-statement executions/queries.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
