### PR TITLE
SNOW-294398: Change queryContext() to the correct case: QueryContext.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -544,13 +544,13 @@ asynchronous mode and synchronous mode.
 		...
 	}
 
-The function db.queryContext() returns an object of type snowflakeRows
+The function db.QueryContext() returns an object of type snowflakeRows
 regardless of whether the query is synchronous or asynchronous. However:
 
-	* If the query is synchronous, then db.queryContext() does not return until
+	* If the query is synchronous, then db.QueryContext() does not return until
 		the query has finished and the result set has been loaded into the
 		snowflakeRows object.
-	* If the query is asynchronous, then db.queryContext() returns a
+	* If the query is asynchronous, then db.QueryContext() returns a
 		potentially incomplete snowflakeRows object that is filled in later
 		in the background.
 


### PR DESCRIPTION
SNOW-294398

### Description

I noticed that I was inconsistent about using upper-case vs. lower-case for the queryContext function. I *think* it's supposed to be InitCap ("QueryContext"), so that's what I changed it to. If that's wrong, please let me know and I'll re-do the fix.

Thank you. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
