### PR TITLE
SNOW-291628 Synchronize the session renewal when token expires

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -78,7 +78,7 @@ func (hc *heartbeat) heartbeatMain() error {
 			return err
 		}
 		if respd.Code == sessionExpiredCode {
-			err = hc.restful.FuncRenewSession(context.TODO(), hc.restful, timeout)
+			err = hc.restful.renewExpiredSessionToken(context.Background(), timeout, token)
 			if err != nil {
 				return err
 			}

--- a/restful_test.go
+++ b/restful_test.go
@@ -222,11 +222,17 @@ func TestUnitTokenAccessorRenewBlocked(t *testing.T) {
 	if renewSessionCalled {
 		t.Fail()
 	}
+
+	// rotate the token again so that the session token is considered stale
+	accessor.SetTokens("new-token", "m", 321)
+
 	// unlock so that renew can happen
 	accessor.Unlock()
 	renewalDone.Wait()
-	// should have done renewing
-	if !renewSessionCalled {
+
+	// renewal should be done but token should still not
+	// have been renewed since we intentionally swapped token while locked
+	if renewSessionCalled {
 		t.Fail()
 	}
 

--- a/util.go
+++ b/util.go
@@ -120,7 +120,7 @@ type TokenAccessor interface {
 	GetTokens() (token string, masterToken string, sessionID int)
 	SetTokens(token string, masterToken string, sessionID int)
 	Lock() error
-	Unlock() error
+	Unlock()
 }
 
 type simpleTokenAccessor struct {
@@ -140,9 +140,8 @@ func (sta *simpleTokenAccessor) Lock() error {
 	return nil
 }
 
-func (sta *simpleTokenAccessor) Unlock() error {
+func (sta *simpleTokenAccessor) Unlock() {
 	sta.accessorLock.Unlock()
-	return nil
 }
 
 func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionID int) {


### PR DESCRIPTION
### Description
When a request comes back as session expired, we issue a
session renewal and rotate the token in the token accessor.

Multiple requests can hit the same session expired error at
the same time, and trigger multiple renewals of the same stale token.

Use a mutex to synchronize the token renewal, and only issue
one renewal for the stale token.

Testing

New tests with multiple goroutines added to verify concurrency.



### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
