### PR TITLE
Mgilkey snow166520 golang and arrow 2021 05

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -26,8 +26,8 @@ Use the Open() function to create a database handle with connection parameters:
 
 The Go Snowflake Driver supports the following connection syntaxes (or data source name (DSN) formats):
 
-	* username[:password]@accountname/dbname/schemaname[?param1=value&...&paramN=valueN
-	* username[:password]@accountname/dbname[?param1=value&...&paramN=valueN
+	* username[:password]@accountname/dbname/schemaname[?param1=value&...&paramN=valueN]
+	* username[:password]@accountname/dbname[?param1=value&...&paramN=valueN]
 	* username[:password]@hostname:port/dbname/schemaname?account=<your_account>[&param1=value&...&paramN=valueN]
 
 where all parameters must be escaped or use Config and DSN to construct a DSN string.


### PR DESCRIPTION
### Description
Please explain the changes you made here.

SNOW-166520: Add documentation about support for the Arrow data format, including an expanded data conversion table.

Also fixed a few other minor things that I saw. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
