### PR TITLE
SNOW-354479 Change Session ID to int64

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -176,7 +176,7 @@ type authResponseMain struct {
 	RemMeValidity       time.Duration           `json:"remMeValidityInSeconds"`
 	HealthCheckInterval time.Duration           `json:"healthCheckInterval"`
 	NewClientForUpgrade string                  `json:"newClientForUpgrade"`
-	SessionID           int                     `json:"sessionId"`
+	SessionID           int64                   `json:"sessionId"`
 	Parameters          []nameValueParameter    `json:"parameters"`
 	SessionInfo         authResponseSessionInfo `json:"sessionInfo"`
 	TokenURL            string                  `json:"tokenUrl,omitempty"`

--- a/auth_test.go
+++ b/auth_test.go
@@ -252,7 +252,7 @@ func getDefaultSnowflakeConn() *snowflakeConn {
 }
 
 func TestUnitAuthenticateWithTokenAccessor(t *testing.T) {
-	expectedSessionID := 123
+	expectedSessionID := int64(123)
 	expectedMasterToken := "master_token"
 	expectedToken := "auth_token"
 

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -424,4 +424,3 @@ func TestPutOverwrite(t *testing.T) {
 		}
 	})
 }
-

--- a/restful.go
+++ b/restful.go
@@ -121,7 +121,7 @@ type renewSessionResponseMain struct {
 	ValidityInSecondsST time.Duration `json:"validityInSecondsST"`
 	MasterToken         string        `json:"masterToken"`
 	ValidityInSecondsMT time.Duration `json:"validityInSecondsMT"`
-	SessionID           int           `json:"sessionId"`
+	SessionID           int64         `json:"sessionId"`
 }
 
 type cancelQueryResponse struct {

--- a/restful_test.go
+++ b/restful_test.go
@@ -176,11 +176,11 @@ func (wa *wrappedAccessor) Unlock() {
 	wa.ta.Unlock()
 }
 
-func (wa *wrappedAccessor) GetTokens() (token string, masterToken string, sessionID int) {
+func (wa *wrappedAccessor) GetTokens() (token string, masterToken string, sessionID int64) {
 	return wa.ta.GetTokens()
 }
 
-func (wa *wrappedAccessor) SetTokens(token string, masterToken string, sessionID int) {
+func (wa *wrappedAccessor) SetTokens(token string, masterToken string, sessionID int64) {
 	wa.ta.SetTokens(token, masterToken, sessionID)
 }
 
@@ -254,7 +254,7 @@ func TestUnitTokenAccessorRenewSessionContention(t *testing.T) {
 
 	expectedToken := "new token"
 	expectedMaster := "new master"
-	expectedSession := 321
+	expectedSession := int64(321)
 
 	renewSessionDummy := func(_ context.Context, sr *snowflakeRestful, _ time.Duration) error {
 		accessor.SetTokens(expectedToken, expectedMaster, expectedSession)
@@ -376,8 +376,8 @@ func TestUnitPostQueryHelperRenewSession(t *testing.T) {
 
 func TestUnitRenewRestfulSession(t *testing.T) {
 	accessor := getSimpleTokenAccessor()
-	oldToken, oldMasterToken, oldSessionID := "oldtoken", "oldmaster", 100
-	newToken, newMasterToken, newSessionID := "newtoken", "newmaster", 200
+	oldToken, oldMasterToken, oldSessionID := "oldtoken", "oldmaster", int64(100)
+	newToken, newMasterToken, newSessionID := "newtoken", "newmaster", int64(200)
 	postTestSuccessWithNewTokens := func(_ context.Context, _ *snowflakeRestful, _ *url.URL, headers map[string]string, _ []byte, _ time.Duration, _ bool) (*http.Response, error) {
 		if headers[headerAuthorizationKey] != fmt.Sprintf(headerSnowflakeToken, oldMasterToken) {
 			t.Fatalf("authorization key doesn't match, %v vs %v", headers[headerAuthorizationKey], fmt.Sprintf(headerSnowflakeToken, oldMasterToken))

--- a/util.go
+++ b/util.go
@@ -140,8 +140,8 @@ func toNamedValues(values []driver.Value) []driver.NamedValue {
 
 // TokenAccessor manages the session token and master token
 type TokenAccessor interface {
-	GetTokens() (token string, masterToken string, sessionID int)
-	SetTokens(token string, masterToken string, sessionID int)
+	GetTokens() (token string, masterToken string, sessionID int64)
+	SetTokens(token string, masterToken string, sessionID int64)
 	Lock() error
 	Unlock()
 }
@@ -149,7 +149,7 @@ type TokenAccessor interface {
 type simpleTokenAccessor struct {
 	token        string
 	masterToken  string
-	sessionID    int
+	sessionID    int64
 	accessorLock sync.Mutex   // Used to implement accessor's Lock and Unlock
 	tokenLock    sync.RWMutex // Used to synchronize SetTokens and GetTokens
 }
@@ -167,13 +167,13 @@ func (sta *simpleTokenAccessor) Unlock() {
 	sta.accessorLock.Unlock()
 }
 
-func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionID int) {
+func (sta *simpleTokenAccessor) GetTokens() (token string, masterToken string, sessionID int64) {
 	sta.tokenLock.RLock()
 	defer sta.tokenLock.RUnlock()
 	return sta.token, sta.masterToken, sta.sessionID
 }
 
-func (sta *simpleTokenAccessor) SetTokens(token string, masterToken string, sessionID int) {
+func (sta *simpleTokenAccessor) SetTokens(token string, masterToken string, sessionID int64) {
 	sta.tokenLock.Lock()
 	defer sta.tokenLock.Unlock()
 	sta.token = token

--- a/util_test.go
+++ b/util_test.go
@@ -33,7 +33,7 @@ func TestSimpleTokenAccessor(t *testing.T) {
 		t.Errorf("unexpected session id %v", sessionID)
 	}
 
-	expectedToken, expectedMasterToken, expectedSessionID := "token123", "master123", 123
+	expectedToken, expectedMasterToken, expectedSessionID := "token123", "master123", int64(123)
 	accessor.SetTokens(expectedToken, expectedMasterToken, expectedSessionID)
 	token, masterToken, sessionID = accessor.GetTokens()
 	if token != expectedToken {
@@ -55,13 +55,13 @@ func TestSimpleTokenAccessorGetTokensSynchronization(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			// set a random session and token
-			session := rand.Int()
-			sessionStr := strconv.Itoa(session)
+			session := rand.Int63()
+			sessionStr := strconv.FormatInt(session, 10)
 			accessor.SetTokens("t"+sessionStr, "m"+sessionStr, session)
 
 			// read back session and token and verify that invariant still holds
 			token, masterToken, session := accessor.GetTokens()
-			sessionStr = strconv.Itoa(session)
+			sessionStr = strconv.FormatInt(session, 10)
 			if "t"+sessionStr != token || "m"+sessionStr != masterToken {
 				failed = true
 			}


### PR DESCRIPTION
### Description
Change session ID to int64 type for 32-bit systems

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
