### PR TITLE
Support Describe Only

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -242,7 +242,7 @@ Note: SQL NULL values are converted to Golang nil values, and vice-versa.
 Preview Feature: Support for Arrow Data Format
 
 This feature is in preview. Snowflake recommends using this feature only in development systems, not production systems.
-This preview is available to all customers. 
+This preview is available to all customers.
 
 The Go Snowflake Driver now supports the Arrow data format for data transfers between Snowflake and the Golang client. The Arrow data format
 avoids extra conversions between binary and textual representations of the data. The Arrow data format can improve performance and reduce
@@ -273,7 +273,7 @@ This parameter can be set only at the session level.
 
 Usage notes:
 
-- The Arrow data format can reduce rounding errors in floating point numbers. 
+- The Arrow data format can reduce rounding errors in floating point numbers.
   You might see slightly different values for floating point numbers when using Arrow format than when using JSON format.
 
 - For some numeric data types, the driver can retrieve larger values when using the Arrow format than when using the

--- a/restful.go
+++ b/restful.go
@@ -232,7 +232,7 @@ func postRestfulQueryHelper(
 
 		var resultURL string
 		isSessionRenewed := false
-		noResult, _ := isAsyncMode(ctx)
+		noResult := isAsyncMode(ctx)
 
 		// if asynchronous query in progress, kick off retrieval but return object
 		if respd.Code == queryInProgressAsyncCode && noResult {

--- a/statement_test.go
+++ b/statement_test.go
@@ -142,3 +142,28 @@ func TestE2EFetchResultByID(t *testing.T) {
 		t.Fatalf("failed to drop table: %v", err)
 	}
 }
+
+func TestWithDescribeOnly(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		ctx := WithDescribeOnly(context.Background())
+		rows := dbt.mustQueryContext(
+			ctx,
+			"SELECT 1.0::NUMBER(30,2) as C1, 2::NUMBER(38,0) AS C2, 't3' AS C3, 4.2::DOUBLE AS C4, 'abcd'::BINARY AS C5, true AS C6")
+		cols, err := rows.Columns()
+		if err != nil {
+			t.Error(err)
+		}
+		types, err := rows.ColumnTypes()
+		if err != nil {
+			t.Error(err)
+		}
+		for i, col := range cols {
+			if types[i].Name() != col {
+				t.Fatalf("column name mismatch. expected: %v, got: %v", col, types[i].Name())
+			}
+		}
+		if rows.Next() {
+			t.Fatal("there should not be any rows in describe only mode")
+		}
+	})
+}

--- a/util.go
+++ b/util.go
@@ -33,6 +33,8 @@ const (
 	fileStreamFile contextKey = "STREAMING_PUT_FILE"
 	// fileTransferOptions allows the user to pass in custom
 	fileTransferOptions contextKey = "FILE_TRANSFER_OPTIONS"
+	// describeOnly returns the description of the query
+	describeOnly contextKey = "DESCRIBE_ONLY"
 )
 
 // WithMultiStatement returns a context that allows the user to execute the desired number of sql queries in one query
@@ -73,6 +75,11 @@ func WithFileStream(ctx context.Context, reader io.Reader) context.Context {
 // WithFileTransferOptions returns a context that contains the address of file transfer options
 func WithFileTransferOptions(ctx context.Context, options *SnowflakeFileTransferOptions) context.Context {
 	return context.WithValue(ctx, fileTransferOptions, options)
+}
+
+// WithDescribeOnly returns a context that enables a describe only query
+func WithDescribeOnly(ctx context.Context) context.Context {
+	return context.WithValue(ctx, describeOnly, true)
 }
 
 // Get the request ID from the context if specified, otherwise generate one


### PR DESCRIPTION
### Description
Support of describe only queries which fetch the column description without actually running the query.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
