### PR TITLE
Fetch and return monitoring data for slow queries

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -9,6 +9,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -371,6 +372,7 @@ func (sc *snowflakeConn) ExecContext(ctx context.Context, query string, args []d
 				Message:  err.Error(),
 				QueryID:  data.Data.QueryID}
 		}
+		return nil, err
 	}
 
 	// if async exec, return result object right away
@@ -479,7 +481,7 @@ func (sc *snowflakeConn) queryContextInternal(ctx context.Context, query string,
 	}
 
 	rows.ChunkDownloader.start()
-	return rows, nil
+	return rows, err
 }
 
 func (sc *snowflakeConn) Prepare(query string) (driver.Stmt, error) {

--- a/connection.go
+++ b/connection.go
@@ -60,7 +60,7 @@ const (
 )
 
 var (
-	// FetchQueryMonitoringDataThresholdMs specifies the ms threshold, over which we'll fetch the monitoring
+	// FetchQueryMonitoringDataThreshold specifies the threshold, over which we'll fetch the monitoring
 	// data for a Snowflake query. We use a time-based threshold, since there is a non-zero latency cost
 	// to fetch this data and we want to bound the additional latency. By default we bound to a 2% increase
 	// in latency - assuming worst case 100ms - when fetching this metadata.
@@ -220,9 +220,9 @@ func (sc *snowflakeConn) exec(
 	return data, err
 }
 
-func (sc *snowflakeConn) monitoring(qid string, runtimeSec time.Duration) (*QueryMonitoringData, error) {
+func (sc *snowflakeConn) monitoring(qid string, runtime time.Duration) (*QueryMonitoringData, error) {
 	// Exit early if this was a "fast" query
-	if runtimeSec < FetchQueryMonitoringDataThreshold {
+	if runtime < FetchQueryMonitoringDataThreshold {
 		return nil, nil
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"

--- a/query.go
+++ b/query.go
@@ -197,3 +197,33 @@ func sfqStatusIsStillRunning(status QueryStatusFromServer) bool {
 	_, exist := sfqueryStatusRunning[status]
 	return exist
 }
+
+type QueryMonitoringData struct {
+	Id                  string           `json:"id"`
+	Status              string           `json:"status"`
+	State               string           `json:"state"`
+	ClientSendTime      int64            `json:"clientSendTime"`
+	StartTime           int64            `json:"startTime"`
+	EndTime             int64            `json:"endTime"`
+	TotalDuration       int64            `json:"totalDuration"`
+	ClusterNumber       int              `json:"clusterNumber"`
+	WarehouseId         int              `json:"warehouseId"`
+	WarehouseName       string           `json:"warehouseName"`
+	WarehouseServerType string           `json:"warehouseServerType"`
+	QueryTag            string           `json:"queryTag"`
+	MajorVersionNumber  int              `json:"majorVersionNumber"`
+	MinorVersionNumber  int              `json:"minorVersionNumber"`
+	PatchVersionNumber  int              `json:"patchVersionNumber"`
+	Stats               map[string]int64 `json:"stats"`
+}
+
+type monitoringResponseData struct {
+	Queries []QueryMonitoringData `json:"queries"`
+}
+
+type monitoringResponse struct {
+	Data    monitoringResponseData `json:"data"`
+	Message string                 `json:"message"`
+	Code    string                 `json:"code"`
+	Success bool                   `json:"success"`
+}

--- a/query.go
+++ b/query.go
@@ -219,13 +219,11 @@ type QueryMonitoringData struct {
 	Stats               map[string]int64 `json:"stats"`
 }
 
-type monitoringResponseData struct {
-	Queries []QueryMonitoringData `json:"queries"`
-}
-
 type monitoringResponse struct {
-	Data    monitoringResponseData `json:"data"`
-	Message string                 `json:"message"`
-	Code    string                 `json:"code"`
-	Success bool                   `json:"success"`
+	Data struct {
+		Queries []QueryMonitoringData `json:"queries"`
+	} `json:"data"`
+	Message string `json:"message"`
+	Code    string `json:"code"`
+	Success bool   `json:"success"`
 }

--- a/query.go
+++ b/query.go
@@ -198,8 +198,10 @@ func sfqStatusIsStillRunning(status QueryStatusFromServer) bool {
 	return exist
 }
 
+// QueryMonitoringData is the struct returned by a request to /montitoring/queries/$qid
+// Contains metadata about a query run
 type QueryMonitoringData struct {
-	Id                  string           `json:"id"`
+	ID                  string           `json:"id"`
 	Status              string           `json:"status"`
 	State               string           `json:"state"`
 	ClientSendTime      int64            `json:"clientSendTime"`
@@ -207,7 +209,7 @@ type QueryMonitoringData struct {
 	EndTime             int64            `json:"endTime"`
 	TotalDuration       int64            `json:"totalDuration"`
 	ClusterNumber       int              `json:"clusterNumber"`
-	WarehouseId         int              `json:"warehouseId"`
+	WarehouseID         int              `json:"warehouseId"`
 	WarehouseName       string           `json:"warehouseName"`
 	WarehouseServerType string           `json:"warehouseServerType"`
 	QueryTag            string           `json:"queryTag"`

--- a/result.go
+++ b/result.go
@@ -21,6 +21,7 @@ const (
 type SnowflakeResult interface {
 	GetQueryID() string
 	GetStatus() queryStatus
+	Monitoring() *QueryMonitoringData
 }
 
 type snowflakeResult struct {
@@ -30,6 +31,7 @@ type snowflakeResult struct {
 	status       queryStatus
 	err          error
 	errChannel   chan error
+	monitoring   *QueryMonitoringData
 }
 
 func (res *snowflakeResult) LastInsertId() (int64, error) {
@@ -68,4 +70,8 @@ func (res *snowflakeResult) waitForAsyncExecStatus() error {
 		return res.err
 	}
 	return nil
+}
+
+func (res *snowflakeResult) Monitoring() *QueryMonitoringData {
+	return res.monitoring
 }

--- a/result.go
+++ b/result.go
@@ -19,9 +19,9 @@ const (
 
 // SnowflakeResult provides the associated query ID
 type SnowflakeResult interface {
+	GetMonitoring() *QueryMonitoringData
 	GetQueryID() string
 	GetStatus() queryStatus
-	Monitoring() *QueryMonitoringData
 }
 
 type snowflakeResult struct {
@@ -72,6 +72,6 @@ func (res *snowflakeResult) waitForAsyncExecStatus() error {
 	return nil
 }
 
-func (res *snowflakeResult) Monitoring() *QueryMonitoringData {
+func (res *snowflakeResult) GetMonitoring() *QueryMonitoringData {
 	return res.monitoring
 }

--- a/rows.go
+++ b/rows.go
@@ -35,6 +35,7 @@ type snowflakeRows struct {
 	status              queryStatus
 	err                 error
 	errChannel          chan error
+	monitoring          *QueryMonitoringData
 }
 
 type snowflakeValue interface{}
@@ -138,6 +139,10 @@ func (rows *snowflakeRows) ColumnTypeScanType(index int) reflect.Type {
 
 func (rows *snowflakeRows) GetQueryID() string {
 	return rows.queryID
+}
+
+func (rows *snowflakeRows) Monitoring() *QueryMonitoringData {
+	return rows.monitoring
 }
 
 func (rows *snowflakeRows) GetStatus() queryStatus {

--- a/rows.go
+++ b/rows.go
@@ -141,7 +141,7 @@ func (rows *snowflakeRows) GetQueryID() string {
 	return rows.queryID
 }
 
-func (rows *snowflakeRows) Monitoring() *QueryMonitoringData {
+func (rows *snowflakeRows) GetMonitoring() *QueryMonitoringData {
 	return rows.monitoring
 }
 

--- a/util.go
+++ b/util.go
@@ -35,6 +35,8 @@ const (
 	fileTransferOptions contextKey = "FILE_TRANSFER_OPTIONS"
 	// describeOnly returns the description of the query
 	describeOnly contextKey = "DESCRIBE_ONLY"
+	// monitoring collects monitoring data for the query
+	monitoring contextKey = "MONITORING"
 )
 
 // WithMultiStatement returns a context that allows the user to execute the desired number of sql queries in one query
@@ -80,6 +82,11 @@ func WithFileTransferOptions(ctx context.Context, options *SnowflakeFileTransfer
 // WithDescribeOnly returns a context that enables a describe only query
 func WithDescribeOnly(ctx context.Context) context.Context {
 	return context.WithValue(ctx, describeOnly, true)
+}
+
+// WithMonitoring returns a context that collects monitoring data on queries
+func WithMonitoring(ctx context.Context) context.Context {
+	return context.WithValue(ctx, monitoring, true)
 }
 
 // Get the request ID from the context if specified, otherwise generate one


### PR DESCRIPTION
### Description
Why: when a query is slow, we'd like to have additional information to help us analyze why (we could get this information via a separate request to the QUERY_HISTORY table, but we'd prefer to have it automatically)

This PR:
1. Adds new `monitoringResponse` and `QueryMonitoringData` types to represent the monitoring data we want to return
2. Adds a `monitoring` field and `Monitoring` public getter to `snowflakeResult` and `snowflakeRows` to expose this data
3. For all `ExecContext` and `QueryContext` calls, if the query takes longer than a fixed timeout to execute, fetch the monitoring data for the query and add it to the result

Open questions:
1. There's overlap between `monitoringResponse/QueryMonitoringData` and the existing types `statusResponse/retStatus`: both represent the result returned by a query to `/monitoring/queries/$qid`, but return different views on that data. How should we reconcile these types to avoid duplication?
2. Similarly, there's overlap between `connection.go:monitoring()` and the existing `connection.go:checkQueryStatus()`. How much do we want to reuse code between these two?
3. Currently, the "slow query" threshold is hardcoded at 5 seconds. How should we allow clients to configure this? Make it a `Context` property? (Once we decide on that, I'll add a test)

### Checklist
- [X] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
