### PR TITLE
SNOW-365333: Support for PUT is still in private preview, so I remove…

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -812,67 +812,10 @@ and before retrieving the results.
 	}
 
 
-Support For PUT (Preview Feature)
-
-This feature is in preview. Snowflake recommends using this feature only in
-development systems, not production systems. This preview is available to all
-customers.
-
-The Go Snowflake Driver supports the PUT command on AWS, Azure and GCP. The PUT
-command copies a file from the local computer (the computer on which the Golang
-client is running) to a stage on the cloud platform computer.
-
-The Go Snowflake Driver supports the same command parameters as are documented
-in the main PUT documentation at
-https://docs.snowflake.com/en/sql-reference/sql/put.html .
-
-The Go Snowflake Driver supports PUT commands to the following types of
-stages:
-
-	* A named internal stage.
-	* The table's stage.
-	* The user's default stage.
-
-To execute a PUT command in Golang, construct the command as a string and pass
-it to the db.Query() function. The syntax is:
-
-    db.Query("PUT file://<local_file> <stage_identifier> <optional_parameters>")
-
-For example:
-
-    db.Query("PUT file:///tmp/my_data_file @~ auto_compress=false overwrite=false")
-
-The "<local_file>" should include the file path as well as the name. Snowflake
-recommends using an absolute path rather than a relative path.
-
-Different client platforms (e.g. linux, Windows) have different path name
-conventions; make sure that you specify path names appropriately. This is
-particularly important on Windows, which uses the backslash character as
-both an escape character and as a separator in path names.
-
-If you wish to send information from a stream (rather than a file), then use
-code similar to the code below. (The ReplaceAll() function is needed on Windows
-to handle backslashes in the path to the file.)
-
-    fileStream, _ := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
-    defer func() {
-        if fileStream != nil {
-            fileStream.Close()
-        }
-    } ()
-
-    sql := "put 'file://%v' @%%%v auto_compress=true parallel=30"
-    sqlText := fmt.Sprintf(sql,
-                           strings.ReplaceAll(fname, "\\", "\\\\"),
-                           tableName)
-    dbt.mustExecContext(WithFileStream(context.Background(), fileStream),
-                        sqlText)
-
-
 Limitations
 
 	* GET operations are unsupported.
-	* PUT operations are unsupported. (PUT is available in preview mode)
+	* PUT operations are unsupported.
 
 */
 package gosnowflake


### PR DESCRIPTION
…d the PUT documentation from this file and moved it to a file in the LIMITEDACCESS (private preview) directory.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
