### PR TITLE
SNOW-342743 Cancellation Retry

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -29,6 +29,7 @@ const (
 	queryInProgressCode      = "333333"
 	queryInProgressAsyncCode = "333334"
 	sessionExpiredCode       = "390112"
+	queryNotExecuting        = "000605"
 )
 
 // Snowflake Server Endpoints
@@ -420,6 +421,15 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful, timeout time
 	}
 }
 
+func getCancelRetry(ctx context.Context) int {
+	val := ctx.Value(cancelRetry)
+	if val == nil {
+		return 5
+	}
+	cnt, _ := val.(int)
+	return cnt
+}
+
 func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID uuid.UUID, timeout time.Duration) error {
 	logger.WithContext(ctx).Info("cancel query")
 	params := &url.Values{}
@@ -452,12 +462,15 @@ func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID uuid.UUID,
 			logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 			return err
 		}
+		ctxRetry := getCancelRetry(ctx)
 		if !respd.Success && respd.Code == sessionExpiredCode {
 			err := sr.FuncRenewSession(ctx, sr, timeout)
 			if err != nil {
 				return err
 			}
 			return sr.FuncCancelQuery(ctx, sr, requestID, timeout)
+		} else if !respd.Success && respd.Code == queryNotExecuting && ctxRetry != 0 {
+			return sr.FuncCancelQuery(context.WithValue(ctx, cancelRetry, ctxRetry-1), sr, requestID, timeout)
 		} else if respd.Success {
 			return nil
 		} else {

--- a/util.go
+++ b/util.go
@@ -37,6 +37,10 @@ const (
 	describeOnly contextKey = "DESCRIBE_ONLY"
 )
 
+const (
+	cancelRetry contextKey = "CANCEL_RETRY"
+)
+
 // WithMultiStatement returns a context that allows the user to execute the desired number of sql queries in one query
 func WithMultiStatement(ctx context.Context, num int) (context.Context, error) {
 	return context.WithValue(ctx, multiStatementCount, num), nil


### PR DESCRIPTION
### Description
Enable retry for cancellation queries. Default value is 5

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
