### PR TITLE
SNOW-302103 Disable OCSP Cache Errors in Logs

### DIFF
--- a/chunk_test.go
+++ b/chunk_test.go
@@ -369,13 +369,13 @@ func TestWithStreamDownloader(t *testing.T) {
 	var v string
 
 	runTests(t, dsn, func(dbt *DBTest) {
+		dbt.mustExec(forceJSON)
 		rows := dbt.mustQueryContext(ctx, fmt.Sprintf(selectRandomGenerator, numrows))
 		defer rows.Close()
 
 		// Next() will block and wait until results are available
 		for rows.Next() {
-			err := rows.Scan(&idx, &v)
-			if err != nil {
+			if err := rows.Scan(&idx, &v); err != nil {
 				t.Fatal(err)
 			}
 			cnt++

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2021 Snowflake Computing Inc. All right reserved.
+
 package gosnowflake
 
 import (
@@ -9,12 +11,11 @@ import (
 func TestCtxVal(t *testing.T) {
 	type favContextKey string
 
-	f := func(ctx context.Context, k favContextKey) {
+	f := func(ctx context.Context, k favContextKey) error {
 		if v := ctx.Value(k); v != nil {
-			fmt.Println("found value:", v)
-			return
+			return nil
 		}
-		fmt.Println("key not found:", k)
+		return fmt.Errorf("key not found: %v", k)
 	}
 
 	k := favContextKey("language")
@@ -22,11 +23,19 @@ func TestCtxVal(t *testing.T) {
 
 	k2 := favContextKey("data")
 	ctx2 := context.WithValue(ctx, k2, "Snowflake")
-	f(ctx, k)
-	f(ctx, favContextKey("color"))
+	if err := f(ctx, k); err != nil {
+		t.Error(err)
+	}
+	if err := f(ctx, "color"); err == nil {
+		t.Error("should not have been found in context")
+	}
 
-	f(ctx2, k)
-	f(ctx2, k2)
+	if err := f(ctx2, k); err != nil {
+		t.Error(err)
+	}
+	if err := f(ctx2, k2); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestLogEntryCtx(t *testing.T) {
@@ -40,8 +49,4 @@ func TestLogEntryCtx(t *testing.T) {
 	l2 := log.WithFields(*fs2)
 	l1.Info("Hello 1")
 	l2.Warning("Hello 2")
-
-	//log.WithContext(ctx).Info("new log text 1")
-	//log.WithContext(ctx2).Info("new log text 2")
-
 }

--- a/doc.go
+++ b/doc.go
@@ -853,4 +853,3 @@ The Go Snowflake Driver has the following limitations:
 
 */
 package gosnowflake
-

--- a/driver_test.go
+++ b/driver_test.go
@@ -1340,8 +1340,8 @@ func TestTimestampLTZ(t *testing.T) {
 
 func testTimestampLTZ(t *testing.T, json bool) {
 	// Set session time zone in Los Angeles, same as machine
-	createDSN("America/Los_Angeles")
-	location, err := time.LoadLocation("America/Los_Angeles")
+	createDSN(PSTLocation)
+	location, err := time.LoadLocation(PSTLocation)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1943,7 +1943,7 @@ func TestTransactionOptions(t *testing.T) {
 }
 
 func TestTimezoneSessionParameter(t *testing.T) {
-	createDSN("America/Los_Angeles")
+	createDSN(PSTLocation)
 	db := openDB(t)
 	defer db.Close()
 
@@ -1960,8 +1960,8 @@ func TestTimezoneSessionParameter(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to run get timezone value. err: %v", err)
 	}
-	if p.Value != "America/Los_Angeles" {
-		t.Fatalf("failed to get an expected timezone. got: %v", p.Value)
+	if p.Value != PSTLocation {
+		t.Errorf("failed to get an expected timezone. got: %v", p.Value)
 	}
 	createDSN("UTC")
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 )
 
 const (
@@ -70,7 +71,7 @@ func (st *snowflakeTelemetry) sendBatch() error {
 	if token, _, _ := st.sr.TokenAccessor.GetTokens(); token != "" {
 		headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
 	}
-	resp, err := st.sr.FuncPost(context.Background(), st.sr, st.sr.getFullURL(telemetryPath, nil), headers, body, 5, true)
+	resp, err := st.sr.FuncPost(context.Background(), st.sr, st.sr.getFullURL(telemetryPath, nil), headers, body, 10*time.Second, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
Demoted OCSP cache errors to warnings to declutter logs.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
