### PR TITLE
Make snowflakeConn public to allow efficient async queries from lambda functions

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -263,7 +263,7 @@ func getHeaders() map[string]string {
 // Used to authenticate the user with Snowflake.
 func authenticate(
 	ctx context.Context,
-	sc *snowflakeConn,
+	sc *SnowflakeConn,
 	samlResponse []byte,
 	proofKey []byte,
 ) (resp *authResponseMain, err error) {
@@ -417,7 +417,7 @@ func prepareJWTToken(config *Config) (string, error) {
 }
 
 // Authenticate with sc.cfg
-func authenticateWithConfig(sc *snowflakeConn) error {
+func authenticateWithConfig(sc *SnowflakeConn) error {
 	var authData *authResponseMain
 	var samlResponse []byte
 	var proofKey []byte

--- a/auth_test.go
+++ b/auth_test.go
@@ -226,7 +226,7 @@ func postAuthCheckJWTToken(_ context.Context, _ *snowflakeRestful, _ *url.Values
 	}, nil
 }
 
-func getDefaultSnowflakeConn() *snowflakeConn {
+func getDefaultSnowflakeConn() *SnowflakeConn {
 	cfg := Config{
 		Account:            "a",
 		User:               "u",
@@ -244,7 +244,7 @@ func getDefaultSnowflakeConn() *snowflakeConn {
 	sr := &snowflakeRestful{
 		TokenAccessor: getSimpleTokenAccessor(),
 	}
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		rest: sr,
 		cfg:  &cfg,
 	}

--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -23,7 +23,7 @@ const (
 
 type bindUploader struct {
 	ctx            context.Context
-	sc             *snowflakeConn
+	sc             *SnowflakeConn
 	stagePath      string
 	fileCount      int
 	arrayBindStage string

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -36,7 +36,7 @@ type chunkDownloader interface {
 }
 
 type snowflakeChunkDownloader struct {
-	sc                 *snowflakeConn
+	sc                 *SnowflakeConn
 	ctx                context.Context
 	Total              int64
 	TotalRowIndex      int64

--- a/client_test.go
+++ b/client_test.go
@@ -39,7 +39,7 @@ func TestInternalClient(t *testing.T) {
 		t.Fatalf("failed to open with config. config: %v, err: %v", config, err)
 	}
 
-	internalClient := (db.(*snowflakeConn)).internal
+	internalClient := (db.(*SnowflakeConn)).internal
 	resp, err := internalClient.Get(context.Background(), &url.URL{}, make(map[string]string), 0)
 	if err != nil || resp.StatusCode != 200 {
 		t.Fail()

--- a/connection.go
+++ b/connection.go
@@ -59,6 +59,7 @@ const (
 	queryResultType     resultType = "query"
 )
 
+// SnowflakeConn implements sql.Conn interface
 type SnowflakeConn struct {
 	ctx             context.Context
 	cfg             *Config
@@ -213,10 +214,12 @@ func (sc *SnowflakeConn) exec(
 	return data, err
 }
 
+// Begin starts a transaction.
 func (sc *SnowflakeConn) Begin() (driver.Tx, error) {
 	return sc.BeginTx(sc.ctx, driver.TxOptions{})
 }
 
+// BeginTx starts a transaction.
 func (sc *SnowflakeConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
 	logger.WithContext(ctx).Info("BeginTx")
 	if opts.ReadOnly {
@@ -250,6 +253,7 @@ func (sc *SnowflakeConn) cleanup() {
 	sc.cfg = nil
 }
 
+// Close cleans up a connection.
 func (sc *SnowflakeConn) Close() (err error) {
 	logger.WithContext(sc.ctx).Infoln("Close")
 	sc.telemetry.sendBatch()
@@ -265,6 +269,7 @@ func (sc *SnowflakeConn) Close() (err error) {
 	return nil
 }
 
+// PrepareContext creates a prepared statement for later queries or executions.
 func (sc *SnowflakeConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
 	logger.WithContext(sc.ctx).Infoln("Prepare")
 	if sc.rest == nil {
@@ -294,6 +299,7 @@ func (sc *SnowflakeConn) PrepareContext(ctx context.Context, query string) (driv
 	return stmt, nil
 }
 
+// ExecContext executes a query without returning any rows.
 func (sc *SnowflakeConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	logger.WithContext(ctx).Infof("Exec: %#v, %v", query, args)
 	if sc.rest == nil {
@@ -344,6 +350,7 @@ func (sc *SnowflakeConn) ExecContext(ctx context.Context, query string, args []d
 	return driver.ResultNoRows, nil
 }
 
+// QueryContext executes a query that returns rows, typically a SELECT.
 func (sc *SnowflakeConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	qid, err := getResumeQueryID(ctx)
 	if err != nil {
@@ -413,10 +420,12 @@ func (sc *SnowflakeConn) queryContextInternal(ctx context.Context, query string,
 	return rows, err
 }
 
+// Prepare creates a prepared statement for later queries or executions.
 func (sc *SnowflakeConn) Prepare(query string) (driver.Stmt, error) {
 	return sc.PrepareContext(sc.ctx, query)
 }
 
+// Exec executes a query without returning any rows.
 func (sc *SnowflakeConn) Exec(
 	query string,
 	args []driver.Value) (
@@ -424,6 +433,7 @@ func (sc *SnowflakeConn) Exec(
 	return sc.ExecContext(sc.ctx, query, toNamedValues(args))
 }
 
+// Query executes a query that returns rows, typically a SELECT.
 func (sc *SnowflakeConn) Query(
 	query string,
 	args []driver.Value) (
@@ -431,6 +441,7 @@ func (sc *SnowflakeConn) Query(
 	return sc.QueryContext(sc.ctx, query, toNamedValues(args))
 }
 
+// Ping verifies the connection to the database is still alive.
 func (sc *SnowflakeConn) Ping(ctx context.Context) error {
 	logger.WithContext(ctx).Infoln("Ping")
 	if sc.rest == nil {

--- a/connection_test.go
+++ b/connection_test.go
@@ -64,7 +64,7 @@ func TestExecWithEmptyRequestID(t *testing.T) {
 		FuncPostQuery: postQueryMock,
 	}
 
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 	}
@@ -102,7 +102,7 @@ func TestGetQueryResultUsesTokenFromTokenAccessor(t *testing.T) {
 		FuncGet:       funcGetMock,
 		TokenAccessor: ta,
 	}
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 	}
@@ -133,7 +133,7 @@ func TestExecWithSpecificRequestID(t *testing.T) {
 		FuncPostQuery: postQueryMock,
 	}
 
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 	}
@@ -152,7 +152,7 @@ func TestServiceName(t *testing.T) {
 		FuncPostQuery: postQueryMock,
 	}
 
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 	}
@@ -189,7 +189,7 @@ func TestCloseIgnoreSessionGone(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncCloseSession: closeSessionMock,
 	}
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 		telemetry: testTelemetry,
@@ -204,7 +204,7 @@ func TestClientSessionPersist(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncCloseSession: closeSessionMock,
 	}
-	sc := &snowflakeConn{
+	sc := &SnowflakeConn{
 		cfg:  &Config{Params: map[string]*string{}},
 		rest: sr,
 		telemetry: testTelemetry,

--- a/connection_test.go
+++ b/connection_test.go
@@ -190,8 +190,8 @@ func TestCloseIgnoreSessionGone(t *testing.T) {
 		FuncCloseSession: closeSessionMock,
 	}
 	sc := &SnowflakeConn{
-		cfg:  &Config{Params: map[string]*string{}},
-		rest: sr,
+		cfg:       &Config{Params: map[string]*string{}},
+		rest:      sr,
 		telemetry: testTelemetry,
 	}
 
@@ -205,8 +205,8 @@ func TestClientSessionPersist(t *testing.T) {
 		FuncCloseSession: closeSessionMock,
 	}
 	sc := &SnowflakeConn{
-		cfg:  &Config{Params: map[string]*string{}},
-		rest: sr,
+		cfg:       &Config{Params: map[string]*string{}},
+		rest:      sr,
 		telemetry: testTelemetry,
 	}
 	sc.cfg.KeepSessionAlive = true

--- a/connector_test.go
+++ b/connector_test.go
@@ -11,7 +11,7 @@ import (
 
 type noopTestDriver struct {
 	config Config
-	conn   *snowflakeConn
+	conn   *SnowflakeConn
 }
 
 func (d *noopTestDriver) Open(_ string) (driver.Conn, error) {
@@ -24,7 +24,7 @@ func (d *noopTestDriver) OpenWithConfig(_ context.Context, config Config) (drive
 }
 
 func TestConnector(t *testing.T) {
-	conn := snowflakeConn{}
+	conn := SnowflakeConn{}
 	mock := noopTestDriver{conn: &conn}
 	createDSN("UTC")
 	config, err := ParseDSN(dsn)

--- a/driver_test.go
+++ b/driver_test.go
@@ -2166,7 +2166,7 @@ func TestOpenWithTransport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open with config. config: %v, err: %v", config, err)
 	}
-	conn := db.(*snowflakeConn)
+	conn := db.(*SnowflakeConn)
 	if conn.rest.Client.Transport != transport {
 		t.Fatal("transport doesn't match")
 	}
@@ -2182,7 +2182,7 @@ func TestOpenWithTransport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open with config. config: %v, err: %v", config, err)
 	}
-	conn = db.(*snowflakeConn)
+	conn = db.(*SnowflakeConn)
 	if conn.rest.Client.Transport != transport {
 		t.Fatal("transport doesn't match")
 	}

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -97,7 +97,7 @@ type SnowflakeFileTransferOptions struct {
 }
 
 type snowflakeFileTransferAgent struct {
-	sc                          *snowflakeConn
+	sc                          *SnowflakeConn
 	data                        *execResponseData
 	command                     string
 	commandType                 commandType

--- a/restful.go
+++ b/restful.go
@@ -60,7 +60,7 @@ type snowflakeRestful struct {
 	TokenAccessor TokenAccessor
 	HeartBeat     *heartbeat
 
-	Connection *snowflakeConn
+	Connection *SnowflakeConn
 
 	FuncPostQuery       func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration, uuid.UUID, *Config) (*execResponse, error)
 	FuncPostQueryHelper func(context.Context, *snowflakeRestful, *url.Values, map[string]string, []byte, time.Duration, uuid.UUID, *Config) (*execResponse, error)

--- a/rows.go
+++ b/rows.go
@@ -28,7 +28,7 @@ var (
 )
 
 type snowflakeRows struct {
-	sc                  *snowflakeConn
+	sc                  *SnowflakeConn
 	ChunkDownloader     chunkDownloader
 	tailChunkDownloader chunkDownloader
 	queryID             string

--- a/rows_test.go
+++ b/rows_test.go
@@ -304,7 +304,7 @@ func TestDownloadChunkInvalidResponseBody(t *testing.T) {
 			"dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
 	scd := &snowflakeChunkDownloader{
-		sc: &snowflakeConn{
+		sc: &SnowflakeConn{
 			rest: &snowflakeRestful{RequestTimeout: defaultRequestTimeout},
 		},
 		ctx:                context.Background(),
@@ -346,7 +346,7 @@ func TestDownloadChunkErrorStatus(t *testing.T) {
 			"dummyURL%v", i+1), RowCount: rowsInChunk})
 	}
 	scd := &snowflakeChunkDownloader{
-		sc: &snowflakeConn{
+		sc: &SnowflakeConn{
 			rest: &snowflakeRestful{RequestTimeout: defaultRequestTimeout},
 		},
 		ctx:                context.Background(),

--- a/statement.go
+++ b/statement.go
@@ -8,7 +8,7 @@ import (
 )
 
 type snowflakeStmt struct {
-	sc    *snowflakeConn
+	sc    *SnowflakeConn
 	query string
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -7,7 +7,7 @@ import (
 )
 
 type snowflakeTx struct {
-	sc *snowflakeConn
+	sc *SnowflakeConn
 }
 
 func (tx *snowflakeTx) Commit() (err error) {


### PR DESCRIPTION
### NOTE: this PR makes NO CODE CHANGES, rather it makes the `snowflakeConn` struct and the `checkQueryStatus` method public.

### Description
We use lambda functions to implement an async query interface. Roughly the flow is:
 1. make async query, return query id to client
 2. client polls for status of query using query id
 3. when done, client uses query id to get results/errors

Step 2) above is currently  implemented using a sql query which is:
* Slow
* Uses compile/planning resources that can significantly load a cluster when there are many queries in flight

This driver has a method that implements step 2) called  `checkQueryStatus`  but it is private. By making this method public step 2) can be done w/out executing a sql query.

This change was tested in our application.

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
