### PR TITLE
SNOW-180452: Change 'an SQL' to 'a SQL' to match our standards.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -42,6 +42,7 @@ schema is "testschema", and warehouse is "mywh":
 
 	db, err := sql.Open("snowflake", "jsmith:mypassword@my_organization-my_account/mydb/testschema?warehouse=mywh")
 
+
 Connection Parameters
 
 The connection string (DSN) can contain both connection parameters (described below) and session parameters

--- a/doc.go
+++ b/doc.go
@@ -131,7 +131,7 @@ Proxy
 
 The Go Snowflake Driver honors the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY for the forward proxy setting.
 
-NO_PROXY specifies which hostname endings should be allowed to bypass the proxy server, e.g. no_proxy=.amazonaws.com means that AWS S3 access does not need to go through the proxy.
+NO_PROXY specifies which hostname endings should be allowed to bypass the proxy server, e.g. no_proxy=.amazonaws.com means that Amazon S3 access does not need to go through the proxy.
 
 NO_PROXY does not support wildcards. Each value specified should be one of the following:
 
@@ -399,9 +399,9 @@ of the returned value:
 
 Binding Parameters
 
-Binding allows an SQL statement to use a value that is stored in a Golang variable.
+Binding allows a SQL statement to use a value that is stored in a Golang variable.
 
-Without binding, an SQL statement specifies values by specifying literals inside the statement.
+Without binding, a SQL statement specifies values by specifying literals inside the statement.
 For example, the following statement uses the literal value ``42`` in an UPDATE statement:
 
 	_, err = db.Exec("UPDATE table1 SET integer_column = 42 WHERE ID = 1000")


### PR DESCRIPTION
### Description
Please explain the changes you made here.

Our Snowflake standard is to write "a SQL" ("a sequel") rather than "an SQL" ("an ess-queue-ell"), but I often forget, so I had to fix it.

Also, S3 storage is properly named "Amazon S3" rather than "AWS S3", so I fixed that, too.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
