### PR TITLE
SNOW-365333: Removed statement that PUT is not supported.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -817,8 +817,7 @@ Limitations
 
 The Go Snowflake Driver has the following limitations:
 
-	* GET operations are unsupported.
-	* PUT operations are unsupported.
+	* GET operations (https://docs.snowflake.com/en/sql-reference/sql/get.html) are unsupported.
 
 */
 package gosnowflake

--- a/doc.go
+++ b/doc.go
@@ -686,6 +686,8 @@ If you want to execute a mix of query and non-query statements (e.g. a mix of SE
 multi-statement query, use QueryContext(). You can retrieve the result sets for the queries,
 and you can retrieve or ignore the row counts for the non-query statements.
 
+Note: PUT statements are not supported for multi-statement queries.
+
 
 If a SQL statement passed to ExecQuery() or QueryContext() fails to compile or execute, that statement is
 aborted, and subsequent statements are not executed. Any statements prior to the aborted statement are unaffected.
@@ -863,6 +865,8 @@ to handle backslashes in the path to the file.)
 		tableName)
 	dbt.mustExecContext(WithFileStream(context.Background(), fileStream),
 		sqlText)
+
+Note: PUT statements are not supported for multi-statement queries.
 
 
 Limitations

--- a/doc.go
+++ b/doc.go
@@ -813,6 +813,58 @@ and before retrieving the results.
 	}
 
 
+Support For PUT
+
+The Go Snowflake Driver supports the PUT command on AWS, Azure and GCP. The PUT
+command copies a file from the local computer (the computer on which the Golang
+client is running) to a stage on the cloud platform computer.
+
+The Go Snowflake Driver supports the same command parameters as are documented
+in the main PUT documentation at
+https://docs.snowflake.com/en/sql-reference/sql/put.html .
+
+The Go Snowflake Driver supports PUT commands to the following types of
+stages:
+	* A named internal stage.
+	* The table's stage.
+	* The user's default stage.
+
+To execute a PUT command in Golang, construct the command as a string and pass
+it to the db.Query() function. The syntax is:
+
+	db.Query("PUT file://<local_file> <stage_identifier> <optional_parameters>")
+
+For example:
+
+	db.Query("PUT file:///tmp/my_data_file @~ auto_compress=false overwrite=false")
+
+The "<local_file>" should include the file path as well as the name. Snowflake
+recommends using an absolute path rather than a relative path.
+
+Different client platforms (e.g. linux, Windows) have different path name
+conventions; make sure that you specify path names appropriately. This is
+particularly important on Windows, which uses the backslash character as
+both an escape character and as a separator in path names.
+
+If you wish to send information from a stream (rather than a file), then use
+code similar to the code below. (The ReplaceAll() function is needed on Windows
+to handle backslashes in the path to the file.)
+
+	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
+	defer func() {
+		if fileStream != nil {
+			fileStream.Close()
+		}
+	} ()
+
+	sql := "put 'file://%v' @%%%v auto_compress=true parallel=30"
+	sqlText := fmt.Sprintf(sql,
+		strings.ReplaceAll(fname, "\\", "\\\\"),
+		tableName)
+	dbt.mustExecContext(WithFileStream(context.Background(), fileStream),
+		sqlText)
+
+
 Limitations
 
 The Go Snowflake Driver has the following limitations:


### PR DESCRIPTION
### Description

Removed the line saying that PUT is not supported by the Golang driver.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
