### PR TITLE
SNOW-370765 Arrow High Precision Flag

### DIFF
--- a/chunk_arrow.go
+++ b/chunk_arrow.go
@@ -17,9 +17,8 @@ type arrowResultChunk struct {
 	allocator        memory.Allocator
 }
 
-func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType) ([]chunkRowType, error) {
+func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType, highPrec bool) ([]chunkRowType, error) {
 	logger.Debug("Arrow Decoder")
-
 	var chunkRows []chunkRowType
 
 	for {
@@ -36,8 +35,7 @@ func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType) ([]
 
 		for colIdx, col := range columns {
 			destcol := make([]snowflakeValue, numRows)
-			err := arrowToValue(&destcol, rowType[colIdx], col)
-			if err != nil {
+			if err = arrowToValue(&destcol, rowType[colIdx], col, highPrec); err != nil {
 				return nil, err
 			}
 

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -98,7 +98,8 @@ func (scd *snowflakeChunkDownloader) start() error {
 		// if the rowsetbase64 retrieved from the server is empty, move on to downloading chunks
 		var err error
 		firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64)
-		scd.CurrentChunk, err = firstArrowChunk.decodeArrowChunk(scd.RowSet.RowType)
+		higherPrecision := higherPrecisionEnabled(scd.ctx)
+		scd.CurrentChunk, err = firstArrowChunk.decodeArrowChunk(scd.RowSet.RowType, higherPrecision)
 		scd.CurrentChunkSize = firstArrowChunk.rowCount
 		if err != nil {
 			return err
@@ -381,7 +382,8 @@ func decodeChunk(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader
 			int(scd.totalUncompressedSize()),
 			memory.NewGoAllocator(),
 		}
-		respd, err = arc.decodeArrowChunk(scd.RowSet.RowType)
+		highPrec := higherPrecisionEnabled(scd.ctx)
+		respd, err = arc.decodeArrowChunk(scd.RowSet.RowType, highPrec)
 		if err != nil {
 			return err
 		}

--- a/connection_test.go
+++ b/connection_test.go
@@ -190,8 +190,8 @@ func TestCloseIgnoreSessionGone(t *testing.T) {
 		FuncCloseSession: closeSessionMock,
 	}
 	sc := &snowflakeConn{
-		cfg:  &Config{Params: map[string]*string{}},
-		rest: sr,
+		cfg:       &Config{Params: map[string]*string{}},
+		rest:      sr,
 		telemetry: testTelemetry,
 	}
 
@@ -205,8 +205,8 @@ func TestClientSessionPersist(t *testing.T) {
 		FuncCloseSession: closeSessionMock,
 	}
 	sc := &snowflakeConn{
-		cfg:  &Config{Params: map[string]*string{}},
-		rest: sr,
+		cfg:       &Config{Params: map[string]*string{}},
+		rest:      sr,
 		telemetry: testTelemetry,
 	}
 	sc.cfg.KeepSessionAlive = true

--- a/converter_test.go
+++ b/converter_test.go
@@ -533,7 +533,7 @@ func TestArrowToValue(t *testing.T) {
 			meta := tc.rowType
 			meta.Type = tc.logical
 
-			err := arrowToValue(&dest, meta, arr)
+			err := arrowToValue(&dest, meta, arr, true)
 			if err != nil {
 				t.Fatalf("error: %s", err)
 			}

--- a/driver.go
+++ b/driver.go
@@ -9,8 +9,7 @@ import (
 )
 
 // SnowflakeDriver is a context of Go Driver
-type SnowflakeDriver struct {
-}
+type SnowflakeDriver struct{}
 
 // Open creates a new connection.
 func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {

--- a/rows_test.go
+++ b/rows_test.go
@@ -47,8 +47,7 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 	rows.ChunkDownloader.start()
 	dest := make([]driver.Value, 2)
 	for i = 0; i < len(cc); i++ {
-		err := rows.Next(dest)
-		if err != nil {
+		if err := rows.Next(dest); err != nil {
 			t.Fatalf("failed to get value. err: %v", err)
 		}
 		if dest[0] != sts1 {
@@ -58,8 +57,7 @@ func TestRowsWithoutChunkDownloader(t *testing.T) {
 			t.Fatalf("failed to get value. expected: %v, got: %v", sts2, dest[1])
 		}
 	}
-	err := rows.Next(dest)
-	if err != io.EOF {
+	if err := rows.Next(dest); err != io.EOF {
 		t.Fatalf("failed to finish getting data. err: %v", err)
 	}
 	logger.Infof("dest: %v", dest)

--- a/util.go
+++ b/util.go
@@ -25,20 +25,20 @@ const (
 	queryIDChannel contextKey = "QUERY_ID_CHANNEL"
 	// snowflakeRequestIDKey is optional context key to specify request id
 	snowflakeRequestIDKey contextKey = "SNOWFLAKE_REQUEST_ID"
-	// streamChunkDownload determines whether to use a stream based chunk downloader
-	streamChunkDownload contextKey = "STREAM_CHUNK_DOWNLOAD"
 	// fetchResultByID the queryID of query result to fetch
 	fetchResultByID contextKey = "SF_FETCH_RESULT_BY_ID"
 	// fileStreamFile is the address of the file to be uploaded via PUT
 	fileStreamFile contextKey = "STREAMING_PUT_FILE"
 	// fileTransferOptions allows the user to pass in custom
 	fileTransferOptions contextKey = "FILE_TRANSFER_OPTIONS"
-	// describeOnly returns the description of the query
-	describeOnly contextKey = "DESCRIBE_ONLY"
+	// enableHigherPrecision returns numbers with higher precision in a *big format
+	enableHigherPrecision contextKey = "ENABLE_HIGHER_PRECISION"
 )
 
 const (
-	cancelRetry contextKey = "CANCEL_RETRY"
+	describeOnly        contextKey = "DESCRIBE_ONLY"
+	cancelRetry         contextKey = "CANCEL_RETRY"
+	streamChunkDownload contextKey = "STREAM_CHUNK_DOWNLOAD"
 )
 
 // WithMultiStatement returns a context that allows the user to execute the desired number of sql queries in one query
@@ -84,6 +84,13 @@ func WithFileTransferOptions(ctx context.Context, options *SnowflakeFileTransfer
 // WithDescribeOnly returns a context that enables a describe only query
 func WithDescribeOnly(ctx context.Context) context.Context {
 	return context.WithValue(ctx, describeOnly, true)
+}
+
+// WithHigherPrecision returns a context that enables higher precision by
+// returning a *big.Int or *big.Float variable when querying rows for column
+// types with numbers that don't fit into its native Golang counterpart
+func WithHigherPrecision(ctx context.Context) context.Context {
+	return context.WithValue(ctx, enableHigherPrecision, true)
 }
 
 // Get the request ID from the context if specified, otherwise generate one


### PR DESCRIPTION
### Description
Enable client side flag that enables higher precision for Arrow.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
