### PR TITLE
SNOW-444264 Make PUT overwrite default

### DIFF
--- a/connection_util.go
+++ b/connection_util.go
@@ -89,8 +89,8 @@ func (sc *snowflakeConn) processFileTransfer(
 	if op := getFileTransferOptions(ctx); op != nil {
 		sfa.options = op
 	}
-	if sfa.options.multiPartThreshold == 0 {
-		sfa.options.multiPartThreshold = dataSizeThreshold
+	if sfa.options.MultiPartThreshold == 0 {
+		sfa.options.MultiPartThreshold = dataSizeThreshold
 	}
 	if err := sfa.execute(); err != nil {
 		return nil, err

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -44,7 +44,7 @@ func TestPutError(t *testing.T) {
 	fta := &snowflakeFileTransferAgent{
 		data: data,
 		options: &SnowflakeFileTransferOptions{
-			raisePutGetError: false,
+			RaisePutGetError: false,
 		},
 	}
 	if err := fta.execute(); err != nil {
@@ -57,7 +57,7 @@ func TestPutError(t *testing.T) {
 	fta = &snowflakeFileTransferAgent{
 		data: data,
 		options: &SnowflakeFileTransferOptions{
-			raisePutGetError: true,
+			RaisePutGetError: true,
 		},
 	}
 	if err := fta.execute(); err != nil {
@@ -269,8 +269,12 @@ func TestPutOverwrite(t *testing.T) {
 		}
 
 		f, _ = os.Open(testData)
+		ctx := WithFileTransferOptions(context.Background(),
+			&SnowflakeFileTransferOptions{
+				DisablePutOverwrite: true,
+			})
 		rows = dbt.mustQueryContext(
-			WithFileStream(context.Background(), f),
+			WithFileStream(ctx, f),
 			fmt.Sprintf("put 'file://%v' @~/test_put_overwrite",
 				strings.ReplaceAll(testData, "\\", "\\\\")))
 		f.Close()

--- a/query.go
+++ b/query.go
@@ -112,7 +112,6 @@ type execResponseData struct {
 	Parallel                int64                 `json:"parallel,omitempty"`
 	Threshold               int64                 `json:"threshold,omitempty"`
 	AutoCompress            bool                  `json:"autoCompress,omitempty"`
-	Overwrite               bool                  `json:"overwrite,omitempty"`
 	SourceCompression       string                `json:"sourceCompression,omitempty"`
 	ShowEncryptionParameter bool                  `json:"clientShowEncryptionParameter,omitempty"`
 	EncryptionMaterial      encryptionWrapper     `json:"encryptionMaterial,omitempty"`

--- a/s3_util_test.go
+++ b/s3_util_test.go
@@ -72,7 +72,7 @@ func TestUploadOneFileToS3WSAEConnAborted(t *testing.T) {
 		srcFileName:       path.Join(dir, "/test_data/put_get_1.txt"),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			multiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: dataSizeThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, &smithy.GenericAPIError{
@@ -137,7 +137,7 @@ func TestUploadOneFileToS3ConnReset(t *testing.T) {
 		srcFileName:       path.Join(dir, "/test_data/put_get_1.txt"),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			multiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: dataSizeThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, &smithy.GenericAPIError{
@@ -184,7 +184,7 @@ func TestUploadFileWithS3UploadFailedError(t *testing.T) {
 		srcFileName:       path.Join(dir, "/test_data/put_get_1.txt"),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			multiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: dataSizeThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, &smithy.GenericAPIError{

--- a/storage_client.go
+++ b/storage_client.go
@@ -95,7 +95,7 @@ func (rsu *remoteStorageUtil) uploadOneFile(meta *fileMetadata) error {
 			}
 		}
 		if meta.overwrite || meta.resStatus == notFoundFile {
-			utilClass.uploadFile(dataFile, meta, encryptMeta, maxConcurrency, meta.options.multiPartThreshold)
+			utilClass.uploadFile(dataFile, meta, encryptMeta, maxConcurrency, meta.options.MultiPartThreshold)
 		}
 		if meta.resStatus == uploaded || meta.resStatus == renewToken || meta.resStatus == renewPresignedURL {
 			return nil


### PR DESCRIPTION
### Description
Make overwrite = true the default for PUT operations unless otherwise specified.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
