### PR TITLE
Set the result type before calling exec from Ping

### DIFF
--- a/async_test.go
+++ b/async_test.go
@@ -45,6 +45,22 @@ func TestAsyncMode(t *testing.T) {
 	})
 }
 
+func TestAsyncModePing(t *testing.T) {
+	ctx := WithAsyncMode(context.Background())
+
+	runDBTest(t, func(dbt *DBTest) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic during ping: %v", r)
+			}
+		}()
+		err := dbt.conn.PingContext(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestAsyncModeMultiStatement(t *testing.T) {
 	withMultiStmtCtx, _ := WithMultiStatement(context.Background(), 6)
 	ctx := WithAsyncMode(withMultiStmtCtx)

--- a/connection.go
+++ b/connection.go
@@ -439,6 +439,7 @@ func (sc *snowflakeConn) Ping(ctx context.Context) error {
 	noResult := isAsyncMode(ctx)
 	isDesc := isDescribeOnly(ctx)
 	// TODO: handle isInternal
+	ctx = setResultType(ctx, execResultType)
 	_, err := sc.exec(ctx, "SELECT 1", noResult, false, /* isInternal */
 		isDesc, []driver.NamedValue{})
 	return err


### PR DESCRIPTION
### Description
If the context has been set to Async Mode, the driver will attempt to
inspect the result type. If the result type has not been set, the driver
will panic when returning the [partial] result.

We ran into this issue when pinging a connection to test for aliveness when the context had `WithAsyncMode` applied. While async mode doesn't make a lot of sense for pings, in this case the same context is used to ping before executing a query.

Happy to write a test, just wasn't clear to me where Ping tests would live.

### Checklist
- [ ] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
