### PR TITLE
feat: add config option to disable file transfers

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -136,6 +136,14 @@ func (sc *snowflakeConn) exec(
 
 	// handle PUT/GET commands
 	if isFileTransfer(query) {
+		if sc.cfg.DisableFileTransfers {
+			return nil, (&SnowflakeError{
+				Number:   code, //TODO do we need a specific code here?
+				SQLState: data.Data.SQLState,
+				Message:  data.Message,
+				QueryID:  data.Data.QueryID,
+			}).exceptionTelemetry(sc)
+		}
 		data, err = sc.processFileTransfer(ctx, data, query, isInternal)
 		if err != nil {
 			return nil, err

--- a/dsn.go
+++ b/dsn.go
@@ -80,6 +80,8 @@ type Config struct {
 	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 
 	DisableTelemetry bool // indicates whether to disable telemetry
+
+	DisableFileTransfers bool // do not allow any file transfers to any endpoint
 }
 
 // ocspMode returns the OCSP mode in string INSECURE, FAIL_OPEN, FAIL_CLOSED


### PR DESCRIPTION
With this change its now possible to explicitly disable the file
transfer logic via the Config struct.

Alternatively I could put this option on the SnowflakeFileTransferOptions struct https://pkg.go.dev/github.com/snowflakedb/gosnowflake#SnowflakeFileTransferOptions

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
