### PR TITLE
Memory improvements for PUT operations

### DIFF
--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -71,10 +71,10 @@ func encryptStream(
 
 	mode := cipher.NewCBCEncrypter(block, ivData)
 	cipherText := make([]byte, chunkSize)
+	chunk := make([]byte, chunkSize)
 
 	// encrypt file with CBC
 	for {
-		chunk := make([]byte, chunkSize)
 		n, err := src.Read(chunk)
 		if n == 0 || err != nil {
 			break
@@ -83,7 +83,6 @@ func encryptStream(
 		}
 		mode.CryptBlocks(cipherText, chunk)
 		out.Write(cipherText[:len(chunk)])
-
 	}
 	if err != nil {
 		return nil, err

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -115,6 +115,28 @@ func TestEncryptDecryptLargeFile(t *testing.T) {
 	}
 }
 
+func BenchmarkEncryptStream(b *testing.B) {
+	var (
+		encMat = snowflakeFileEncryption{
+			"ztke8tIdVt1zmlQIZm0BMA==",
+			"123873c7-3a66-40c4-ab89-e3722fbccce1",
+			3112,
+		}
+		cr cheapReader
+		w  = ioutil.Discard
+	)
+
+	for _, size := range benchmarkInputSizes {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			var r = io.LimitReader(cr, size)
+			for i := 0; i < b.N; i++ {
+				_, _ = encryptStream(&encMat, r, w, 0)
+			}
+		})
+	}
+}
+
 func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string, error) {
 	if tmpDir == "" {
 		_, err := ioutil.TempDir(tmpDir, "data")

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -847,8 +847,10 @@ func (sfa *snowflakeFileTransferAgent) uploadOneFile(meta *fileMetadata) (*fileM
 	if meta.srcStream != nil {
 		if meta.realSrcStream != nil {
 			meta.sha256Digest, meta.uploadSize, err = fileUtil.getDigestAndSizeForStream(meta.realSrcStream)
+			meta.realSrcStream.Reset()
 		} else {
 			meta.sha256Digest, meta.uploadSize, err = fileUtil.getDigestAndSizeForStream(meta.srcStream)
+			meta.srcStream.Reset()
 		}
 		if err != nil {
 			return meta, err

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -846,9 +846,12 @@ func (sfa *snowflakeFileTransferAgent) uploadOneFile(meta *fileMetadata) (*fileM
 
 	if meta.srcStream != nil {
 		if meta.realSrcStream != nil {
-			meta.sha256Digest, meta.uploadSize = fileUtil.getDigestAndSizeForStream(&meta.realSrcStream)
+			meta.sha256Digest, meta.uploadSize, err = fileUtil.getDigestAndSizeForStream(meta.realSrcStream)
 		} else {
-			meta.sha256Digest, meta.uploadSize = fileUtil.getDigestAndSizeForStream(&meta.srcStream)
+			meta.sha256Digest, meta.uploadSize, err = fileUtil.getDigestAndSizeForStream(meta.srcStream)
+		}
+		if err != nil {
+			return meta, err
 		}
 	} else {
 		meta.sha256Digest, meta.uploadSize, err = fileUtil.getDigestAndSizeForFile(meta.realSrcFileName)

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -1,0 +1,125 @@
+package gosnowflake
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// benchmark a variety of input sizes for each test
+var benchmarkInputSizes = []int64{
+	100 * KB,
+	1 * MB,
+	10 * MB,
+	100 * MB,
+}
+
+func BenchmarkCompressFileWithGzipFromStream(b *testing.B) {
+	var (
+		buf  = bytes.NewBuffer(make([]byte, 0))
+		cr   cheapReader
+		util = new(snowflakeFileUtil)
+	)
+
+	for _, size := range benchmarkInputSizes {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				buf.Reset()
+				_, _ = buf.ReadFrom(io.LimitReader(cr, size))
+				_, _, _ = util.compressFileWithGzipFromStream(&buf)
+			}
+		})
+	}
+}
+
+func BenchmarkCompressFileWithGzip(b *testing.B) {
+	var (
+		cr   cheapReader
+		util = new(snowflakeFileUtil)
+	)
+
+	for _, size := range benchmarkInputSizes {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+
+			// populate a temporary file
+			tf, _ := ioutil.TempFile(os.TempDir(), "")
+			defer os.Remove(tf.Name())
+			_, _ = io.Copy(tf, io.LimitReader(cr, size))
+			tf.Close()
+
+			for i := 0; i < b.N; i++ {
+				_, _, _ = util.compressFileWithGzip(tf.Name(), os.TempDir())
+			}
+		})
+	}
+}
+
+func BenchmarkGetDigestAndSizeForStream(b *testing.B) {
+	var (
+		buf  = bytes.NewBuffer(make([]byte, 0))
+		cr   cheapReader
+		util = new(snowflakeFileUtil)
+	)
+
+	for _, size := range benchmarkInputSizes {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				buf.Reset()
+				_, _ = buf.ReadFrom(io.LimitReader(cr, size))
+				_, _ = util.getDigestAndSizeForStream(&buf)
+			}
+		})
+	}
+}
+
+func BenchmarkGetDigestAndSizeForFile(b *testing.B) {
+	var (
+		cr   cheapReader
+		util = new(snowflakeFileUtil)
+	)
+
+	for _, size := range benchmarkInputSizes {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+
+			// populate a temporary file
+			tf, _ := ioutil.TempFile(os.TempDir(), "")
+			defer os.Remove(tf.Name())
+			_, _ = io.Copy(tf, io.LimitReader(cr, size))
+			tf.Close()
+
+			for i := 0; i < b.N; i++ {
+				_, _, _ = util.getDigestAndSizeForFile(tf.Name())
+			}
+		})
+	}
+}
+
+// cheapReader is an io.Reader for testing that is cheap to call. Must be used in conjunction with
+// io.LimitReader, since cheapReader.Read will otherwise never return an io.EOF.
+type cheapReader struct{}
+
+// Read implements io.Reader, but always returns the same test data on each call.
+func (r cheapReader) Read(p []byte) (int, error) { return copy(p, "12345678"), nil }
+
+// prove that cheapReader contributes insignificantly to other benchmarks.
+func BenchmarkCheapReader(b *testing.B) {
+	var cr cheapReader
+	var buf = make([]byte, 8)
+	for i := 0; i < b.N; i++ {
+		_, _ = cr.Read(buf)
+		buf = buf[0:]
+	}
+}
+
+const (
+	B  = iota
+	KB = 1 << (10 * iota)
+	MB
+)

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -71,8 +71,7 @@ func BenchmarkGetDigestAndSizeForStream(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				buf.Reset()
-				_, _ = buf.ReadFrom(io.LimitReader(cr, size))
-				_, _ = util.getDigestAndSizeForStream(&buf)
+				_, _, _ = util.getDigestAndSizeForStream(io.LimitReader(cr, size))
 			}
 		})
 	}


### PR DESCRIPTION
### Description
See Issue #536 (SNOW-535791) for more background.

I've addressed some of the low-hanging fruit memory improvements in this PR.  Specifically, using the non-streaming API (and having the caller be responsible for staging the full data on disk instead) now follows a code path that doesn't read the whole file into memory.  The streaming API still reads the whole file into memory and will need more effort to fix beyond the changes suggested here.

In addition to the changes, I've also added a few benchmarks on the functions I've been working with, which can be run with a command similar to `SKIP_SETUP=1 go test -bench '^Benchmark.*$' -run '^$'`.  Running these tests in the baseline benchmarks commit and again at HEAD show that (at least for file-based functions) the number of allocations and bytes allocated don't scale with input size after the changes are applied.  Note that these benchmarks don't need to connect to a test snowflake instance (hence `SKIP_SETUP`), but they do take a bit of time to run since they generate a lot of fake data.

### Checklist
- [x] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
