### PR TITLE
Remove describe from PrepareContext due to slowdown

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -212,24 +212,6 @@ func (sc *snowflakeConn) PrepareContext(
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
-	noResult := isAsyncMode(ctx)
-	data, err := sc.exec(ctx, query, noResult, false, /* isInternal */
-		true /* describeOnly */, []driver.NamedValue{})
-	if err != nil {
-		if data != nil {
-			code, err := strconv.Atoi(data.Code)
-			if err != nil {
-				return nil, err
-			}
-			return nil, (&SnowflakeError{
-				Number:   code,
-				SQLState: data.Data.SQLState,
-				Message:  err.Error(),
-				QueryID:  data.Data.QueryID,
-			}).exceptionTelemetry(sc)
-		}
-		return nil, err
-	}
 	stmt := &snowflakeStmt{
 		sc:    sc,
 		query: query,


### PR DESCRIPTION
### Description
We noticed a big slowdown in our queries that we bisected down to the
1.4.1 release.

Specifically, our `CREATE USER` statements went from around 250ms
duration to 1000ms+ duration after this change.

We noticed that in that release, that `snowflakeConn.PrepareContext`
method started making an additional call to describe the query.

When I deleted this extra call, the duration again dropped from 1000ms+
to 250ms.

I could be wrong, but I don't think this call is strictly necessary.

See https://github.com/hashicorp/vault-plugin-database-snowflake/issues/13
for some additional context.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
