### PR TITLE
Temp fix for multipart binding upload failure

### DIFF
--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unsafe"
 )
 
 const (
@@ -18,7 +19,9 @@ const (
 		" file_format=" + "(type=csv field_optionally_enclosed_by='\"')"
 
 	// size (in bytes) of max input stream (10MB default) as per JDBC specs
-	inputStreamBufferSize = 1024 * 1024 * 10
+	// Temporary fix for TestBulkArrayMultiPartBindingInt:
+	// mulipart binding upload failed when the first data file is exactly 10MB
+	inputStreamBufferSize = int(1024*1024*10 - unsafe.Sizeof(int(0)))
 )
 
 type bindUploader struct {

--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -20,7 +20,7 @@ const (
 
 	// size (in bytes) of max input stream (10MB default) as per JDBC specs
 	// Temporary fix for TestBulkArrayMultiPartBindingInt:
-	// mulipart binding upload failed when the first data file is exactly 10MB
+	// multipart binding upload failed when the first data file is exactly 10MB
 	inputStreamBufferSize = int(1024*1024*10 - unsafe.Sizeof(int(0)))
 )
 


### PR DESCRIPTION
### Description
Multipart binding upload failed when the first data file is exactly 10MB.
Apply temporary fix for multipart binding upload issue by changing the input stream buffer size until root cause is found.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
