### PR TITLE
bind_uploader: don't allow more than 10M in upload buffer

### DIFF
--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"unsafe"
 )
 
 const (
@@ -19,9 +18,7 @@ const (
 		" file_format=" + "(type=csv field_optionally_enclosed_by='\"')"
 
 	// size (in bytes) of max input stream (10MB default) as per JDBC specs
-	// Temporary fix for TestBulkArrayMultiPartBindingInt:
-	// multipart binding upload failed when the first data file is exactly 10MB
-	inputStreamBufferSize = int(1024*1024*10 - unsafe.Sizeof(int(0)))
+	inputStreamBufferSize = 1024 * 1024 * 10
 )
 
 type bindUploader struct {
@@ -41,7 +38,7 @@ func (bu *bindUploader) upload(bindings []driver.NamedValue) (*execResponse, err
 	bu.fileCount = 0
 	var data *execResponse
 	for rowNum < len(bindingRows) {
-		for numBytes < inputStreamBufferSize && rowNum < len(bindingRows) {
+		for rowNum < len(bindingRows) && numBytes + len(bindingRows[rowNum]) < inputStreamBufferSize {
 			numBytes += len(bindingRows[rowNum])
 			rowNum++
 		}


### PR DESCRIPTION
Prior to this, the buffer maximum could be exceeded if a
column's byte count was >8

I'm unable to run the tests myself, so I'm not sure if this
breaks any of them. It does totally seem to resolve the
issue I've been having in trying to upload large batches
though!