### PR TITLE
Fixes external browser failed with encrypted SAML assertions

### DIFF
--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -147,7 +147,7 @@ func getTokenFromResponse(response string) (string, error) {
 			MessageArgs: []interface{}{response},
 		}
 	}
-	token := strings.TrimLeft(arr[0], start)
+	token := strings.TrimPrefix(arr[0], start)
 	token = strings.Split(token, " ")[0]
 	return token, nil
 }

--- a/authexternalbrowser_test.go
+++ b/authexternalbrowser_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+
+package gosnowflake
+
+import (
+	"testing"
+)
+
+func TestGetTokenFromResponseFail(t *testing.T) {
+	response := "GET /?fakeToken=fakeEncodedSamlToken HTTP/1.1\r\n" +
+		"Host: localhost:54001\r\n" +
+		"Connection: keep-alive\r\n" +
+		"Upgrade-Insecure-Requests: 1\r\n" +
+		"User-Agent: userAgentStr\r\n" +
+		"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\r\n" +
+		"Referer: https://myaccount.snowflakecomputing.com/fed/login\r\n" +
+		"Accept-Encoding: gzip, deflate, br\r\n" +
+		"Accept-Language: en-US,en;q=0.9\r\n\r\n"
+
+	_, err := getTokenFromResponse(response)
+	if err == nil {
+		t.Errorf("Should have failed parsing the malformed response.")
+	}
+}
+
+func TestGetTokenFromResponse(t *testing.T) {
+	response := "GET /?token=GETtokenFromResponse HTTP/1.1\r\n" +
+		"Host: localhost:54001\r\n" +
+		"Connection: keep-alive\r\n" +
+		"Upgrade-Insecure-Requests: 1\r\n" +
+		"User-Agent: userAgentStr\r\n" +
+		"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\r\n" +
+		"Referer: https://myaccount.snowflakecomputing.com/fed/login\r\n" +
+		"Accept-Encoding: gzip, deflate, br\r\n" +
+		"Accept-Language: en-US,en;q=0.9\r\n\r\n"
+
+	expected := "GETtokenFromResponse"
+
+	token, err := getTokenFromResponse(response)
+	if err != nil {
+		t.Errorf("Failed to get the token. Err: %#v", err)
+	}
+	if token != expected {
+		t.Errorf("Expected: %s, found: %s", expected, token)
+	}
+}


### PR DESCRIPTION
### Description
Simba incident 00388511

When the SAML token encryption is enabled in the identity provider, the driver fails authenticating with an external browser because part of the token was trimmed.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
