### PR TITLE
Disable the test for new statement type CALL

### DIFF
--- a/statement_test.go
+++ b/statement_test.go
@@ -167,6 +167,8 @@ func TestWithDescribeOnly(t *testing.T) {
 }
 
 func TestCallStatement(t *testing.T) {
+	t.Skip("USE_STATEMENT_TYPE_CALL_FOR_STORED_PROC_CALLS is not yet supported")
+
 	runTests(t, dsn, func(dbt *DBTest) {
 		in1 := float64(1)
 		in2 := string("[2,3]")


### PR DESCRIPTION
### Description
Follow up on #590.
TestCallStatement in statement_test.go will be disabled until server supports the parameter USE_STATEMENT_TYPE_CALL_FOR_STORED_PROC_CALLS

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
