### PR TITLE
Add parameter to enable logging in connection string / DSN

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -113,6 +113,7 @@ The following connection parameters are supported:
 								 Database, Schema, Warehouse and Role when setting up the connection
 
     * tracing: Specifies the logging level to be used. Set to error by default.
+        Valid values are trace, debug, info, print, warning, error, fatal, panic.
 
 All other parameters are interpreted as session parameters (https://docs.snowflake.com/en/sql-reference/parameters.html).
 For example, the TIMESTAMP_OUTPUT_FORMAT session parameter can be set by adding:

--- a/doc.go
+++ b/doc.go
@@ -112,6 +112,8 @@ The following connection parameters are supported:
 	* validateDefaultParameters: true by default. Set to false to disable checks on existence and privileges check for
 								 Database, Schema, Warehouse and Role when setting up the connection
 
+    * tracing: Specifies the logging level to be used. Set to error by default.
+
 All other parameters are interpreted as session parameters (https://docs.snowflake.com/en/sql-reference/parameters.html).
 For example, the TIMESTAMP_OUTPUT_FORMAT session parameter can be set by adding:
 

--- a/driver.go
+++ b/driver.go
@@ -28,6 +28,9 @@ func (d SnowflakeDriver) OpenWithConfig(
 	ctx context.Context,
 	config Config) (
 	driver.Conn, error) {
+	if config.Tracing != "" {
+		logger.SetLogLevel(config.Tracing)
+	}
 	logger.Info("OpenWithConfig")
 	sc, err := buildSnowflakeConn(ctx, config)
 	if err != nil {

--- a/dsn.go
+++ b/dsn.go
@@ -80,6 +80,8 @@ type Config struct {
 	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 
 	DisableTelemetry bool // indicates whether to disable telemetry
+
+	Tracing string // sets logging level
 }
 
 // ocspMode returns the OCSP mode in string INSECURE, FAIL_OPEN, FAIL_CLOSED
@@ -189,6 +191,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	}
 	if cfg.InsecureMode {
 		params.Add("insecureMode", strconv.FormatBool(cfg.InsecureMode))
+	}
+	if cfg.Tracing != "" {
+		params.Add("tracing", cfg.Tracing)
 	}
 
 	params.Add("ocspFailOpen", strconv.FormatBool(cfg.OCSPFailOpen != OCSPFailOpenFalse))
@@ -604,6 +609,8 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			} else {
 				cfg.ValidateDefaultParameters = ConfigBoolFalse
 			}
+		case "tracing":
+			cfg.Tracing = value
 		default:
 			if cfg.Params == nil {
 				cfg.Params = make(map[string]*string)


### PR DESCRIPTION
### Description
Add a connection property 'Tracing' to enable logging via connection string or DSN.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
