### PR TITLE
SNOW-559914 Fix multipart binding upload failure due to missing padding

### DIFF
--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -39,7 +39,7 @@ func (bu *bindUploader) upload(bindings []driver.NamedValue) (*execResponse, err
 	bu.fileCount = 0
 	var data *execResponse
 	for rowNum < len(bindingRows) {
-		for rowNum < len(bindingRows) && numBytes+len(bindingRows[rowNum]) < inputStreamBufferSize {
+		for numBytes < inputStreamBufferSize && rowNum < len(bindingRows) {
 			numBytes += len(bindingRows[rowNum])
 			rowNum++
 		}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -77,12 +77,17 @@ func TestEncryptDecryptFilePadding(t *testing.T) {
 	}
 
 	testcases := []encryptDecryptTestFile{
-		// file size is a multiple of 65536 bytes
+		// File size is a multiple of 65536 bytes (chunkSize)
 		{numberOfBytesInEachRow: 8, numberOfLines: 16384},
 		{numberOfBytesInEachRow: 16, numberOfLines: 4096},
-		// file size is not a multiple of 65536 bytes
+		// File size is not a multiple of 65536 bytes (chunkSize)
 		{numberOfBytesInEachRow: 8, numberOfLines: 10240},
 		{numberOfBytesInEachRow: 16, numberOfLines: 6144},
+		// The second chunk's size is a multiple of 16 bytes (aes.BlockSize)
+		{numberOfBytesInEachRow: 16, numberOfLines: 4097},
+		// The second chunk's size is not a multiple of 16 bytes (aes.BlockSize)
+		{numberOfBytesInEachRow: 12, numberOfLines: 5462},
+		{numberOfBytesInEachRow: 10, numberOfLines: 6556},
 	}
 
 	for _, test := range testcases {


### PR DESCRIPTION
### Description
Fix the "Failed to decrypt. Check file key and master key" error that occurs when uploading a file which the size is a multiple of 65536 bytes. Missing padding bytes at the end of the file is the root cause of the issue.

Removed the temporary workaround in #583.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
