### PR TITLE
deprecate: ioutil

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -9,7 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -234,7 +234,7 @@ func postAuth(
 			MessageArgs: []interface{}{resp.StatusCode, fullURL},
 		}
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -42,7 +41,7 @@ func buildResponse(application string) bytes.Buffer {
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,
 		ProtoMinor:    1,
-		Body:          ioutil.NopCloser(bytes.NewBufferString(body)),
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
 		ContentLength: int64(len(body)),
 		Request:       nil,
 		Header:        make(http.Header),
@@ -153,14 +152,14 @@ func getTokenFromResponse(response string) (string, error) {
 }
 
 // Authentication by an external browser takes place via the following:
-// - the golang snowflake driver communicates to Snowflake that the user wishes to
-//   authenticate via external browser
-// - snowflake sends back the IDP Url configured at the Snowflake side for the
-//   provided account
-// - the default browser is opened to that URL
-// - user authenticates at the IDP, and is redirected to Snowflake
-// - Snowflake directs the user back to the driver
-// - authenticate is complete!
+//   - the golang snowflake driver communicates to Snowflake that the user wishes to
+//     authenticate via external browser
+//   - snowflake sends back the IDP Url configured at the Snowflake side for the
+//     provided account
+//   - the default browser is opened to that URL
+//   - user authenticates at the IDP, and is redirected to Snowflake
+//   - Snowflake directs the user back to the driver
+//   - authenticate is complete!
 func authenticateByExternalBrowser(
 	ctx context.Context,
 	sr *snowflakeRestful,

--- a/authokta.go
+++ b/authokta.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -27,21 +27,23 @@ type authOKTAResponse struct {
 /*
 authenticateBySAML authenticates a user by SAML
 SAML Authentication
-1.  query GS to obtain IDP token and SSO url
-2.  IMPORTANT Client side validation:
-	validate both token url and sso url contains same prefix
-	(protocol + host + port) as the given authenticator url.
-	Explanation:
-	This provides a way for the user to 'authenticate' the IDP it is
-	sending his/her credentials to.  Without such a check, the user could
-	be coerced to provide credentials to an IDP impersonator.
-3.  query IDP token url to authenticate and retrieve access token
-4.  given access token, query IDP URL snowflake app to get SAML response
-5.  IMPORTANT Client side validation:
-	validate the post back url come back with the SAML response
-	contains the same prefix as the Snowflake's server url, which is the
-	intended destination url to Snowflake.
+ 1. query GS to obtain IDP token and SSO url
+ 2. IMPORTANT Client side validation:
+    validate both token url and sso url contains same prefix
+    (protocol + host + port) as the given authenticator url.
+    Explanation:
+    This provides a way for the user to 'authenticate' the IDP it is
+    sending his/her credentials to.  Without such a check, the user could
+    be coerced to provide credentials to an IDP impersonator.
+ 3. query IDP token url to authenticate and retrieve access token
+ 4. given access token, query IDP URL snowflake app to get SAML response
+ 5. IMPORTANT Client side validation:
+    validate the post back url come back with the SAML response
+    contains the same prefix as the Snowflake's server url, which is the
+    intended destination url to Snowflake.
+
 Explanation:
+
 	This emulates the behavior of IDP initiated login flow in the user
 	browser where the IDP instructs the browser to POST the SAML
 	assertion to the specific SP endpoint.  This is critical in
@@ -239,7 +241,7 @@ func postAuthSAML(
 			MessageArgs: []interface{}{resp.StatusCode, fullURL},
 		}
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
@@ -279,7 +281,7 @@ func postAuthOKTA(
 		}
 		return &respd, nil
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
@@ -313,7 +315,7 @@ func getSSO(
 		return nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -243,7 +243,7 @@ func (util *snowflakeAzureClient) detectAzureTokenExpireError(resp *http.Respons
 	if resp.StatusCode != 403 {
 		return false
 	}
-	azureErr, err := ioutil.ReadAll(resp.Body)
+	azureErr, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false
 	}

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -363,7 +362,7 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 	defer resp.Body.Close()
 	logger.Debugf("response returned chunk: %v for URL: %v", idx+1, scd.ChunkMetas[idx].URL)
 	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(bufStream)
+		b, err := io.ReadAll(bufStream)
 		if err != nil {
 			return err
 		}
@@ -639,7 +638,7 @@ func (f *httpStreamChunkFetcher) fetch(URL string, rows chan<- []*string) error 
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}

--- a/cmd/verifycert/verifycert.go
+++ b/cmd/verifycert/verifycert.go
@@ -4,7 +4,7 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -36,7 +36,7 @@ func main() {
 	if res.StatusCode != http.StatusOK {
 		log.Fatalf("failed to get 200: %v", res.StatusCode)
 	}
-	_, err = ioutil.ReadAll(res.Body)
+	_, err = io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatalf("failed to read content body for %v", targetURL)
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -266,7 +265,7 @@ func customGetQuery(ctx context.Context, rest *snowflakeRestful, url *url.URL,
 	if strings.Contains(url.Path, "/monitoring/queries/") {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader(jsonStr)),
+			Body:       io.NopCloser(strings.NewReader(jsonStr)),
 		}, nil
 	}
 	return getRestful(ctx, rest, url, vals, rest.RequestTimeout)

--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 )
@@ -173,7 +172,7 @@ func encryptFile(
 	if chunkSize == 0 {
 		chunkSize = aes.BlockSize * 4 * 1024
 	}
-	tmpOutputFile, err := ioutil.TempFile(tmpDir, baseName(filename)+"#")
+	tmpOutputFile, err := os.CreateTemp(tmpDir, baseName(filename)+"#")
 	if err != nil {
 		return nil, "", err
 	}
@@ -225,7 +224,7 @@ func decryptFile(
 	}
 	mode := cipher.NewCBCDecrypter(block, ivBytes)
 
-	tmpOutputFile, err := ioutil.TempFile(tmpDir, baseName(filename)+"#")
+	tmpOutputFile, err := os.CreateTemp(tmpDir, baseName(filename)+"#")
 	if err != nil {
 		return "", err
 	}

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -467,7 +466,7 @@ func (sfa *snowflakeFileTransferAgent) processFileCompressionType() error {
 					if err != nil {
 						return err
 					}
-					ioutil.ReadAll(r) // flush out tee buffer
+					io.ReadAll(r) // flush out tee buffer
 				} else {
 					mtype, err = mimetype.DetectFile(fileName)
 					if err != nil {
@@ -829,7 +828,7 @@ func (sfa *snowflakeFileTransferAgent) uploadFilesSequential(fileMetas []*fileMe
 
 func (sfa *snowflakeFileTransferAgent) uploadOneFile(meta *fileMetadata) (*fileMetadata, error) {
 	meta.realSrcFileName = meta.srcFileName
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, err
 	}
@@ -976,7 +975,7 @@ func (sfa *snowflakeFileTransferAgent) downloadFilesSequential(fileMetas []*file
 }
 
 func (sfa *snowflakeFileTransferAgent) downloadOneFile(meta *fileMetadata) (*fileMetadata, error) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/file_util.go
+++ b/file_util.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	usr "os/user"
@@ -25,7 +24,7 @@ const (
 
 func (util *snowflakeFileUtil) compressFileWithGzipFromStream(srcStream **bytes.Buffer) (*bytes.Buffer, int, error) {
 	r := getReaderFromBuffer(srcStream)
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -83,7 +83,7 @@ func (hc *heartbeat) heartbeatMain() error {
 		}
 		return nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Errorf("failed to extract HTTP response body. err: %v", err)
 		return err

--- a/local_storage_client.go
+++ b/local_storage_client.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -97,11 +96,11 @@ func (util *localUtil) downloadOneFile(meta *fileMetadata) error {
 		}
 	}
 
-	data, err := ioutil.ReadFile(fullSrcFileName)
+	data, err := os.ReadFile(fullSrcFileName)
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(fullDstFileName, data, os.ModePerm); err != nil {
+	if err = os.WriteFile(fullDstFileName, data, os.ModePerm); err != nil {
 		return err
 	}
 	fi, err := os.Stat(fullDstFileName)

--- a/ocsp.go
+++ b/ocsp.go
@@ -15,9 +15,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ocsp"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -30,6 +28,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/crypto/ocsp"
 )
 
 var (
@@ -429,7 +429,7 @@ func retryOCSP(
 		}
 	}
 	logger.Debug("reading contents")
-	ocspResBytes, err = ioutil.ReadAll(res.Body)
+	ocspResBytes, err = io.ReadAll(res.Body)
 	if err != nil {
 		return ocspRes, ocspResBytes, &ocspStatus{
 			code: ocspFailedExtractResponse,
@@ -857,7 +857,7 @@ func writeOCSPCacheFile() {
 		logger.Debugf("failed to convert OCSP Response cache to JSON. ignored.")
 		return
 	}
-	if err = ioutil.WriteFile(cacheFileName, j, 0644); err != nil {
+	if err = os.WriteFile(cacheFileName, j, 0644); err != nil {
 		logger.Debugf("failed to write OCSP Response cache. err: %v. ignored.\n", err)
 	}
 }

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -58,7 +57,7 @@ func TestOCSP(t *testing.T) {
 					t.Fatalf("failed to GET contents. err: %v", err)
 				}
 				defer res.Body.Close()
-				_, err = ioutil.ReadAll(res.Body)
+				_, err = io.ReadAll(res.Body)
 				if err != nil {
 					t.Fatalf("failed to read content body for %v", tgt)
 				}

--- a/priv_key_test.go
+++ b/priv_key_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -50,7 +49,7 @@ func setupPrivateKey() {
 	} else {
 		// path to the DER file
 		customPrivateKey = true
-		data, _ := ioutil.ReadFile(privKeyPath)
+		data, _ := os.ReadFile(privKeyPath)
 		block, _ := pem.Decode(data)
 		if block == nil || block.Type != "PRIVATE KEY" {
 			panic(fmt.Sprintf("%v is not a public key in PEM format.", privKeyPath))

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/user"
@@ -35,11 +34,7 @@ func TestPutError(t *testing.T) {
 	if isWindows {
 		t.Skip("permission model is different")
 	}
-	tmpDir, err := ioutil.TempDir("", "putfiledir")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	file1 := filepath.Join(tmpDir, "file1")
 	remoteLocation := filepath.Join(tmpDir, "remote_loc")
 	f, err := os.OpenFile(file1, os.O_CREATE|os.O_WRONLY, os.ModePerm)
@@ -243,11 +238,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 	if runningOnGithubAction() && !runningOnAWS() {
 		t.Skip("skipping non aws environment")
 	}
-	tmpDir, err := ioutil.TempDir("", "put")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	testData := filepath.Join(tmpDir, "data.txt")
 	f, err := os.OpenFile(testData, os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	if err != nil {
@@ -283,11 +274,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 }
 
 func TestPutOverwrite(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "data")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	testData := filepath.Join(tmpDir, "data.txt")
 	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, os.ModePerm)
 	if err != nil {
@@ -374,11 +361,7 @@ func TestPutGetStream(t *testing.T) {
 }
 
 func testPutGet(t *testing.T, isStream bool) {
-	tmpDir, err := ioutil.TempDir("", "put_get")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	fname := filepath.Join(tmpDir, "test_put_get.txt.gz")
 	originalContents := "123,test1\n456,test2\n"
 	tableName := randomString(5)
@@ -387,7 +370,7 @@ func testPutGet(t *testing.T, isStream bool) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 

--- a/put_get_user_stage_test.go
+++ b/put_get_user_stage_test.go
@@ -3,7 +3,6 @@ package gosnowflake
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,18 +28,18 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
 		t.Fatal("no aws secret access key found")
 	}
-	tmpDir, err := ioutil.TempDir(tmpDir, "data")
+	tmpDir, err := os.MkdirTemp(tmpDir, "data")
 	if err != nil {
 		t.Error(err)
 	}
-	tmpDir, err = generateKLinesOfNFiles(numberOfLines, numberOfFiles, false, tmpDir)
+	tmpDir, err = generateKLinesOfNFiles(t, numberOfLines, numberOfFiles, false, tmpDir)
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.RemoveAll(tmpDir)
 	var files string
 	if isStream {
-		list, err := ioutil.ReadDir(tmpDir)
+		list, err := os.ReadDir(tmpDir)
 		if err != nil {
 			t.Error(err)
 		}

--- a/put_get_with_aws_test.go
+++ b/put_get_with_aws_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -90,11 +89,7 @@ func TestPutWithInvalidToken(t *testing.T) {
 	if !runningOnAWS() {
 		t.Skip("skipping non aws environment")
 	}
-	tmpDir, err := ioutil.TempDir("", "aws_put")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	fname := filepath.Join(tmpDir, "test_put_get_with_aws.txt.gz")
 	originalContents := "123,test1\n456,test2\n"
 
@@ -102,7 +97,7 @@ func TestPutWithInvalidToken(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -202,11 +197,7 @@ func TestPretendToPutButList(t *testing.T) {
 	if runningOnGithubAction() && !runningOnAWS() {
 		t.Skip("skipping non aws environment")
 	}
-	tmpDir, err := ioutil.TempDir("", "aws_put")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	fname := filepath.Join(tmpDir, "test_put_get_with_aws.txt.gz")
 	originalContents := "123,test1\n456,test2\n"
 
@@ -214,7 +205,7 @@ func TestPretendToPutButList(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -269,11 +260,7 @@ func TestPutGetAWSStage(t *testing.T) {
 		t.Skip("skipping non aws environment")
 	}
 
-	tmpDir, err := ioutil.TempDir("", "put_get")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	name := "test_put_get.txt.gz"
 	fname := filepath.Join(tmpDir, name)
 	originalContents := "123,test1\n456,test2\n"
@@ -283,7 +270,7 @@ func TestPutGetAWSStage(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 

--- a/restful.go
+++ b/restful.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -271,7 +271,7 @@ func postRestfulQueryHelper(
 		}
 		return &respd, nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
@@ -321,7 +321,7 @@ func closeSession(ctx context.Context, sr *snowflakeRestful, timeout time.Durati
 		}
 		return nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return err
@@ -382,7 +382,7 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful, timeout time
 		sr.TokenAccessor.SetTokens(respd.Data.SessionToken, respd.Data.MasterToken, respd.Data.SessionID)
 		return nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return err
@@ -461,7 +461,7 @@ func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID UUID, time
 			}
 		}
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return err


### PR DESCRIPTION
### Description
Since Go1.16, `ioutil` is deprecated. So I replaced this to `os` or `io`.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
