### PR TITLE
Fixes floats from being truncated to 7 digit precision

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -195,7 +195,8 @@ func stringToValue(
 	dest *driver.Value,
 	srcColumnMeta execResponseRowType,
 	srcValue *string,
-	loc *time.Location) error {
+	loc *time.Location,
+) error {
 	if srcValue == nil {
 		logger.Debugf("snowflake data type: %v, raw value: nil", srcColumnMeta.Type)
 		*dest = nil
@@ -308,7 +309,8 @@ func arrowToValue(
 	srcColumnMeta execResponseRowType,
 	srcValue array.Interface,
 	loc *time.Location,
-	higherPrecision bool) error {
+	higherPrecision bool,
+) error {
 	data := srcValue.Data()
 	var err error
 	if len(*destcol) != srcValue.Data().Len() {
@@ -427,11 +429,7 @@ func arrowToValue(
 	case realType:
 		for i, flt64 := range array.NewFloat64Data(data).Float64Values() {
 			if !srcValue.IsNull(i) {
-				if higherPrecision {
-					(*destcol)[i] = flt64
-				} else {
-					(*destcol)[i] = fmt.Sprintf("%f", flt64)
-				}
+				(*destcol)[i] = flt64
 			}
 		}
 		return err
@@ -909,8 +907,8 @@ func arrowToRecord(record array.Record, rowType []execResponseRowType, loc *time
 		srcColumnMeta := rowType[i]
 		data := col.Data()
 
-		//TODO: confirm that it is okay to be using higher precision logic for conversions
-		var newCol = col
+		// TODO: confirm that it is okay to be using higher precision logic for conversions
+		newCol := col
 		switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 		case fixedType:
 			switch col.DataType().ID() {
@@ -1141,7 +1139,7 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 			converted = false
 		}
 
-		var newField = f
+		newField := f
 		if converted {
 			newField = arrow.Field{
 				Name:     f.Name,

--- a/converter.go
+++ b/converter.go
@@ -195,8 +195,7 @@ func stringToValue(
 	dest *driver.Value,
 	srcColumnMeta execResponseRowType,
 	srcValue *string,
-	loc *time.Location,
-) error {
+	loc *time.Location) error {
 	if srcValue == nil {
 		logger.Debugf("snowflake data type: %v, raw value: nil", srcColumnMeta.Type)
 		*dest = nil
@@ -309,8 +308,7 @@ func arrowToValue(
 	srcColumnMeta execResponseRowType,
 	srcValue array.Interface,
 	loc *time.Location,
-	higherPrecision bool,
-) error {
+	higherPrecision bool) error {
 	data := srcValue.Data()
 	var err error
 	if len(*destcol) != srcValue.Data().Len() {
@@ -907,8 +905,8 @@ func arrowToRecord(record array.Record, rowType []execResponseRowType, loc *time
 		srcColumnMeta := rowType[i]
 		data := col.Data()
 
-		// TODO: confirm that it is okay to be using higher precision logic for conversions
-		newCol := col
+		//TODO: confirm that it is okay to be using higher precision logic for conversions
+		var newCol = col
 		switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 		case fixedType:
 			switch col.DataType().ID() {
@@ -1139,7 +1137,7 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 			converted = false
 		}
 
-		newField := f
+		var newField = f
 		if converted {
 			newField = arrow.Field{
 				Name:     f.Name,


### PR DESCRIPTION
### Description
#453 introduced a bug with how float64 values are handled.  Since float64 is a native type, there is no reason to utilise the higherPrecision check.  The string formatting that was being utilised was truncating float values past the 7th decimal place.

This PR reverts the change that caused the issue.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
