### PR TITLE
Take changes from PR 655

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -427,11 +427,7 @@ func arrowToValue(
 	case realType:
 		for i, flt64 := range array.NewFloat64Data(data).Float64Values() {
 			if !srcValue.IsNull(i) {
-				if higherPrecision {
-					(*destcol)[i] = flt64
-				} else {
-					(*destcol)[i] = fmt.Sprintf("%f", flt64)
-				}
+				(*destcol)[i] = flt64
 			}
 		}
 		return err


### PR DESCRIPTION
### Description
Customer PR 655 has decrypt key issue and CLA Assist check fails. So I took the changes and raised the new PR. Somehow Snowflake internal team is not got this CLA Assist issue.

Description from 655:
https://github.com/snowflakedb/gosnowflake/pull/453 introduced a bug with how float64 values are handled. Since float64 is a native type, there is no reason to utilise the higherPrecision check. The string formatting that was being utilised was truncating float values past the 7th decimal place.

This PR reverts the change that caused the issue.
### Checklist
- [ x] Code compiles correctly
- [ x] Run ``make fmt`` to fix inconsistent formats
- [ x] Run ``make lint`` to get lint errors and fix all of them
- [ x] Created tests which fail without the change (if possible)
- [ x] All tests passing
- [ x] Extended the README / documentation, if necessary
