### PR TITLE
Change GetArrowBatches() in snowflakeRows to be public and blocking call

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -720,6 +720,11 @@ func (rb *ArrowBatch) Fetch() (*[]array.Record, error) {
 	return rb.rec, nil
 }
 
+// GetRowCount returns the number of rows in an arrow batch
+func (rb *ArrowBatch) GetRowCount() int {
+	return rb.rowCount
+}
+
 func usesArrowBatches(ctx context.Context) bool {
 	val := ctx.Value(arrowBatches)
 	if val == nil {

--- a/rows.go
+++ b/rows.go
@@ -28,6 +28,13 @@ var (
 	maxChunkDownloaderErrorCounter = 5
 )
 
+// SnowflakeRows provides an API for methods exposed to the clients
+type SnowflakeRows interface {
+	GetQueryID() string
+	GetStatus() queryStatus
+	GetArrowBatches() ([]*ArrowBatch, error)
+}
+
 type snowflakeRows struct {
 	sc                  *snowflakeConn
 	ChunkDownloader     chunkDownloader

--- a/rows.go
+++ b/rows.go
@@ -154,6 +154,10 @@ func (rows *snowflakeRows) GetStatus() queryStatus {
 
 // GetArrowBatches returns an array of ArrowBatch objects to retrieve data in array.Record format
 func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
+	if err := rows.waitForAsyncQueryStatus(); err != nil {
+		return nil, err
+	}
+
 	return rows.ChunkDownloader.getArrowBatches(), nil
 }
 

--- a/rows.go
+++ b/rows.go
@@ -154,6 +154,8 @@ func (rows *snowflakeRows) GetStatus() queryStatus {
 
 // GetArrowBatches returns an array of ArrowBatch objects to retrieve data in array.Record format
 func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
+	// Wait for all arrow batches before fetching.
+	// Otherwise, a panic error "invalid memory address or nil pointer dereference" will be thrown.
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
Salesforce ticket 00396666

The GetArrowBatches() API was implemented to access data in arrow.Record format directly from queries (#544).
However, the API is not public so it's not usable by customers. It is also not a blocking call which results in panic in async mode.

This PR adds the public interface SnowflakeRows and exposes the functions GetQueryID(), GetStatus() and GetArrowBatches(). This matches the functions that are exposed in SnowflakeResult. GetArrowBatches() is also changed to a blocking call to ensure the arrow batches are ready before fetching it. Customer has verified the changes in this branch.

### Checklist
- [x] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
