### PR TITLE
Change string format for float and numeric when converting arrow types

### DIFF
--- a/bindings_test.go
+++ b/bindings_test.go
@@ -249,13 +249,6 @@ func TestBindingInterfaceString(t *testing.T) {
 		if s, ok := v3.(string); !ok || s != "t3" {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v3)
 		}
-		if s, ok := v4.(string); !ok {
-			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v4)
-		} else if d, err := strconv.ParseFloat(s, 64); err != nil {
-			dbt.Errorf("failed to convert to float. value: %v, err: %v", v1, err)
-		} else if d != 4.2 {
-			dbt.Errorf("failed to fetch. expected: 4.2, value: %v", v1)
-		}
 	})
 }
 

--- a/converter.go
+++ b/converter.go
@@ -335,7 +335,7 @@ func arrowToValue(
 						if higherPrecision {
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%g", f)
+							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
 						}
 					}
 				}
@@ -354,7 +354,7 @@ func arrowToValue(
 							f := intToBigFloat(val, srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -373,7 +373,7 @@ func arrowToValue(
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -392,7 +392,7 @@ func arrowToValue(
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -411,7 +411,7 @@ func arrowToValue(
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -431,11 +431,7 @@ func arrowToValue(
 		// e.g. FLOAT/REAL/DOUBLE
 		for i, flt64 := range array.NewFloat64Data(data).Float64Values() {
 			if !srcValue.IsNull(i) {
-				if higherPrecision {
-					(*destcol)[i] = flt64
-				} else {
-					(*destcol)[i] = fmt.Sprintf("%g", flt64)
-				}
+				(*destcol)[i] = flt64
 			}
 		}
 		return err

--- a/converter.go
+++ b/converter.go
@@ -318,6 +318,8 @@ func arrowToValue(
 
 	switch getSnowflakeType(strings.ToUpper(srcColumnMeta.Type)) {
 	case fixedType:
+		// Snowflake data types that are fixed-point numbers will fall into this category
+		// e.g. NUMBER, DECIMAL/NUMERIC, INT/INTEGER
 		switch srcValue.DataType().ID() {
 		case arrow.DECIMAL:
 			for i, num := range array.NewDecimal128Data(data).Values() {
@@ -333,7 +335,7 @@ func arrowToValue(
 						if higherPrecision {
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%f", f)
+							(*destcol)[i] = fmt.Sprintf("%g", f)
 						}
 					}
 				}
@@ -352,7 +354,7 @@ func arrowToValue(
 							f := intToBigFloat(val, srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%f", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -371,7 +373,7 @@ func arrowToValue(
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%f", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -390,7 +392,7 @@ func arrowToValue(
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%f", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -409,7 +411,7 @@ func arrowToValue(
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%f", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = fmt.Sprintf("%g", float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
 						}
 					}
 				}
@@ -425,12 +427,14 @@ func arrowToValue(
 		}
 		return err
 	case realType:
+		// Snowflake data types that are floating-point numbers will fall in this category
+		// e.g. FLOAT/REAL/DOUBLE
 		for i, flt64 := range array.NewFloat64Data(data).Float64Values() {
 			if !srcValue.IsNull(i) {
 				if higherPrecision {
 					(*destcol)[i] = flt64
 				} else {
-					(*destcol)[i] = fmt.Sprintf("%f", flt64)
+					(*destcol)[i] = fmt.Sprintf("%g", flt64)
 				}
 			}
 		}


### PR DESCRIPTION
### Description
Take change from #655 to remove high precision check on non-fixed types i.e. FLOAT/REAL/DOUBLE.
For fixed types i.e. NUMBER/DECIMAL, use the column metadata scale when formatting: fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)

Fixes #578 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
