### PR TITLE
Drop support for go 1.17 and upgrade to go 1.19

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.18', '1.17' ]
+                go: [ '1.19', '1.18' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Ubuntu
         steps:
             - uses: actions/checkout@v1
@@ -48,7 +48,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.18', '1.17' ]
+                go: [ '1.19', '1.18' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Mac
         steps:
             - uses: actions/checkout@v1
@@ -70,7 +70,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.18', '1.17' ]
+                go: [ '1.19', '1.18' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Windows
         steps:
             - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following software packages are required to use the Go Snowflake Driver.
 
 ## Go
 
-The latest driver requires the [Go language](https://golang.org/) 1.17 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
+The latest driver requires the [Go language](https://golang.org/) 1.18 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
 
 
 # Installation

--- a/auth.go
+++ b/auth.go
@@ -9,7 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -234,7 +234,7 @@ func postAuth(
 			MessageArgs: []interface{}{resp.StatusCode, fullURL},
 		}
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -153,14 +153,14 @@ func getTokenFromResponse(response string) (string, error) {
 }
 
 // Authentication by an external browser takes place via the following:
-// - the golang snowflake driver communicates to Snowflake that the user wishes to
-//   authenticate via external browser
-// - snowflake sends back the IDP Url configured at the Snowflake side for the
-//   provided account
-// - the default browser is opened to that URL
-// - user authenticates at the IDP, and is redirected to Snowflake
-// - Snowflake directs the user back to the driver
-// - authenticate is complete!
+//   - the golang snowflake driver communicates to Snowflake that the user wishes to
+//     authenticate via external browser
+//   - snowflake sends back the IDP Url configured at the Snowflake side for the
+//     provided account
+//   - the default browser is opened to that URL
+//   - user authenticates at the IDP, and is redirected to Snowflake
+//   - Snowflake directs the user back to the driver
+//   - authenticate is complete!
 func authenticateByExternalBrowser(
 	ctx context.Context,
 	sr *snowflakeRestful,

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -42,7 +41,7 @@ func buildResponse(application string) bytes.Buffer {
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,
 		ProtoMinor:    1,
-		Body:          ioutil.NopCloser(bytes.NewBufferString(body)),
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
 		ContentLength: int64(len(body)),
 		Request:       nil,
 		Header:        make(http.Header),

--- a/authokta.go
+++ b/authokta.go
@@ -27,21 +27,23 @@ type authOKTAResponse struct {
 /*
 authenticateBySAML authenticates a user by SAML
 SAML Authentication
-1.  query GS to obtain IDP token and SSO url
-2.  IMPORTANT Client side validation:
-	validate both token url and sso url contains same prefix
-	(protocol + host + port) as the given authenticator url.
-	Explanation:
-	This provides a way for the user to 'authenticate' the IDP it is
-	sending his/her credentials to.  Without such a check, the user could
-	be coerced to provide credentials to an IDP impersonator.
-3.  query IDP token url to authenticate and retrieve access token
-4.  given access token, query IDP URL snowflake app to get SAML response
-5.  IMPORTANT Client side validation:
-	validate the post back url come back with the SAML response
-	contains the same prefix as the Snowflake's server url, which is the
-	intended destination url to Snowflake.
+ 1. query GS to obtain IDP token and SSO url
+ 2. IMPORTANT Client side validation:
+    validate both token url and sso url contains same prefix
+    (protocol + host + port) as the given authenticator url.
+    Explanation:
+    This provides a way for the user to 'authenticate' the IDP it is
+    sending his/her credentials to.  Without such a check, the user could
+    be coerced to provide credentials to an IDP impersonator.
+ 3. query IDP token url to authenticate and retrieve access token
+ 4. given access token, query IDP URL snowflake app to get SAML response
+ 5. IMPORTANT Client side validation:
+    validate the post back url come back with the SAML response
+    contains the same prefix as the Snowflake's server url, which is the
+    intended destination url to Snowflake.
+
 Explanation:
+
 	This emulates the behavior of IDP initiated login flow in the user
 	browser where the IDP instructs the browser to POST the SAML
 	assertion to the specific SP endpoint.  This is critical in

--- a/authokta.go
+++ b/authokta.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -241,7 +241,7 @@ func postAuthSAML(
 			MessageArgs: []interface{}{resp.StatusCode, fullURL},
 		}
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
@@ -281,7 +281,7 @@ func postAuthOKTA(
 		}
 		return &respd, nil
 	}
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
@@ -315,7 +315,7 @@ func getSSO(
 		return nil, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -243,7 +243,7 @@ func (util *snowflakeAzureClient) detectAzureTokenExpireError(resp *http.Respons
 	if resp.StatusCode != 403 {
 		return false
 	}
-	azureErr, err := ioutil.ReadAll(resp.Body)
+	azureErr, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false
 	}

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -363,7 +362,7 @@ func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx
 	defer resp.Body.Close()
 	logger.Debugf("response returned chunk: %v for URL: %v", idx+1, scd.ChunkMetas[idx].URL)
 	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(bufStream)
+		b, err := io.ReadAll(bufStream)
 		if err != nil {
 			return err
 		}
@@ -639,7 +638,7 @@ func (f *httpStreamChunkFetcher) fetch(URL string, rows chan<- []*string) error 
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}

--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -1,7 +1,6 @@
 // Example: Authenticate with OAuth. In order for this to work, one should
 // complete the OAuth flow to get an access token, which is beyond (for now!)
 // the scope of this example.
-//
 package main
 
 import (

--- a/cmd/showparam/showparam.go
+++ b/cmd/showparam/showparam.go
@@ -1,5 +1,4 @@
 // Example: Set the session parameter in DSN and verify it
-//
 package main
 
 import (

--- a/connection_test.go
+++ b/connection_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -266,7 +265,7 @@ func customGetQuery(ctx context.Context, rest *snowflakeRestful, url *url.URL,
 	if strings.Contains(url.Path, "/monitoring/queries/") {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader(jsonStr)),
+			Body:       io.NopCloser(strings.NewReader(jsonStr)),
 		}, nil
 	}
 	return getRestful(ctx, rest, url, vals, rest.RequestTimeout)

--- a/doc.go
+++ b/doc.go
@@ -18,7 +18,7 @@ Clients can use the database/sql package directly. For example:
 		...
 	}
 
-Connection String
+# Connection String
 
 Use the Open() function to create a database handle with connection parameters:
 
@@ -26,9 +26,9 @@ Use the Open() function to create a database handle with connection parameters:
 
 The Go Snowflake Driver supports the following connection syntaxes (or data source name (DSN) formats):
 
-	* username[:password]@<account_identifier>/dbname/schemaname[?param1=value&...&paramN=valueN]
-	* username[:password]@<account_identifier>/dbname[?param1=value&...&paramN=valueN]
-	* username[:password]@hostname:port/dbname/schemaname?account=<account_identifier>[&param1=value&...&paramN=valueN]
+  - username[:password]@<account_identifier>/dbname/schemaname[?param1=value&...&paramN=valueN]
+  - username[:password]@<account_identifier>/dbname[?param1=value&...&paramN=valueN]
+  - username[:password]@hostname:port/dbname/schemaname?account=<account_identifier>[&param1=value&...&paramN=valueN]
 
 where all parameters must be escaped or use Config and DSN to construct a DSN string.
 
@@ -42,78 +42,81 @@ schema is "testschema", and warehouse is "mywh":
 
 	db, err := sql.Open("snowflake", "jsmith:mypassword@my_organization-my_account/mydb/testschema?warehouse=mywh")
 
-
-Connection Parameters
+# Connection Parameters
 
 The connection string (DSN) can contain both connection parameters (described below) and session parameters
 (https://docs.snowflake.com/en/sql-reference/parameters.html).
 
 The following connection parameters are supported:
 
-	* account <string>: Specifies your Snowflake account, where "<string>" is the account
-		identifier assigned to your account by Snowflake.
-		For information about account identifiers, see the Snowflake documentation
-		(https://docs.snowflake.com/en/user-guide/admin-account-identifier.html).
+  - account <string>: Specifies your Snowflake account, where "<string>" is the account
+    identifier assigned to your account by Snowflake.
+    For information about account identifiers, see the Snowflake documentation
+    (https://docs.snowflake.com/en/user-guide/admin-account-identifier.html).
 
-		If you are using a global URL, then append the connection group and ".global"
-		(e.g. "<account_identifier>-<connection_group>.global"). The account identifier and the
-		connection group are separated by a dash ("-"), as shown above.
+    If you are using a global URL, then append the connection group and ".global"
+    (e.g. "<account_identifier>-<connection_group>.global"). The account identifier and the
+    connection group are separated by a dash ("-"), as shown above.
 
-		This parameter is optional if your account identifier is specified after the "@" character
-		in the connection string.
+    This parameter is optional if your account identifier is specified after the "@" character
+    in the connection string.
 
-	* region <string>: DEPRECATED. You may specify a region, such as
-		"eu-central-1", with this parameter. However, since this parameter
-		is deprecated, it is best to specify the region as part of the
-		account parameter. For details, see the description of the account
-		parameter.
+  - region <string>: DEPRECATED. You may specify a region, such as
+    "eu-central-1", with this parameter. However, since this parameter
+    is deprecated, it is best to specify the region as part of the
+    account parameter. For details, see the description of the account
+    parameter.
 
-	* database: Specifies the database to use by default in the client session
-		(can be changed after login).
+  - database: Specifies the database to use by default in the client session
+    (can be changed after login).
 
-	* schema: Specifies the database schema to use by default in the client
-		session (can be changed after login).
+  - schema: Specifies the database schema to use by default in the client
+    session (can be changed after login).
 
-	* warehouse: Specifies the virtual warehouse to use by default for queries,
-		loading, etc. in the client session (can be changed after login).
+  - warehouse: Specifies the virtual warehouse to use by default for queries,
+    loading, etc. in the client session (can be changed after login).
 
-	* role: Specifies the role to use by default for accessing Snowflake
-		objects in the client session (can be changed after login).
+  - role: Specifies the role to use by default for accessing Snowflake
+    objects in the client session (can be changed after login).
 
-	* passcode: Specifies the passcode provided by Duo when using multi-factor authentication (MFA) for login.
+  - passcode: Specifies the passcode provided by Duo when using multi-factor authentication (MFA) for login.
 
-	* passcodeInPassword: false by default. Set to true if the MFA passcode is embedded
-		in the login password. Appends the MFA passcode to the end of the password.
+  - passcodeInPassword: false by default. Set to true if the MFA passcode is embedded
+    in the login password. Appends the MFA passcode to the end of the password.
 
-	* loginTimeout: Specifies the timeout, in seconds, for login. The default
-		is 60 seconds. The login request gives up after the timeout length if the
-		HTTP response is success.
+  - loginTimeout: Specifies the timeout, in seconds, for login. The default
+    is 60 seconds. The login request gives up after the timeout length if the
+    HTTP response is success.
 
-	* authenticator: Specifies the authenticator to use for authenticating user credentials:
-		- To use the internal Snowflake authenticator, specify snowflake (Default).
-		- To authenticate through Okta, specify https://<okta_account_name>.okta.com (URL prefix for Okta).
-		- To authenticate using your IDP via a browser, specify externalbrowser.
-		- To authenticate via OAuth, specify oauth and provide an OAuth Access Token (see the token parameter below).
+  - authenticator: Specifies the authenticator to use for authenticating user credentials:
 
-	* application: Identifies your application to Snowflake Support.
+  - To use the internal Snowflake authenticator, specify snowflake (Default).
 
-	* insecureMode: false by default. Set to true to bypass the Online
-		Certificate Status Protocol (OCSP) certificate revocation check.
-		IMPORTANT: Change the default value for testing or emergency situations only.
+  - To authenticate through Okta, specify https://<okta_account_name>.okta.com (URL prefix for Okta).
 
-	* token: a token that can be used to authenticate. Should be used in conjunction with the "oauth" authenticator.
+  - To authenticate using your IDP via a browser, specify externalbrowser.
 
-	* client_session_keep_alive: Set to true have a heartbeat in the background every hour to keep the connection alive
-		such that the connection session will never expire. Care should be taken in using this option as it opens up
-		the access forever as long as the process is alive.
+  - To authenticate via OAuth, specify oauth and provide an OAuth Access Token (see the token parameter below).
 
-	* ocspFailOpen: true by default. Set to false to make OCSP check fail closed mode.
+  - application: Identifies your application to Snowflake Support.
 
-	* validateDefaultParameters: true by default. Set to false to disable checks on existence and privileges check for
-								 Database, Schema, Warehouse and Role when setting up the connection
+  - insecureMode: false by default. Set to true to bypass the Online
+    Certificate Status Protocol (OCSP) certificate revocation check.
+    IMPORTANT: Change the default value for testing or emergency situations only.
 
-    * tracing: Specifies the logging level to be used. Set to error by default.
-        Valid values are trace, debug, info, print, warning, error, fatal, panic.
+  - token: a token that can be used to authenticate. Should be used in conjunction with the "oauth" authenticator.
+
+  - client_session_keep_alive: Set to true have a heartbeat in the background every hour to keep the connection alive
+    such that the connection session will never expire. Care should be taken in using this option as it opens up
+    the access forever as long as the process is alive.
+
+  - ocspFailOpen: true by default. Set to false to make OCSP check fail closed mode.
+
+  - validateDefaultParameters: true by default. Set to false to disable checks on existence and privileges check for
+    Database, Schema, Warehouse and Role when setting up the connection
+
+  - tracing: Specifies the logging level to be used. Set to error by default.
+    Valid values are trace, debug, info, print, warning, error, fatal, panic.
 
 All other parameters are interpreted as session parameters (https://docs.snowflake.com/en/sql-reference/parameters.html).
 For example, the TIMESTAMP_OUTPUT_FORMAT session parameter can be set by adding:
@@ -122,17 +125,17 @@ For example, the TIMESTAMP_OUTPUT_FORMAT session parameter can be set by adding:
 
 A complete connection string looks similar to the following:
 
-	my_user_name:my_password@ac123456/my_database/my_schema?my_warehouse=inventory_warehouse&role=my_user_role&DATE_OUTPUT_FORMAT=YYYY-MM-DD
-                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                                                      connection                     connection           session
-                                                                      parameter                      parameter            parameter
+		my_user_name:my_password@ac123456/my_database/my_schema?my_warehouse=inventory_warehouse&role=my_user_role&DATE_OUTPUT_FORMAT=YYYY-MM-DD
+	                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+	                                                                      connection                     connection           session
+	                                                                      parameter                      parameter            parameter
 
 Session-level parameters can also be set by using the SQL command "ALTER SESSION"
 (https://docs.snowflake.com/en/sql-reference/sql/alter-session.html).
 
 Alternatively, use OpenWithConfig() function to create a database handle with the specified Config.
 
-Proxy
+# Proxy
 
 The Go Snowflake Driver honors the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY for the forward proxy setting.
 
@@ -140,16 +143,15 @@ NO_PROXY specifies which hostname endings should be allowed to bypass the proxy 
 
 NO_PROXY does not support wildcards. Each value specified should be one of the following:
 
-    * The end of a hostname (or a complete hostname), for example: ".amazonaws.com" or "xy12345.snowflakecomputing.com".
+  - The end of a hostname (or a complete hostname), for example: ".amazonaws.com" or "xy12345.snowflakecomputing.com".
 
-    * An IP address, for example "192.196.1.15".
+  - An IP address, for example "192.196.1.15".
 
 If more than one value is specified, values should be separated by commas, for example:
 
-    no_proxy=localhost,.my_company.com,xy12345.snowflakecomputing.com,192.168.1.15,192.168.1.16
+	no_proxy=localhost,.my_company.com,xy12345.snowflakecomputing.com,192.168.1.15,192.168.1.16
 
-
-Logging
+# Logging
 
 By default, the driver's builtin logger is exposing logrus's FieldLogger and default at INFO level.
 Users can use SetLogger in driver.go to set a customized logger for gosnowflake package.
@@ -157,8 +159,7 @@ Users can use SetLogger in driver.go to set a customized logger for gosnowflake 
 In order to enable debug logging for the driver, user could use SetLogLevel("debug") in SFLogger interface
 as shown in demo code at cmd/logger.go. To redirect the logs SFlogger.SetOutput method could do the work.
 
-
-Query request ID
+# Query request ID
 
 A specific query request ID can be set in the context and will be passed through
 in place of the default randomized request ID. For example:
@@ -167,7 +168,7 @@ in place of the default randomized request ID. For example:
 	ctxWithID := WithRequestID(ctx, requestID)
 	rows, err := db.QueryContext(ctxWithID, query)
 
-Canceling Query by CtrlC
+# Canceling Query by CtrlC
 
 From 0.5.0, a signal handling responsibility has moved to the applications. If you want to cancel a
 query/command by Ctrl+C, add a os.Interrupt trap in context to execute methods that can take the context parameter
@@ -194,7 +195,7 @@ query/command by Ctrl+C, add a os.Interrupt trap in context to execute methods t
 
 See cmd/selectmany.go for the full example.
 
-Supported Data Types
+# Supported Data Types
 
 The Go Snowflake Driver now supports the Arrow data format for data transfers
 between Snowflake and the Golang client. The Arrow data format avoids extra
@@ -210,8 +211,8 @@ GO_QUERY_RESULT_FORMAT. To use JSON format, execute:
 
 The valid values for the parameter are:
 
-	* ARROW (default)
-	* JSON
+  - ARROW (default)
+  - JSON
 
 If the user attempts to set the parameter to an invalid value, an error is
 returned.
@@ -222,92 +223,96 @@ This parameter can be set only at the session level.
 
 Usage notes:
 
-	* The Arrow data format reduces rounding errors in floating point numbers. You might see slightly
-	  different values for floating point numbers when using Arrow format than when using JSON format.
-	  In order to take advantage of the increased precision, you must pass in the context.Context object
-	  provided by the WithHigherPrecision function when querying.
+  - The Arrow data format reduces rounding errors in floating point numbers. You might see slightly
+    different values for floating point numbers when using Arrow format than when using JSON format.
+    In order to take advantage of the increased precision, you must pass in the context.Context object
+    provided by the WithHigherPrecision function when querying.
 
-	* Traditionally, the rows.Scan() method returned a string when a variable of types interface was passed
-	  in. Turning on the flag ENABLE_HIGHER_PRECISION via WithHigherPrecision will return the natural,
-	  expected data type as well.
+  - Traditionally, the rows.Scan() method returned a string when a variable of types interface was passed
+    in. Turning on the flag ENABLE_HIGHER_PRECISION via WithHigherPrecision will return the natural,
+    expected data type as well.
 
-	* For some numeric data types, the driver can retrieve larger values when using the Arrow format than
-	  when using the JSON format. For example, using Arrow format allows the full range of SQL NUMERIC(38,0)
-	  values to be retrieved, while using JSON format allows only values in the range supported by the
-	  Golang int64 data type.
+  - For some numeric data types, the driver can retrieve larger values when using the Arrow format than
+    when using the JSON format. For example, using Arrow format allows the full range of SQL NUMERIC(38,0)
+    values to be retrieved, while using JSON format allows only values in the range supported by the
+    Golang int64 data type.
 
-	  Users should ensure that Golang variables are declared using the appropriate data type for the full
-	  range of values contained in the column. For an example, see below.
+    Users should ensure that Golang variables are declared using the appropriate data type for the full
+    range of values contained in the column. For an example, see below.
 
 When using the Arrow format, the driver supports more Golang data types and
 more ways to convert SQL values to those Golang data types. The table below
 lists the supported Snowflake SQL data types and the corresponding Golang
 data types. The columns are:
 
-   1. The SQL data type.
-   2. The default Golang data type that is returned when you use snowflakeRows.Scan() to read data from
-      Arrow data format via an interface{}.
-   3. The possible Golang data types that can be returned when you use snowflakeRows.Scan() to read data
-      from Arrow data format directly.
-   4. The default Golang data type that is returned when you use snowflakeRows.Scan() to read data from
-      JSON data format via an interface{}. (All returned values are strings.)
-   5. The standard Golang data type that is returned when you use snowflakeRows.Scan() to read data from
-      JSON data format directly.
+ 1. The SQL data type.
 
-  Go Data Types for Scan()
-  ===================================================================================================================
-                         |                    ARROW                    |                    JSON
-  ===================================================================================================================
-  SQL Data Type          | Default Go Data Type   | Supported Go Data  | Default Go Data Type   | Supported Go Data
-                         | for Scan() interface{} | Types for Scan()   | for Scan() interface{} | Types for Scan()
-  ===================================================================================================================
+ 2. The default Golang data type that is returned when you use snowflakeRows.Scan() to read data from
+    Arrow data format via an interface{}.
+
+ 3. The possible Golang data types that can be returned when you use snowflakeRows.Scan() to read data
+    from Arrow data format directly.
+
+ 4. The default Golang data type that is returned when you use snowflakeRows.Scan() to read data from
+    JSON data format via an interface{}. (All returned values are strings.)
+
+ 5. The standard Golang data type that is returned when you use snowflakeRows.Scan() to read data from
+    JSON data format directly.
+
+    Go Data Types for Scan()
+    ===================================================================================================================
+    |                    ARROW                    |                    JSON
+    ===================================================================================================================
+    SQL Data Type          | Default Go Data Type   | Supported Go Data  | Default Go Data Type   | Supported Go Data
+    | for Scan() interface{} | Types for Scan()   | for Scan() interface{} | Types for Scan()
+    ===================================================================================================================
     BOOLEAN              | bool                                        | string                 | bool
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     VARCHAR              | string                                      | string
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     DOUBLE               | float32, float64                  [1] , [2] | string                 | float32, float64
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     INTEGER that         | int, int8, int16, int32, int64              | string                 | int, int8, int16,
     fits in int64        |                                   [1] , [2] |                        | int32, int64
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     INTEGER that doesn't | int, int8, int16, int32, int64,  *big.Int   | string                 | error
     fit in int64         |                       [1] , [2] , [3] , [4] |
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     NUMBER(P, S)         | float32, float64,  *big.Float               | string                 | float32, float64
     where S > 0          |                       [1] , [2] , [3] , [5] |
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     DATE                 | time.Time                                   | string                 | time.Time
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     TIME                 | time.Time                                   | string                 | time.Time
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     TIMESTAMP_LTZ        | time.Time                                   | string                 | time.Time
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     TIMESTAMP_NTZ        | time.Time                                   | string                 | time.Time
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     TIMESTAMP_TZ         | time.Time                                   | string                 | time.Time
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     BINARY               | []byte                                      | string                 | []byte
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     ARRAY                | string                                      | string
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     OBJECT               | string                                      | string
-  -------------------------------------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------------------------------------
     VARIANT              | string                                      | string
 
-  [1] Converting from a higher precision data type to a lower precision data type via the snowflakeRows.Scan()
-      method can lose low bits (lose precision), lose high bits (completely change the value), or result in error.
+    [1] Converting from a higher precision data type to a lower precision data type via the snowflakeRows.Scan()
+    method can lose low bits (lose precision), lose high bits (completely change the value), or result in error.
 
-  [2] Attempting to convert from a higher precision data type to a lower precision data type via interface{}
-      causes an error.
+    [2] Attempting to convert from a higher precision data type to a lower precision data type via interface{}
+    causes an error.
 
-  [3] Higher precision data types like *big.Int and *big.Float can be accessed by querying with a context
-      returned by WithHigherPrecision().
+    [3] Higher precision data types like *big.Int and *big.Float can be accessed by querying with a context
+    returned by WithHigherPrecision().
 
-  [4] You cannot directly Scan() into the alternative data types via snowflakeRows.Scan(), but can convert to
-      those data types by using .Int64()/.String()/.Uint64() methods. For an example, see below.
+    [4] You cannot directly Scan() into the alternative data types via snowflakeRows.Scan(), but can convert to
+    those data types by using .Int64()/.String()/.Uint64() methods. For an example, see below.
 
-  [5] You cannot directly Scan() into the alternative data types via snowflakeRows.Scan(), but can convert to
-      those data types by using .Float32()/.String()/.Float64() methods. For an example, see below.
+    [5] You cannot directly Scan() into the alternative data types via snowflakeRows.Scan(), but can convert to
+    those data types by using .Float32()/.String()/.Float64() methods. For an example, see below.
 
 Note: SQL NULL values are converted to Golang nil values, and vice-versa.
 
@@ -317,72 +322,71 @@ extracts a big.Int value from that interface. If the value fits into an int64,
 then the code also copies the value to a variable of type int64. Note that a
 context that enables higher precision must be passed in with the query.
 
-       import "context"
-       import "math/big"
+	import "context"
+	import "math/big"
 
-       ...
+	...
 
-       var my_interface interface{}
-       var my_big_int_pointer *big.Int
-       var my_int64 int64
-       var rows snowflakeRows
+	var my_interface interface{}
+	var my_big_int_pointer *big.Int
+	var my_int64 int64
+	var rows snowflakeRows
 
-       ...
-       rows = db.QueryContext(WithHigherPrecision(context.Background), <query>)
-       rows.Scan(&my_interface)
-       my_big_int_pointer, ok = my_interface.(*big.Int)
-       if my_big_int_pointer.IsInt64() {
-           my_int64 = my_big_int_pointer.Int64()
-       }
+	...
+	rows = db.QueryContext(WithHigherPrecision(context.Background), <query>)
+	rows.Scan(&my_interface)
+	my_big_int_pointer, ok = my_interface.(*big.Int)
+	if my_big_int_pointer.IsInt64() {
+	    my_int64 = my_big_int_pointer.Int64()
+	}
 
 If the variable named "rows" is known to contain a big.Int, then you can use the following instead of scanning into an interface
 and then converting to a big.Int:
 
-       rows.Scan(&my_big_int_pointer)
+	rows.Scan(&my_big_int_pointer)
 
 If the variable named "rows" contains a big.Int, then each of the following fails:
 
-       rows.Scan(&my_int64)
+	rows.Scan(&my_int64)
 
-       my_int64, _ = my_interface.(int64)
+	my_int64, _ = my_interface.(int64)
 
 Similar code and rules also apply to big.Float values.
 
 If you are not sure what data type will be returned, you can use code similar to the following to check the data type
 of the returned value:
 
-    // Create variables into which you can scan the returned values.
-    var i64 int64
-    var bigIntPtr *big.Int
+	// Create variables into which you can scan the returned values.
+	var i64 int64
+	var bigIntPtr *big.Int
 
-    for rows.Next() {
-        // Get the data type info.
-        column_types, err := rows.ColumnTypes()
-        if err != nil {
-            log.Fatalf("ERROR: ColumnTypes() failed. err: %v", err)
-        }
-        // The data type of the zeroeth column in the row.
-        column_type := column_types[0].ScanType()
-        // Choose the appropriate variable based on the data type.
-        switch column_type {
-            case reflect.TypeOf(i64):
-                err = rows.Scan(&i64)
-                fmt.Println("INFO: retrieved int64 value:")
-                fmt.Println(i64)
-            case reflect.TypeOf(bigIntPtr):
-                err = rows.Scan(&bigIntPtr)
-                fmt.Println("INFO: retrieved bigIntPtr value:")
-                fmt.Println(bigIntPtr)
-        }
-    }
+	for rows.Next() {
+	    // Get the data type info.
+	    column_types, err := rows.ColumnTypes()
+	    if err != nil {
+	        log.Fatalf("ERROR: ColumnTypes() failed. err: %v", err)
+	    }
+	    // The data type of the zeroeth column in the row.
+	    column_type := column_types[0].ScanType()
+	    // Choose the appropriate variable based on the data type.
+	    switch column_type {
+	        case reflect.TypeOf(i64):
+	            err = rows.Scan(&i64)
+	            fmt.Println("INFO: retrieved int64 value:")
+	            fmt.Println(i64)
+	        case reflect.TypeOf(bigIntPtr):
+	            err = rows.Scan(&bigIntPtr)
+	            fmt.Println("INFO: retrieved bigIntPtr value:")
+	            fmt.Println(bigIntPtr)
+	    }
+	}
 
-
-Binding Parameters
+# Binding Parameters
 
 Binding allows a SQL statement to use a value that is stored in a Golang variable.
 
 Without binding, a SQL statement specifies values by specifying literals inside the statement.
-For example, the following statement uses the literal value ``42`` in an UPDATE statement:
+For example, the following statement uses the literal value “42“ in an UPDATE statement:
 
 	_, err = db.Exec("UPDATE table1 SET integer_column = 42 WHERE ID = 1000")
 
@@ -391,13 +395,12 @@ With binding, you can execute a SQL statement that uses a value that is inside a
 	var my_integer_variable int = 42
 	_, err = db.Exec("UPDATE table1 SET integer_column = ? WHERE ID = 1000", my_integer_variable)
 
-The ``?`` inside the ``VALUES`` clause specifies that the SQL statement uses the value from a variable.
+The “?“ inside the “VALUES“ clause specifies that the SQL statement uses the value from a variable.
 
 Binding data that involves time zones can require special handling. For details, see the section
 titled "Timestamps with Time Zones".
 
-
-Binding Parameters to Array Variables
+# Binding Parameters to Array Variables
 
 Version 1.3.9 (and later) of the Go Snowflake Driver supports the ability to bind an array variable to a parameter in a SQL
 INSERT statement. You can use this technique to insert multiple rows in a single batch.
@@ -420,30 +423,30 @@ binds arrays to the parameters in the INSERT statement.
 If the array contains SQL NULL values, use slice []interface{}, which allows Golang nil values.
 This feature is available in version 1.6.12 (and later) of the driver. For exmaple,
 
- 	// Define the arrays containing the data to insert.
- 	strArray := make([]interface{}, 3)
-	strArray[0] = "test1"
-	strArray[1] = "test2"
-	strArray[2] = nil // This line is optional as nil is the default value.
-	...
-	// Create a table and insert the data from the array as shown above.
-	_, err = db.Exec("create or replace table my_table(c1 string)")
-	_, err = db.Exec("insert into my_table values (?)", Array(&strArray))
-	...
-	// Use sql.NullString to fetch the string column that contains NULL values.
-	var s sql.NullString
-	rows, _ := db.Query("select * from my_table")
-	for rows.Next() {
-		err := rows.Scan(&s)
-		if err != nil {
-			log.Fatalf("Failed to scan. err: %v", err)
+	 	// Define the arrays containing the data to insert.
+	 	strArray := make([]interface{}, 3)
+		strArray[0] = "test1"
+		strArray[1] = "test2"
+		strArray[2] = nil // This line is optional as nil is the default value.
+		...
+		// Create a table and insert the data from the array as shown above.
+		_, err = db.Exec("create or replace table my_table(c1 string)")
+		_, err = db.Exec("insert into my_table values (?)", Array(&strArray))
+		...
+		// Use sql.NullString to fetch the string column that contains NULL values.
+		var s sql.NullString
+		rows, _ := db.Query("select * from my_table")
+		for rows.Next() {
+			err := rows.Scan(&s)
+			if err != nil {
+				log.Fatalf("Failed to scan. err: %v", err)
+			}
+			if s.Valid {
+				fmt.Println("Retrieved value:", s.String)
+			} else {
+				fmt.Println("Retrieved value: NULL")
+			}
 		}
-		if s.Valid {
-			fmt.Println("Retrieved value:", s.String)
-		} else {
-			fmt.Println("Retrieved value: NULL")
-		}
-	}
 
 For slices []interface{} containing time.Time values, a binding parameter flag is required for the preceding array variable in the Array() function.
 This feature is available in version 1.6.13 (and later) of the driver. For exmaple,
@@ -454,8 +457,7 @@ This feature is available in version 1.6.13 (and later) of the driver. For exmap
 Note: For alternative ways to load data into the Snowflake database (including bulk loading using the COPY command), see
 Loading Data into Snowflake (https://docs.snowflake.com/en/user-guide-data-load.html).
 
-
-Batch Inserts and Binding Parameters
+# Batch Inserts and Binding Parameters
 
 When you use array binding to insert a large number of values, the driver can
 improve performance by streaming the data (without creating files on the local
@@ -464,7 +466,7 @@ when the number of values exceeds a threshold (no changes are needed to user cod
 
 In order for the driver to send the data to a temporary stage, the user must have the following privilege on the schema:
 
-    CREATE STAGE
+	CREATE STAGE
 
 If the user does not have this privilege, the driver falls back to sending the data with the query to the Snowflake database.
 
@@ -477,8 +479,7 @@ the CREATE TEMPORARY STAGE command executed by the driver can fail with the foll
 For alternative ways to load data into the Snowflake database (including bulk loading using the COPY command),
 see Loading Data into Snowflake (https://docs.snowflake.com/en/user-guide-data-load.html).
 
-
-Binding a Parameter to a Time Type
+# Binding a Parameter to a Time Type
 
 Go's database/sql package supports the ability to bind a parameter in a SQL statement to a time.Time variable.
 However, when the client binds data to send to the server, the driver cannot determine the correct Snowflake date/timestamp data
@@ -507,7 +508,7 @@ or BINARY data type. The above example could be rewritten as follows:
 	// ...
 	_, err = stmt.Exec(sf.DataTypeTimestampNtz, tmValue, sf.DataTypeTimestampLtz, tmValue)
 
-Timestamps with Time Zones
+# Timestamps with Time Zones
 
 The driver fetches TIMESTAMP_TZ (timestamp with time zone) data using the
 offset-based Location types, which represent a collection of time offsets in
@@ -520,7 +521,7 @@ Currently, Snowflake does not support the name-based Location types (e.g. "Ameri
 
 For more information about Location types, see the Go documentation for https://golang.org/pkg/time/#Location.
 
-Binary Data
+# Binary Data
 
 Internally, this feature leverages the []byte data type. As a result, BINARY
 data cannot be bound without the binding parameter flag. In the following
@@ -529,7 +530,7 @@ example, sf is an alias for the gosnowflake package:
 	var b = []byte{0x01, 0x02, 0x03}
 	_, err = stmt.Exec(sf.DataTypeBinary, b)
 
-Maximum Number of Result Set Chunk Downloader
+# Maximum Number of Result Set Chunk Downloader
 
 The driver directly downloads a result set from the cloud storage if the size is large. It is
 required to shift workloads from the Snowflake database to the clients for scale. The download takes place by goroutine
@@ -543,7 +544,6 @@ memory footprint by itself. Consider Custom JSON Decoder.
 		sf "github.com/snowflakedb/gosnowflake"
 	)
 	sf.MaxChunkDownloadWorkers = 2
-
 
 Custom JSON Decoder for Parsing Result Set (Experimental)
 
@@ -559,7 +559,7 @@ This option will reduce the memory footprint to half or even quarter, but it can
 performance depending on the environment. The test cases running on Travis Ubuntu box show five times less memory
 footprint while four times slower. Be cautious when using the option.
 
-JWT authentication
+# JWT authentication
 
 The Go Snowflake Driver supports JWT (JSON Web Token) authentication.
 
@@ -584,23 +584,22 @@ The <your_public_key> should be a base64 Standard encoded PKI public key string.
 
 To generate the valid key pair, you can execute the following commands in the shell:
 
-	# generate 2048-bit pkcs8 encoded RSA private key
-	openssl genpkey -algorithm RSA \
-    	-pkeyopt rsa_keygen_bits:2048 \
-    	-pkeyopt rsa_keygen_pubexp:65537 | \
-  		openssl pkcs8 -topk8 -outform der > rsa-2048-private-key.p8
+		# generate 2048-bit pkcs8 encoded RSA private key
+		openssl genpkey -algorithm RSA \
+	    	-pkeyopt rsa_keygen_bits:2048 \
+	    	-pkeyopt rsa_keygen_pubexp:65537 | \
+	  		openssl pkcs8 -topk8 -outform der > rsa-2048-private-key.p8
 
-	# extract 2048-bit PKI encoded RSA public key from the private key
-	openssl pkey -pubout -inform der -outform der \
-    	-in rsa-2048-private-key.p8 \
-    	-out rsa-2048-public-key.spki
+		# extract 2048-bit PKI encoded RSA public key from the private key
+		openssl pkey -pubout -inform der -outform der \
+	    	-in rsa-2048-private-key.p8 \
+	    	-out rsa-2048-public-key.spki
 
 Note: As of February 2020, Golang's official library does not support passcode-encrypted PKCS8 private key.
 For security purposes, Snowflake highly recommends that you store the passcode-encrypted private key on the disk and
 decrypt the key in your application using a library you trust.
 
-
-Executing Multiple Statements in One Call
+# Executing Multiple Statements in One Call
 
 This feature is available in version 1.3.8 or later of the driver.
 
@@ -614,8 +613,8 @@ inject a statement by appending it. More details are below.
 
 The Go Snowflake Driver provides two functions that can execute multiple SQL statements in a single call:
 
-	* db.QueryContext(): This function is used to execute queries, such as SELECT statements, that return a result set.
-	* db.ExecContext(): This function is used to execute statements that don't return a result set (i.e. most DML and DDL statements).
+  - db.QueryContext(): This function is used to execute queries, such as SELECT statements, that return a result set.
+  - db.ExecContext(): This function is used to execute statements that don't return a result set (i.e. most DML and DDL statements).
 
 To compose a multi-statement query, simply create a string that contains all the queries, separated by semicolons,
 in the order in which the statements should be executed.
@@ -670,21 +669,19 @@ available.
 
 The following code shows how to retrieve the result of a multi-statement query executed through db.ExecContext():
 
-    Execute the SQL statements:
+	Execute the SQL statements:
 
-        res, err := db.ExecContext(ctx, multiStmtQuery)
+	    res, err := db.ExecContext(ctx, multiStmtQuery)
 
-    Get the summed result and store it in the variable named count:
+	Get the summed result and store it in the variable named count:
 
-        count, err := res.RowsAffected()
-
+	    count, err := res.RowsAffected()
 
 Note: Because a multi-statement ExecContext() returns a single value, you cannot detect offsetting errors.
 For example, suppose you expected the return value to be 20 because you expected each UPDATE statement to
 update 10 rows. If one UPDATE statement updated 15 rows and the other UPDATE statement updated only 5
 rows, the total would still be 20. You would see no indication that the UPDATES had not functioned as
 expected.
-
 
 The ExecContext() function does not return an error if passed a query (e.g. a SELECT statement). However, it
 still returns only a single value, not a result set, so using it to execute queries (or a mix of queries and non-query
@@ -701,13 +698,11 @@ and you can retrieve or ignore the row counts for the non-query statements.
 
 Note: PUT statements are not supported for multi-statement queries.
 
-
 If a SQL statement passed to ExecQuery() or QueryContext() fails to compile or execute, that statement is
 aborted, and subsequent statements are not executed. Any statements prior to the aborted statement are unaffected.
 
 For example, if the statements below are run as one multi-statement query, the multi-statement query fails on the
 third statement, and an exception is thrown.
-
 
 	CREATE OR REPLACE TABLE test(n int);
 	INSERT INTO TEST VALUES (1), (2);
@@ -726,8 +721,7 @@ example:
 
 Preparing statements and using bind variables are also not supported for multi-statement queries.
 
-
-Asynchronous Queries
+# Asynchronous Queries
 
 The Go Snowflake Driver supports asynchronous execution of SQL statements.
 Asynchronous execution allows you to start executing a statement and then
@@ -761,12 +755,12 @@ asynchronous mode and synchronous mode.
 The function db.QueryContext() returns an object of type snowflakeRows
 regardless of whether the query is synchronous or asynchronous. However:
 
-	* If the query is synchronous, then db.QueryContext() does not return until
-		the query has finished and the result set has been loaded into the
-		snowflakeRows object.
-	* If the query is asynchronous, then db.QueryContext() returns a
-		potentially incomplete snowflakeRows object that is filled in later
-		in the background.
+  - If the query is synchronous, then db.QueryContext() does not return until
+    the query has finished and the result set has been loaded into the
+    snowflakeRows object.
+  - If the query is asynchronous, then db.QueryContext() returns a
+    potentially incomplete snowflakeRows object that is filled in later
+    in the background.
 
 The call to the Next() function of snowflakeRows is always synchronous (i.e. blocking).
 If the query has not yet completed and the snowflakeRows object (named "rows" in this
@@ -788,47 +782,46 @@ asynchronous handling. However, the technique works for larger data sets, and fo
 situations where the programmer might want to do other work after starting the queries
 and before retrieving the results.
 
-	package gosnowflake
+		package gosnowflake
 
-	import  (
-		"context"
-		"database/sql"
-		"database/sql/driver"
-		"fmt"
-		"log"
-		"os"
-		sf "github.com/snowflakedb/gosnowflake"
-    )
+		import  (
+			"context"
+			"database/sql"
+			"database/sql/driver"
+			"fmt"
+			"log"
+			"os"
+			sf "github.com/snowflakedb/gosnowflake"
+	    )
 
-	...
+		...
 
-	func DemonstrateAsyncMode(db *sql.DB) {
-		// Enable asynchronous mode.
-		ctx := WithAsyncMode(context.Background())
-		// Establish connection
-		conn, _ := db.Conn(ctx)
+		func DemonstrateAsyncMode(db *sql.DB) {
+			// Enable asynchronous mode.
+			ctx := WithAsyncMode(context.Background())
+			// Establish connection
+			conn, _ := db.Conn(ctx)
 
-		// Unwrap connection
-		err = conn.Raw(func(x interface{}) error {
-			// Execute asynchronous query
-			rows, _ := x.(driver.QueryerContext).QueryContext(ctx, "select 1", nil)
-			defer rows.Close()
+			// Unwrap connection
+			err = conn.Raw(func(x interface{}) error {
+				// Execute asynchronous query
+				rows, _ := x.(driver.QueryerContext).QueryContext(ctx, "select 1", nil)
+				defer rows.Close()
 
-			// Retrieve and check results of the query after casting the result
-			status := rows.(SnowflakeResult).GetStatus()
-			if status == QueryStatusComplete {
-				// do something
-			} else if status == QueryStatusInProgress {
-				// do something
-			} else if status == QueryFailed {
-				// do something
-			}
-			return nil
-		})
-	}
+				// Retrieve and check results of the query after casting the result
+				status := rows.(SnowflakeResult).GetStatus()
+				if status == QueryStatusComplete {
+					// do something
+				} else if status == QueryStatusInProgress {
+					// do something
+				} else if status == QueryFailed {
+					// do something
+				}
+				return nil
+			})
+		}
 
-
-Support For PUT and GET
+# Support For PUT and GET
 
 The Go Snowflake Driver supports the PUT and GET commands.
 
@@ -838,15 +831,15 @@ copies data files from a stage on the cloud platform to a local computer.
 
 See the following for information on the syntax and supported parameters:
 
-  * PUT: https://docs.snowflake.com/en/sql-reference/sql/put.html
-  * GET: https://docs.snowflake.com/en/sql-reference/sql/get.html
+  - PUT: https://docs.snowflake.com/en/sql-reference/sql/put.html
+  - GET: https://docs.snowflake.com/en/sql-reference/sql/get.html
 
-Using PUT
+# Using PUT
 
 The following example shows how to run a PUT command by passing a string to the
 db.Query() function:
 
-  db.Query("PUT file://<local_file> <stage_identifier> <optional_parameters>")
+	db.Query("PUT file://<local_file> <stage_identifier> <optional_parameters>")
 
 "<local_file>" should include the file path as well as the name. Snowflake recommends
 using an absolute path rather than a relative path. For example:
@@ -877,17 +870,16 @@ To send information from a stream (rather than a file) use code similar to the c
 
 Note: PUT statements are not supported for multi-statement queries.
 
-Using GET
+# Using GET
 
 The following example shows how to run a GET command by passing a string to the
 db.Query() function:
 
-  db.Query("GET file://<local_file> <stage_identifier> <optional_parameters>")
+	db.Query("GET file://<local_file> <stage_identifier> <optional_parameters>")
 
 "<local_file>" should include the file path as well as the name. Snowflake recommends using
 an absolute path rather than a relative path. For example:
 
-  db.Query("GET file:///tmp/my_data_file @~ auto_compress=false overwrite=false")
-
+	db.Query("GET file:///tmp/my_data_file @~ auto_compress=false overwrite=false")
 */
 package gosnowflake

--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 )
@@ -173,7 +172,7 @@ func encryptFile(
 	if chunkSize == 0 {
 		chunkSize = aes.BlockSize * 4 * 1024
 	}
-	tmpOutputFile, err := ioutil.TempFile(tmpDir, baseName(filename)+"#")
+	tmpOutputFile, err := os.CreateTemp(tmpDir, baseName(filename)+"#")
 	if err != nil {
 		return nil, "", err
 	}
@@ -225,7 +224,7 @@ func decryptFile(
 	}
 	mode := cipher.NewCBCDecrypter(block, ivBytes)
 
-	tmpOutputFile, err := ioutil.TempFile(tmpDir, baseName(filename)+"#")
+	tmpOutputFile, err := os.CreateTemp(tmpDir, baseName(filename)+"#")
 	if err != nil {
 		return "", err
 	}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -7,7 +7,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -60,7 +59,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 		t.Error(err)
 	}
 	defer fd.Close()
-	content, err := ioutil.ReadAll(fd)
+	content, err := io.ReadAll(fd)
 	if err != nil {
 		t.Error(err)
 	}
@@ -91,7 +90,7 @@ func TestEncryptDecryptFilePadding(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		tmpDir, err := ioutil.TempDir("", "data")
+		tmpDir, err := os.MkdirTemp("", "data")
 		if err != nil {
 			t.Error(err)
 		}
@@ -113,7 +112,7 @@ func TestEncryptDecryptLargeFile(t *testing.T) {
 
 	numberOfFiles := 1
 	numberOfLines := 10000
-	tmpDir, err := ioutil.TempDir("", "data")
+	tmpDir, err := os.MkdirTemp("", "data")
 	if err != nil {
 		t.Error(err)
 	}
@@ -163,7 +162,7 @@ func encryptDecryptFile(t *testing.T, encMat snowflakeFileEncryption, expected i
 
 func generateKLinesOfNByteRows(numLines int, numBytes int, tmpDir string) (string, error) {
 	if tmpDir == "" {
-		_, err := ioutil.TempDir(tmpDir, "data")
+		_, err := os.MkdirTemp(tmpDir, "data")
 		if err != nil {
 			return "", err
 		}
@@ -185,7 +184,7 @@ func generateKLinesOfNByteRows(numLines int, numBytes int, tmpDir string) (strin
 
 func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string, error) {
 	if tmpDir == "" {
-		_, err := ioutil.TempDir(tmpDir, "data")
+		_, err := os.MkdirTemp(tmpDir, "data")
 		if err != nil {
 			return "", err
 		}
@@ -230,8 +229,8 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 					return "", err
 				}
 				gzipCmd.Start()
-				ioutil.ReadAll(gzipOut)
-				ioutil.ReadAll(gzipErr)
+				io.ReadAll(gzipOut)
+				io.ReadAll(gzipErr)
 				gzipCmd.Wait()
 			} else {
 				fOut, err := os.OpenFile(fname+".gz", os.O_CREATE|os.O_WRONLY, os.ModePerm)

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -467,7 +466,7 @@ func (sfa *snowflakeFileTransferAgent) processFileCompressionType() error {
 					if err != nil {
 						return err
 					}
-					ioutil.ReadAll(r) // flush out tee buffer
+					io.ReadAll(r) // flush out tee buffer
 				} else {
 					mtype, err = mimetype.DetectFile(fileName)
 					if err != nil {
@@ -829,7 +828,7 @@ func (sfa *snowflakeFileTransferAgent) uploadFilesSequential(fileMetas []*fileMe
 
 func (sfa *snowflakeFileTransferAgent) uploadOneFile(meta *fileMetadata) (*fileMetadata, error) {
 	meta.realSrcFileName = meta.srcFileName
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, err
 	}
@@ -976,7 +975,7 @@ func (sfa *snowflakeFileTransferAgent) downloadFilesSequential(fileMetas []*file
 }
 
 func (sfa *snowflakeFileTransferAgent) downloadOneFile(meta *fileMetadata) (*fileMetadata, error) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/file_util.go
+++ b/file_util.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	usr "os/user"
@@ -25,7 +24,7 @@ const (
 
 func (util *snowflakeFileUtil) compressFileWithGzipFromStream(srcStream **bytes.Buffer) (*bytes.Buffer, int, error) {
 	r := getReaderFromBuffer(srcStream)
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snowflakedb/gosnowflake
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/azure-storage-blob-go v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -210,7 +210,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220630215102-69896b714898/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20221002022538-bcab6841153b h1:6e93nYa3hNqAvLr0pD4PN1fFS+gKzp2zAXqrnTCstqU=
@@ -239,7 +238,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25 h1:nwzwVf0l2Y/lkov/+IYgMMbFyI+QypZDds9RxlSmsFQ=
 golang.org/x/sys v0.0.0-20220926163933-8cfa568d3c25/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -83,7 +83,7 @@ func (hc *heartbeat) heartbeatMain() error {
 		}
 		return nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Errorf("failed to extract HTTP response body. err: %v", err)
 		return err

--- a/local_storage_client.go
+++ b/local_storage_client.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -97,11 +96,11 @@ func (util *localUtil) downloadOneFile(meta *fileMetadata) error {
 		}
 	}
 
-	data, err := ioutil.ReadFile(fullSrcFileName)
+	data, err := os.ReadFile(fullSrcFileName)
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(fullDstFileName, data, os.ModePerm); err != nil {
+	if err = os.WriteFile(fullDstFileName, data, os.ModePerm); err != nil {
 		return err
 	}
 	fi, err := os.Stat(fullDstFileName)

--- a/log.go
+++ b/log.go
@@ -12,16 +12,16 @@ import (
 	"time"
 )
 
-//SFSessionIDKey is context key of session id
+// SFSessionIDKey is context key of session id
 const SFSessionIDKey contextKey = "LOG_SESSION_ID"
 
-//SFSessionUserKey is context key of  user id of a session
+// SFSessionUserKey is context key of  user id of a session
 const SFSessionUserKey contextKey = "LOG_USER"
 
-//LogKeys these keys in context should be included in logging messages when using logger.WithContext
+// LogKeys these keys in context should be included in logging messages when using logger.WithContext
 var LogKeys = [...]contextKey{SFSessionIDKey, SFSessionUserKey}
 
-//SFLogger Snowflake logger interface to expose FieldLogger defined in logrus
+// SFLogger Snowflake logger interface to expose FieldLogger defined in logrus
 type SFLogger interface {
 	rlog.Ext1FieldLogger
 	SetLogLevel(level string) error
@@ -29,7 +29,7 @@ type SFLogger interface {
 	SetOutput(output io.Writer)
 }
 
-//SFCallerPrettyfier to provide base file name and function name from calling frame used in SFLogger
+// SFCallerPrettyfier to provide base file name and function name from calling frame used in SFLogger
 func SFCallerPrettyfier(frame *runtime.Frame) (string, string) {
 	return path.Base(frame.Function), fmt.Sprintf("%s:%d", path.Base(frame.File), frame.Line)
 }
@@ -38,7 +38,7 @@ type defaultLogger struct {
 	inner *rlog.Logger
 }
 
-//SetLogLevel set logging level for calling defaultLogger
+// SetLogLevel set logging level for calling defaultLogger
 func (log *defaultLogger) SetLogLevel(level string) error {
 	actualLevel, err := rlog.ParseLevel(level)
 	if err != nil {
@@ -48,13 +48,13 @@ func (log *defaultLogger) SetLogLevel(level string) error {
 	return nil
 }
 
-//WithContext return Entry to include fields in context
+// WithContext return Entry to include fields in context
 func (log *defaultLogger) WithContext(ctx context.Context) *rlog.Entry {
 	fields := context2Fields(ctx)
 	return log.inner.WithFields(*fields)
 }
 
-//CreateDefaultLogger return a new instance of SFLogger with default config
+// CreateDefaultLogger return a new instance of SFLogger with default config
 func CreateDefaultLogger() SFLogger {
 	var rLogger = rlog.New()
 	var formatter = rlog.TextFormatter{CallerPrettyfier: SFCallerPrettyfier}

--- a/ocsp.go
+++ b/ocsp.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -430,7 +429,7 @@ func retryOCSP(
 		}
 	}
 	logger.Debug("reading contents")
-	ocspResBytes, err = ioutil.ReadAll(res.Body)
+	ocspResBytes, err = io.ReadAll(res.Body)
 	if err != nil {
 		return ocspRes, ocspResBytes, &ocspStatus{
 			code: ocspFailedExtractResponse,
@@ -858,7 +857,7 @@ func writeOCSPCacheFile() {
 		logger.Debugf("failed to convert OCSP Response cache to JSON. ignored.")
 		return
 	}
-	if err = ioutil.WriteFile(cacheFileName, j, 0644); err != nil {
+	if err = os.WriteFile(cacheFileName, j, 0644); err != nil {
 		logger.Debugf("failed to write OCSP Response cache. err: %v. ignored.\n", err)
 	}
 }

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -58,7 +57,7 @@ func TestOCSP(t *testing.T) {
 					t.Fatalf("failed to GET contents. err: %v", err)
 				}
 				defer res.Body.Close()
-				_, err = ioutil.ReadAll(res.Body)
+				_, err = io.ReadAll(res.Body)
 				if err != nil {
 					t.Fatalf("failed to read content body for %v", tgt)
 				}

--- a/priv_key_test.go
+++ b/priv_key_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -50,7 +49,7 @@ func setupPrivateKey() {
 	} else {
 		// path to the DER file
 		customPrivateKey = true
-		data, _ := ioutil.ReadFile(privKeyPath)
+		data, _ := os.ReadFile(privKeyPath)
 		block, _ := pem.Decode(data)
 		if block == nil || block.Type != "PRIVATE KEY" {
 			panic(fmt.Sprintf("%v is not a public key in PEM format.", privKeyPath))

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/user"
@@ -35,7 +34,7 @@ func TestPutError(t *testing.T) {
 	if isWindows {
 		t.Skip("permission model is different")
 	}
-	tmpDir, err := ioutil.TempDir("", "putfiledir")
+	tmpDir, err := os.MkdirTemp("", "putfiledir")
 	if err != nil {
 		t.Error(err)
 	}
@@ -243,7 +242,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 	if runningOnGithubAction() && !runningOnAWS() {
 		t.Skip("skipping non aws environment")
 	}
-	tmpDir, err := ioutil.TempDir("", "put")
+	tmpDir, err := os.MkdirTemp("", "put")
 	if err != nil {
 		t.Error(err)
 	}
@@ -283,7 +282,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 }
 
 func TestPutOverwrite(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "data")
+	tmpDir, err := os.MkdirTemp("", "data")
 	if err != nil {
 		t.Error(err)
 	}
@@ -374,7 +373,7 @@ func TestPutGetStream(t *testing.T) {
 }
 
 func testPutGet(t *testing.T, isStream bool) {
-	tmpDir, err := ioutil.TempDir("", "put_get")
+	tmpDir, err := os.MkdirTemp("", "put_get")
 	if err != nil {
 		t.Error(err)
 	}
@@ -387,7 +386,7 @@ func testPutGet(t *testing.T, isStream bool) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 

--- a/put_get_user_stage_test.go
+++ b/put_get_user_stage_test.go
@@ -3,7 +3,6 @@ package gosnowflake
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,7 +28,7 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
 		t.Fatal("no aws secret access key found")
 	}
-	tmpDir, err := ioutil.TempDir(tmpDir, "data")
+	tmpDir, err := os.MkdirTemp(tmpDir, "data")
 	if err != nil {
 		t.Error(err)
 	}
@@ -40,7 +39,7 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 	defer os.RemoveAll(tmpDir)
 	var files string
 	if isStream {
-		list, err := ioutil.ReadDir(tmpDir)
+		list, err := os.ReadDir(tmpDir)
 		if err != nil {
 			t.Error(err)
 		}

--- a/put_get_with_aws_test.go
+++ b/put_get_with_aws_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -90,7 +89,7 @@ func TestPutWithInvalidToken(t *testing.T) {
 	if !runningOnAWS() {
 		t.Skip("skipping non aws environment")
 	}
-	tmpDir, err := ioutil.TempDir("", "aws_put")
+	tmpDir, err := os.MkdirTemp("", "aws_put")
 	if err != nil {
 		t.Error(err)
 	}
@@ -102,7 +101,7 @@ func TestPutWithInvalidToken(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -202,7 +201,7 @@ func TestPretendToPutButList(t *testing.T) {
 	if runningOnGithubAction() && !runningOnAWS() {
 		t.Skip("skipping non aws environment")
 	}
-	tmpDir, err := ioutil.TempDir("", "aws_put")
+	tmpDir, err := os.MkdirTemp("", "aws_put")
 	if err != nil {
 		t.Error(err)
 	}
@@ -214,7 +213,7 @@ func TestPretendToPutButList(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -269,7 +268,7 @@ func TestPutGetAWSStage(t *testing.T) {
 		t.Skip("skipping non aws environment")
 	}
 
-	tmpDir, err := ioutil.TempDir("", "put_get")
+	tmpDir, err := os.MkdirTemp("", "put_get")
 	if err != nil {
 		t.Error(err)
 	}
@@ -283,7 +282,7 @@ func TestPutGetAWSStage(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = ioutil.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 

--- a/restful.go
+++ b/restful.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -271,7 +271,7 @@ func postRestfulQueryHelper(
 		}
 		return &respd, nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
@@ -321,7 +321,7 @@ func closeSession(ctx context.Context, sr *snowflakeRestful, timeout time.Durati
 		}
 		return nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return err
@@ -382,7 +382,7 @@ func renewRestfulSession(ctx context.Context, sr *snowflakeRestful, timeout time
 		sr.TokenAccessor.SetTokens(respd.Data.SessionToken, respd.Data.MasterToken, respd.Data.SessionID)
 		return nil
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return err
@@ -461,7 +461,7 @@ func cancelQuery(ctx context.Context, sr *snowflakeRestful, requestID UUID, time
 			}
 		}
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return err

--- a/retry.go
+++ b/retry.go
@@ -74,7 +74,8 @@ type requestGUIDReplace struct {
 	urlValues url.Values
 }
 
-/**
+/*
+*
 This function would replace they value of the requestGUIDKey in a url with a newly
 generated UUID
 */


### PR DESCRIPTION
### Description
Drop support for go 1.17 and add support for go 1.19

io/util package is deprecated with 1.16. This also replaces usages with either os or io.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
