### PR TITLE
Updated expected result after scan bytes fix on the server side

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -410,7 +410,7 @@ func TestGetQueryStatus(t *testing.T) {
 		t.Fatal("there was no query status returned")
 	}
 
-	if qStatus.ErrorCode != "" || qStatus.ScanBytes != 1536 || qStatus.ProducedRows != 10 {
+	if qStatus.ErrorCode != "" || qStatus.ScanBytes != 2048 || qStatus.ProducedRows != 10 {
 		t.Errorf("expected no error. got: %v, scan bytes: %v, produced rows: %v",
 			qStatus.ErrorCode, qStatus.ScanBytes, qStatus.ProducedRows)
 	}


### PR DESCRIPTION
### Description
There was a fix for scan bytes deployed on the snowflake server around end of September and caused the test TestGetQueryStatus to fail. This PR updates the expected result in the test.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
