### PR TITLE
Ignore 405 error when S3 Acceleration is disabled on the S3 bucket

### DIFF
--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -615,6 +615,8 @@ func (sfa *snowflakeFileTransferAgent) transferAccelerateConfig() error {
 			if errors.As(err, &ae) {
 				if ae.ErrorCode() == "AccessDenied" {
 					return nil
+				} else if ae.ErrorCode() == "MethodNotAllowed" {
+					return nil
 				}
 			}
 			return err

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
+
+package gosnowflake
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/smithy-go"
+)
+
+func TestGetBucketAccelerateConfiguration(t *testing.T) {
+	if runningOnGithubAction() {
+		t.Skip("Should be run against an account in AWS EU North1 region.")
+	}
+	config, err := ParseDSN(dsn)
+	if err != nil {
+		t.Error(err)
+	}
+	sc, err := buildSnowflakeConn(context.Background(), *config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = authenticateWithConfig(sc); err != nil {
+		t.Fatal(err)
+	}
+	sfa := &snowflakeFileTransferAgent{
+		sc:          sc,
+		commandType: uploadCommand,
+		srcFiles:    make([]string, 0),
+		data: &execResponseData{
+			SrcLocations: make([]string, 0),
+		},
+	}
+	if err = sfa.transferAccelerateConfig(); err != nil {
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			if ae.ErrorCode() == "MethodNotAllowed" {
+				t.Fatalf("should have ignored 405 error: %v", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description
Simba Salesforce ticket number 00406729.

Description provided by Snowflake Support:
When we need to upload a file to an internal stage using the PUT command it fails when GetBucketAccelerateConfiguration returns 405.

It happens when the driver tries to use the S3 acceleration service on the accounts where the S3 Acceleration is disabled on the buckets. 

Observed behavior:
The driver fails with: ERRO[0000]connection.go:318 gosnowflake.(*snowflakeConn).queryContextInternal error: operation error S3: GetBucketAccelerateConfiguration, https response error StatusCode:
The file is not uploaded
In Snowflake job history the PUT query appears successful

Expected behavior:
The 405 error appears in the log
The file is uploaded
In Snowflake job history the PUT query appears successful
(This is how it is implemented in the python connector.)

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
