### PR TITLE
Arrow decoding memory cleanup

### DIFF
--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -44,7 +44,7 @@ func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType, hig
 
 		for colIdx, col := range columns {
 			values := make([]snowflakeValue, numRows)
-			if err = arrowToValue(&values, rowType[colIdx], col, arc.loc, highPrec); err != nil {
+			if err = arrowToValue(values, rowType[colIdx], col, arc.loc, highPrec); err != nil {
 				return nil, err
 			}
 

--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -14,11 +14,9 @@ import (
 )
 
 type arrowResultChunk struct {
-	reader           ipc.Reader
-	rowCount         int
-	uncompressedSize int
-	allocator        memory.Allocator
-	loc              *time.Location
+	reader   ipc.Reader
+	rowCount int
+	loc      *time.Location
 }
 
 func (arc *arrowResultChunk) decodeArrowChunk(rowType []execResponseRowType, highPrec bool) ([]chunkRowType, error) {

--- a/auth.go
+++ b/auth.go
@@ -409,7 +409,6 @@ func authenticate(
 		}
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
-			code = -1
 			return nil, err
 		}
 		return nil, (&SnowflakeError{

--- a/authokta.go
+++ b/authokta.go
@@ -95,7 +95,6 @@ func authenticateBySAML(
 		sr.TokenAccessor.SetTokens("", "", -1)
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
-			code = -1
 			return nil, err
 		}
 		return nil, &SnowflakeError{

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -56,7 +56,6 @@ type snowflakeChunkDownloader struct {
 	ChunksFinalErrors  []*chunkError
 	ChunksMutex        *sync.Mutex
 	DoneDownloadCond   *sync.Cond
-	FirstBatch         *ArrowBatch
 	NextDownloader     chunkDownloader
 	Qrmk               string
 	QueryResultFormat  string
@@ -243,10 +242,7 @@ func (scd *snowflakeChunkDownloader) getRowType() []execResponseRowType {
 }
 
 func (scd *snowflakeChunkDownloader) getArrowBatches() []*ArrowBatch {
-	if scd.FirstBatch.rec == nil {
-		return scd.ArrowBatches
-	}
-	return append([]*ArrowBatch{scd.FirstBatch}, scd.ArrowBatches...)
+	return scd.ArrowBatches
 }
 
 func getChunk(
@@ -264,27 +260,8 @@ func getChunk(
 }
 
 func (scd *snowflakeChunkDownloader) startArrowBatches() error {
-	var err error
-	chunkMetaLen := len(scd.ChunkMetas)
-	var loc *time.Location
-	if scd.sc != nil {
-		loc = getCurrentLocation(scd.sc.cfg.Params)
-	}
-	firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc)
-	scd.FirstBatch = &ArrowBatch{
-		idx:                0,
-		scd:                scd,
-		funcDownloadHelper: scd.FuncDownloadHelper,
-	}
-	// decode first chunk if possible
-	if firstArrowChunk.allocator != nil {
-		scd.FirstBatch.rec, err = firstArrowChunk.decodeArrowBatch(scd)
-		if err != nil {
-			return err
-		}
-	}
-	scd.ArrowBatches = make([]*ArrowBatch, chunkMetaLen)
-	for i := 0; i < chunkMetaLen; i++ {
+	scd.ArrowBatches = make([]*ArrowBatch, len(scd.ChunkMetas))
+	for i := 0; i < len(scd.ArrowBatches); i++ {
 		scd.ArrowBatches[i] = &ArrowBatch{
 			idx:                i,
 			scd:                scd,

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -2,32 +2,11 @@ package main
 
 import (
 	"bytes"
-	rlog "github.com/sirupsen/logrus"
-	sf "github.com/snowflakedb/gosnowflake"
 	"log"
 	"strings"
+
+	sf "github.com/snowflakedb/gosnowflake"
 )
-
-type testLogger struct {
-	*rlog.Logger
-}
-
-func (log *testLogger) SetLogLevel(level string) error {
-	actualLevel, err := rlog.ParseLevel(level)
-	if err != nil {
-		return err
-	}
-	log.Level = actualLevel
-	return nil
-}
-
-func createTestLogger() testLogger {
-	var logging = testLogger{rlog.New()}
-	var formatter = rlog.JSONFormatter{CallerPrettyfier: sf.SFCallerPrettyfier}
-	logging.SetReportCaller(true)
-	logging.SetFormatter(&formatter)
-	return logging
-}
 
 func main() {
 	buf := &bytes.Buffer{}

--- a/converter.go
+++ b/converter.go
@@ -139,14 +139,14 @@ func valueToString(v driver.Value, tsmode snowflakeType) (*string, error) {
 			case dateType:
 				_, offset := tm.Zone()
 				tm = tm.Add(time.Second * time.Duration(offset))
-				s := fmt.Sprintf("%d", tm.Unix()*1000)
+				s := strconv.FormatInt(tm.Unix()*1000, 10)
 				return &s, nil
 			case timeType:
-				s := fmt.Sprintf("%d",
-					(tm.Hour()*3600+tm.Minute()*60+tm.Second())*1e9+tm.Nanosecond())
+				ns := (tm.Hour()*3600+tm.Minute()*60+tm.Second())*1e9 + tm.Nanosecond()
+				s := strconv.FormatInt(int64(ns), 10)
 				return &s, nil
 			case timestampNtzType, timestampLtzType:
-				s := fmt.Sprintf("%d", tm.UnixNano())
+				s := strconv.FormatInt(tm.UnixNano(), 10)
 				return &s, nil
 			case timestampTzType:
 				_, offset := tm.Zone()
@@ -336,6 +336,7 @@ func arrowToValue(
 							(*destcol)[i] = f
 						} else {
 							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
+							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
 						}
 					}
 				}
@@ -347,14 +348,14 @@ func arrowToValue(
 						if higherPrecision {
 							(*destcol)[i] = val
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%d", val)
+							(*destcol)[i] = strconv.FormatInt(val, 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(val, srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -366,14 +367,14 @@ func arrowToValue(
 						if higherPrecision {
 							(*destcol)[i] = int64(val)
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%d", val)
+							(*destcol)[i] = strconv.FormatInt(int64(val), 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -385,14 +386,14 @@ func arrowToValue(
 						if higherPrecision {
 							(*destcol)[i] = int64(val)
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%d", val)
+							(*destcol)[i] = strconv.FormatInt(int64(val), 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -404,14 +405,14 @@ func arrowToValue(
 						if higherPrecision {
 							(*destcol)[i] = int64(val)
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%d", val)
+							(*destcol)[i] = strconv.FormatInt(int64(val), 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
 							(*destcol)[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, float64(val)/math.Pow10(int(srcColumnMeta.Scale)))
+							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -742,7 +743,7 @@ func snowflakeArrayToString(nv *driver.NamedValue, stream bool) (snowflakeType, 
 		for _, x := range *a {
 			_, offset := x.Zone()
 			x = x.Add(time.Second * time.Duration(offset))
-			v := fmt.Sprintf("%d", x.Unix()*1000)
+			v := strconv.FormatInt(x.Unix()*1000, 10)
 			arr = append(arr, &v)
 		}
 	case reflect.TypeOf(&timeArray{}):
@@ -858,7 +859,7 @@ func interfaceSliceToString(interfaceSlice reflect.Value, stream bool, tzType ..
 					t = dateType
 					_, offset := x.Zone()
 					x = x.Add(time.Second * time.Duration(offset))
-					v := fmt.Sprintf("%d", x.Unix()*1000)
+					v := strconv.FormatInt(x.Unix()*1000, 10)
 					arr = append(arr, &v)
 				case TimeType:
 					t = timeType

--- a/converter.go
+++ b/converter.go
@@ -304,14 +304,14 @@ func decimalToBigFloat(num decimal128.Num, scale int64) *big.Float {
 // Arrow Interface (Column) converter. This is called when Arrow chunks are
 // downloaded to convert to the corresponding row type.
 func arrowToValue(
-	destcol *[]snowflakeValue,
+	destcol []snowflakeValue,
 	srcColumnMeta execResponseRowType,
 	srcValue array.Interface,
 	loc *time.Location,
 	higherPrecision bool) error {
 	data := srcValue.Data()
 	var err error
-	if len(*destcol) != srcValue.Data().Len() {
+	if len(destcol) != srcValue.Data().Len() {
 		err = fmt.Errorf("array interface length mismatch")
 	}
 	logger.Debugf("snowflake data type: %v, arrow data type: %v", srcColumnMeta.Type, srcValue.DataType())
@@ -326,17 +326,17 @@ func arrowToValue(
 				if !srcValue.IsNull(i) {
 					if srcColumnMeta.Scale == 0 {
 						if higherPrecision {
-							(*destcol)[i] = decimalToBigInt(num)
+							destcol[i] = decimalToBigInt(num)
 						} else {
-							(*destcol)[i] = decimalToBigInt(num).String()
+							destcol[i] = decimalToBigInt(num).String()
 						}
 					} else {
 						f := decimalToBigFloat(num, srcColumnMeta.Scale)
 						if higherPrecision {
-							(*destcol)[i] = f
+							destcol[i] = f
 						} else {
-							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
-							(*destcol)[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
+							destcol[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
+							destcol[i] = fmt.Sprintf("%.*f", srcColumnMeta.Scale, f)
 						}
 					}
 				}
@@ -346,16 +346,16 @@ func arrowToValue(
 				if !srcValue.IsNull(i) {
 					if srcColumnMeta.Scale == 0 {
 						if higherPrecision {
-							(*destcol)[i] = val
+							destcol[i] = val
 						} else {
-							(*destcol)[i] = strconv.FormatInt(val, 10)
+							destcol[i] = strconv.FormatInt(val, 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(val, srcColumnMeta.Scale)
-							(*destcol)[i] = f
+							destcol[i] = f
 						} else {
-							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
+							destcol[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -365,16 +365,16 @@ func arrowToValue(
 				if !srcValue.IsNull(i) {
 					if srcColumnMeta.Scale == 0 {
 						if higherPrecision {
-							(*destcol)[i] = int64(val)
+							destcol[i] = int64(val)
 						} else {
-							(*destcol)[i] = strconv.FormatInt(int64(val), 10)
+							destcol[i] = strconv.FormatInt(int64(val), 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
-							(*destcol)[i] = f
+							destcol[i] = f
 						} else {
-							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
+							destcol[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -384,16 +384,16 @@ func arrowToValue(
 				if !srcValue.IsNull(i) {
 					if srcColumnMeta.Scale == 0 {
 						if higherPrecision {
-							(*destcol)[i] = int64(val)
+							destcol[i] = int64(val)
 						} else {
-							(*destcol)[i] = strconv.FormatInt(int64(val), 10)
+							destcol[i] = strconv.FormatInt(int64(val), 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
-							(*destcol)[i] = f
+							destcol[i] = f
 						} else {
-							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
+							destcol[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -403,16 +403,16 @@ func arrowToValue(
 				if !srcValue.IsNull(i) {
 					if srcColumnMeta.Scale == 0 {
 						if higherPrecision {
-							(*destcol)[i] = int64(val)
+							destcol[i] = int64(val)
 						} else {
-							(*destcol)[i] = strconv.FormatInt(int64(val), 10)
+							destcol[i] = strconv.FormatInt(int64(val), 10)
 						}
 					} else {
 						if higherPrecision {
 							f := intToBigFloat(int64(val), srcColumnMeta.Scale)
-							(*destcol)[i] = f
+							destcol[i] = f
 						} else {
-							(*destcol)[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
+							destcol[i] = strconv.FormatFloat(float64(val)/math.Pow10(int(srcColumnMeta.Scale)), 'f', int(srcColumnMeta.Scale), 64)
 						}
 					}
 				}
@@ -421,9 +421,9 @@ func arrowToValue(
 		return err
 	case booleanType:
 		boolData := array.NewBooleanData(data)
-		for i := range *destcol {
+		for i := range destcol {
 			if !srcValue.IsNull(i) {
-				(*destcol)[i] = boolData.Value(i)
+				destcol[i] = boolData.Value(i)
 			}
 		}
 		return err
@@ -432,23 +432,23 @@ func arrowToValue(
 		// e.g. FLOAT/REAL/DOUBLE
 		for i, flt64 := range array.NewFloat64Data(data).Float64Values() {
 			if !srcValue.IsNull(i) {
-				(*destcol)[i] = flt64
+				destcol[i] = flt64
 			}
 		}
 		return err
 	case textType, arrayType, variantType, objectType:
 		strings := array.NewStringData(data)
-		for i := range *destcol {
+		for i := range destcol {
 			if !srcValue.IsNull(i) {
-				(*destcol)[i] = strings.Value(i)
+				destcol[i] = strings.Value(i)
 			}
 		}
 		return err
 	case binaryType:
 		binaryData := array.NewBinaryData(data)
-		for i := range *destcol {
+		for i := range destcol {
 			if !srcValue.IsNull(i) {
-				(*destcol)[i] = binaryData.Value(i)
+				destcol[i] = binaryData.Value(i)
 			}
 		}
 		return err
@@ -456,7 +456,7 @@ func arrowToValue(
 		for i, date32 := range array.NewDate32Data(data).Date32Values() {
 			if !srcValue.IsNull(i) {
 				t0 := time.Unix(int64(date32)*86400, 0).UTC()
-				(*destcol)[i] = t0
+				destcol[i] = t0
 			}
 		}
 		return err
@@ -465,13 +465,13 @@ func arrowToValue(
 		if srcValue.DataType().ID() == arrow.INT64 {
 			for i, i64 := range array.NewInt64Data(data).Int64Values() {
 				if !srcValue.IsNull(i) {
-					(*destcol)[i] = t0.Add(time.Duration(i64 * int64(math.Pow10(9-int(srcColumnMeta.Scale)))))
+					destcol[i] = t0.Add(time.Duration(i64 * int64(math.Pow10(9-int(srcColumnMeta.Scale)))))
 				}
 			}
 		} else {
 			for i, i32 := range array.NewInt32Data(data).Int32Values() {
 				if !srcValue.IsNull(i) {
-					(*destcol)[i] = t0.Add(time.Duration(int64(i32) * int64(math.Pow10(9-int(srcColumnMeta.Scale)))))
+					destcol[i] = t0.Add(time.Duration(int64(i32) * int64(math.Pow10(9-int(srcColumnMeta.Scale)))))
 				}
 			}
 		}
@@ -481,9 +481,9 @@ func arrowToValue(
 			structData := array.NewStructData(data)
 			epoch := array.NewInt64Data(structData.Field(0).Data()).Int64Values()
 			fraction := array.NewInt32Data(structData.Field(1).Data()).Int32Values()
-			for i := range *destcol {
+			for i := range destcol {
 				if !srcValue.IsNull(i) {
-					(*destcol)[i] = time.Unix(epoch[i], int64(fraction[i])).UTC()
+					destcol[i] = time.Unix(epoch[i], int64(fraction[i])).UTC()
 				}
 			}
 		} else {
@@ -492,7 +492,7 @@ func arrowToValue(
 					scale := int(srcColumnMeta.Scale)
 					epoch := t / int64(math.Pow10(scale))
 					fraction := (t % int64(math.Pow10(scale))) * int64(math.Pow10(9-scale))
-					(*destcol)[i] = time.Unix(epoch, fraction).UTC()
+					destcol[i] = time.Unix(epoch, fraction).UTC()
 				}
 			}
 		}
@@ -502,9 +502,9 @@ func arrowToValue(
 			structData := array.NewStructData(data)
 			epoch := array.NewInt64Data(structData.Field(0).Data()).Int64Values()
 			fraction := array.NewInt32Data(structData.Field(1).Data()).Int32Values()
-			for i := range *destcol {
+			for i := range destcol {
 				if !srcValue.IsNull(i) {
-					(*destcol)[i] = time.Unix(epoch[i], int64(fraction[i])).In(loc)
+					destcol[i] = time.Unix(epoch[i], int64(fraction[i])).In(loc)
 				}
 			}
 		} else {
@@ -512,7 +512,7 @@ func arrowToValue(
 				if !srcValue.IsNull(i) {
 					q := t / int64(math.Pow10(int(srcColumnMeta.Scale)))
 					r := t % int64(math.Pow10(int(srcColumnMeta.Scale)))
-					(*destcol)[i] = time.Unix(q, r).In(loc)
+					destcol[i] = time.Unix(q, r).In(loc)
 				}
 			}
 		}
@@ -522,22 +522,22 @@ func arrowToValue(
 		if structData.NumField() == 2 {
 			epoch := array.NewInt64Data(structData.Field(0).Data()).Int64Values()
 			timezone := array.NewInt32Data(structData.Field(1).Data()).Int32Values()
-			for i := range *destcol {
+			for i := range destcol {
 				if !srcValue.IsNull(i) {
 					loc := Location(int(timezone[i]) - 1440)
 					tt := time.Unix(epoch[i], 0)
-					(*destcol)[i] = tt.In(loc)
+					destcol[i] = tt.In(loc)
 				}
 			}
 		} else {
 			epoch := array.NewInt64Data(structData.Field(0).Data()).Int64Values()
 			fraction := array.NewInt32Data(structData.Field(1).Data()).Int32Values()
 			timezone := array.NewInt32Data(structData.Field(2).Data()).Int32Values()
-			for i := range *destcol {
+			for i := range destcol {
 				if !srcValue.IsNull(i) {
 					loc := Location(int(timezone[i]) - 1440)
 					tt := time.Unix(epoch[i], int64(fraction[i]))
-					(*destcol)[i] = tt.In(loc)
+					destcol[i] = tt.In(loc)
 				}
 			}
 		}

--- a/converter_test.go
+++ b/converter_test.go
@@ -570,7 +570,7 @@ func TestArrowToValue(t *testing.T) {
 			meta := tc.rowType
 			meta.Type = tc.logical
 
-			if err := arrowToValue(&dest, meta, arr, localTime.Location(), true); err != nil {
+			if err := arrowToValue(dest, meta, arr, localTime.Location(), true); err != nil {
 				t.Fatalf("error: %s", err)
 			}
 


### PR DESCRIPTION
### Description

This PR includes some improvements to the memory allocation and usage of the Arrow decoding code.

I also included some linting cleanup given that it is part of the PR checklist below. For example, `arrowResultChunk.allocator` can never be non-nil, so the field and the code branches that depend on it can be removed.

### Checklist

- [x] Code compiles correctly
- [x] Run `make fmt` to fix inconsistent formats
- [x] Run `make lint` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
