### PR TITLE
Fix panic issues in file downloading

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -187,6 +187,8 @@ const (
 	ErrFailedToConvertToS3Client = 264010
 	// ErrNotImplemented is an error code denoting the file transfer feature is not implemented
 	ErrNotImplemented = 264011
+	// ErrInvalidPadding is an error code denoting the invalid padding of decryption key
+	ErrInvalidPadding = 264012
 
 	/* binding */
 
@@ -285,6 +287,7 @@ const (
 	errMsgFailedToConvertToS3Client          = "failed to convert interface to s3 client"
 	errMsgNoResultIDs                        = "no result IDs returned with the multi-statement query"
 	errMsgQueryStatus                        = "server ErrorCode=%s, ErrorMessage=%s"
+	errMsgInvalidPadding                     = "invalid padding on input"
 )
 
 var (

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -253,7 +253,7 @@ func (sfa *snowflakeFileTransferAgent) parseCommand() error {
 		if err != nil {
 			return err
 		}
-		if fi, err := os.Stat(sfa.localLocation); !fi.IsDir() || err != nil {
+		if fi, err := os.Stat(sfa.localLocation); err != nil || !fi.IsDir() {
 			return (&SnowflakeError{
 				Number:      ErrLocalPathNotDirectory,
 				SQLState:    sfa.data.SQLState,

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -5,6 +5,10 @@ package gosnowflake
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aws/smithy-go"
@@ -41,4 +45,35 @@ func TestGetBucketAccelerateConfiguration(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDownloadWithInvalidLocalPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "data")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	testData := filepath.Join(tmpDir, "data.txt")
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, os.ModePerm)
+	if err != nil {
+		t.Error(err)
+	}
+	f.WriteString("test1,test2\ntest3,test4\n")
+	f.Close()
+
+	runTests(t, dsn, func(dbt *DBTest) {
+		if _, err = dbt.db.Exec("use role sysadmin"); err != nil {
+			t.Skip("snowflake admin account not accessible")
+		}
+		dbt.mustExec("rm @~/test_get")
+		sqlText := fmt.Sprintf("put file://%v @~/test_get", testData)
+		sqlText = strings.ReplaceAll(sqlText, "\\", "\\\\")
+		dbt.mustExec(sqlText)
+
+		sqlText = fmt.Sprintf("get @~/test_get/data.txt file://%v\\get", tmpDir)
+		if _, err = dbt.db.Query(sqlText); err == nil {
+			t.Fatalf("should return local path not directory error.")
+		}
+		dbt.mustExec("rm @~/test_get")
+	})
 }


### PR DESCRIPTION
### Description
1. SNOW-636725: panic: crypto/cipher: input not full blocks (Issue #632): Add padding when the source being decrypted is not divisible by block size (16).
3. SNOW-636720: Panic due to slice bounds out of range in paddingTrim (Issue #631): Add check on unpadding to make sure the length is not 0 or too big. Return an error if the padding is invalid.
4. SNOW-636717: Panic inside `snowflakeFileTransferAgent.parseCommand` due to nil pointer dereference (Issue #630): check for error first to avoid nil pointer reference.

The customer has confirmed the fixes on their end.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
