### PR TITLE
Support getQueryID() method on snowflakeStmt object

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -881,5 +881,36 @@ db.Query() function:
 an absolute path rather than a relative path. For example:
 
 	db.Query("GET file:///tmp/my_data_file @~ auto_compress=false overwrite=false")
+
+# Retrieving Last Query ID
+
+The Go Snowflake driver supports retrieving the query ID of the last executed query.
+
+The following example shows how to retrieve the query ID from the snowflakeStmt object:
+
+	if err = conn.Raw(func(x interface{}) error {
+		// Prepare the query
+		stmt, err := x.(driver.ConnPrepareContext).PrepareContext(ctx, "select 1")
+		if err != nil {
+			return err
+		}
+		// Execute the query
+		rows, err = stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
+		if err != nil {
+			return err
+		}
+		...
+		// Retrieve the query ID
+		qid := stmt.(SnowflakeStmt).GetQueryID()
+		....
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to prepare statement. err: %v", err)
+	}
+
+To retrieve the query ID from the snowflakeRows/snowflakeResult object use:
+
+	qid := rows.(SnowflakeRows).GetQueryID()
+	qid := rows.(SnowflakeResult).GetQueryID()
 */
 package gosnowflake

--- a/statement.go
+++ b/statement.go
@@ -51,4 +51,4 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 
 func (stmt *snowflakeStmt) GetQueryID() string {
 	return stmt.sc.QueryID
-}	
+}

--- a/statement.go
+++ b/statement.go
@@ -7,6 +7,11 @@ import (
 	"database/sql/driver"
 )
 
+// SnowflakeStmt provides an API for methods exposed to the clients
+type SnowflakeStmt interface {
+	GetQueryID() string
+}
+
 type snowflakeStmt struct {
 	sc    *snowflakeConn
 	query string
@@ -43,3 +48,7 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Query")
 	return stmt.sc.Query(stmt.query, args)
 }
+
+func (stmt *snowflakeStmt) GetQueryID() string {
+	return stmt.sc.QueryID
+}	

--- a/statement_test.go
+++ b/statement_test.go
@@ -227,11 +227,11 @@ func TestGetQueryIDFromStmt(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		secondQueryId := stmt.(SnowflakeStmt).GetQueryID()
-		if firstQueryID == "" || secondQueryId == "" {
+		secondQueryID := stmt.(SnowflakeStmt).GetQueryID()
+		if firstQueryID == "" || secondQueryID == "" {
 			t.Fatalf("Failed to get stmt last query ID")
 		}
-		if firstQueryID == secondQueryId {
+		if firstQueryID == secondQueryID {
 			t.Fatalf("Failed to get ID of last executed query. ID: %v", firstQueryID)
 		}
 		return nil

--- a/statement_test.go
+++ b/statement_test.go
@@ -202,3 +202,40 @@ func TestCallStatement(t *testing.T) {
 		dbt.mustExec("drop procedure if exists TEST_SP_CALL_STMT_ENABLED(float, variant)")
 	})
 }
+
+func TestGetQueryIDFromStmt(t *testing.T) {
+	db := openDB(t)
+	defer db.Close()
+
+	ctx := context.TODO()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err = conn.Raw(func(x interface{}) error {
+		stmt, err := x.(driver.ConnPrepareContext).PrepareContext(ctx, "select 1")
+		if err != nil {
+			return err
+		}
+		_, err = stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
+		if err != nil {
+			return err
+		}
+		firstQueryID := stmt.(SnowflakeStmt).GetQueryID()
+		_, err = stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
+		if err != nil {
+			return err
+		}
+		secondQueryId := stmt.(SnowflakeStmt).GetQueryID()
+		if firstQueryID == "" || secondQueryId == "" {
+			t.Fatalf("Failed to get stmt last query ID")
+		}
+		if firstQueryID == secondQueryId {
+			t.Fatalf("Failed to get ID of last executed query. ID: %v", firstQueryID)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to prepare statement. err: %v", err)
+	}
+}


### PR DESCRIPTION
### Description
getQueryID() is supported on result and rows objects but not statement. Add SnowflakeStmt interface to expose the getQueryID() method.

Example of how to get the query ID from the statement:
```
		stmt, err := x.(driver.ConnPrepareContext).PrepareContext(ctx, "select 1")
		if err != nil {
			return err
		}
		rows, err = stmt.(driver.StmtQueryContext).QueryContext(ctx, nil)
		if err != nil {
			return err
		}
		qid := stmt.(SnowflakeStmt).GetQueryID()
```

https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/123

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
