### PR TITLE
Drop Go 1.18 and add Go 1.20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.19', '1.18' ]
+                go: [ '1.20', '1.19' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Ubuntu
         steps:
             - uses: actions/checkout@v1
@@ -48,7 +48,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.19', '1.18' ]
+                go: [ '1.20', '1.19' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Mac
         steps:
             - uses: actions/checkout@v1
@@ -70,7 +70,7 @@ jobs:
         strategy:
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.19', '1.18' ]
+                go: [ '1.20', '1.19' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Windows
         steps:
             - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following software packages are required to use the Go Snowflake Driver.
 
 ## Go
 
-The latest driver requires the [Go language](https://golang.org/) 1.18 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
+The latest driver requires the [Go language](https://golang.org/) 1.19 or higher. The supported operating systems are Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
 
 
 # Installation

--- a/ci/build.bat
+++ b/ci/build.bat
@@ -9,7 +9,7 @@ IF !ERRORLEVEL! NEQ 0 go install golang.org/x/lint/golint@latest
 where make2help
 IF !ERRORLEVEL! NEQ 0 go install github.com/Songmu/make2help/cmd/make2help@latest
 where staticcheck
-IF !ERRORLEVEL! NEQ 0 go install honnef.co/go/tools/cmd/staticcheck@v0.3
+IF !ERRORLEVEL! NEQ 0 go install honnef.co/go/tools/cmd/staticcheck@v0.4
 
 echo [INFO] Go mod
 go mod tidy

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"net/url"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -672,14 +671,11 @@ func TestExpiredCertificate(t *testing.T) {
 		t.Fatalf("failed to extract error URL Error: %v", err)
 	}
 	_, ok = urlErr.Err.(x509.CertificateInvalidError)
+
 	if !ok {
-		if runtime.GOOS == "darwin" {
-			// Go 1.18 on Mac: errors.errorString is thrown
-			errString := urlErr.Err.Error()
-			if !strings.HasPrefix(errString, "x509:") || !strings.HasSuffix(errString, "certificate is expired") {
-				t.Fatalf("failed to extract error Certificate error: %v", err)
-			}
-		} else {
+		// Go 1.20 throws tls CertificateVerification error
+		errString := urlErr.Err.Error()
+		if !strings.Contains(errString, "certificate has expired or is not yet valid") {
 			t.Fatalf("failed to extract error Certificate error: %v", err)
 		}
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -376,9 +376,9 @@ func invalidUserPassErrorTests(invalidDNS string, t *testing.T) {
 
 func TestBogusHostNameParameters(t *testing.T) {
 	invalidDNS := fmt.Sprintf("%s:%s@%s", username, pass, "INVALID_HOST:1234")
-	invalidHostErrorTests(invalidDNS, []string{"no such host", "verify account name is correct", "HTTP Status: 403", "Temporary failure in name resolution"}, t)
+	invalidHostErrorTests(invalidDNS, []string{"no such host", "verify account name is correct", "HTTP Status: 403", "Temporary failure in name resolution", "server misbehaving"}, t)
 	invalidDNS = fmt.Sprintf("%s:%s@%s", username, pass, "INVALID_HOST")
-	invalidHostErrorTests(invalidDNS, []string{"read: connection reset by peer", "EOF", "verify account name is correct", "HTTP Status: 403", "Temporary failure in name resolution"}, t)
+	invalidHostErrorTests(invalidDNS, []string{"read: connection reset by peer", "EOF", "verify account name is correct", "HTTP Status: 403", "Temporary failure in name resolution", "server misbehaving"}, t)
 }
 
 func invalidHostErrorTests(invalidDNS string, mstr []string, t *testing.T) {

--- a/file_compression_type.go
+++ b/file_compression_type.go
@@ -12,7 +12,6 @@ import (
 type compressionType struct {
 	name          string
 	fileExtension string
-	mimeType      string
 	mimeSubtypes  []string
 	isSupported   bool
 }
@@ -21,91 +20,78 @@ var compressionTypes = map[string]*compressionType{
 	"GZIP": {
 		"GZIP",
 		".gz",
-		"application",
 		[]string{"gzip", "x-gzip"},
 		true,
 	},
 	"DEFLATE": {
 		"DEFLATE",
 		".deflate",
-		"application",
 		[]string{"zlib", "deflate"},
 		true,
 	},
 	"RAW_DEFLATE": {
 		"RAW_DEFLATE",
 		".raw_deflate",
-		"application",
 		[]string{"raw_deflate"},
 		true,
 	},
 	"BZIP2": {
 		"BZIP2",
 		".bz2",
-		"application",
 		[]string{"bzip2", "x-bzip2", "x-bz2", "x-bzip", "bz2"},
 		true,
 	},
 	"LZIP": {
 		"LZIP",
 		".lz",
-		"application",
 		[]string{"lzip", "x-lzip"},
 		false,
 	},
 	"LZMA": {
 		"LZMA",
 		".lzma",
-		"application",
 		[]string{"lzma", "x-lzma"},
 		false,
 	},
 	"LZO": {
 		"LZO",
 		".lzo",
-		"application",
 		[]string{"lzo", "x-lzo"},
 		false,
 	},
 	"XZ": {
 		"XZ",
 		".xz",
-		"application",
 		[]string{"xz", "x-xz"},
 		false,
 	},
 	"COMPRESS": {
 		"COMPRESS",
 		".Z",
-		"application",
 		[]string{"compress", "x-compress"},
 		false,
 	},
 	"PARQUET": {
 		"PARQUET",
 		".parquet",
-		"snowflake",
 		[]string{"parquet"},
 		true,
 	},
 	"ZSTD": {
 		"ZSTD",
 		".zst",
-		"application",
 		[]string{"zstd", "x-zstd"},
 		true,
 	},
 	"BROTLI": {
 		"BROTLI",
 		".br",
-		"application",
 		[]string{"br", "x-br"},
 		true,
 	},
 	"ORC": {
 		"ORC",
 		".orc",
-		"snowflake",
 		[]string{"orc"},
 		true,
 	},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snowflakedb/gosnowflake
 
-go 1.18
+go 1.19
 
 require (
 	github.com/99designs/keyring v1.2.1

--- a/gosnowflake.mak
+++ b/gosnowflake.mak
@@ -5,7 +5,7 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 setup:
 	@which golint &> /dev/null  || go install golang.org/x/lint/golint@latest
 	@which make2help &> /dev/null || go install github.com/Songmu/make2help/cmd/make2help@latest
-	@which staticcheck &> /dev/null || go install honnef.co/go/tools/cmd/staticcheck@v0.3
+	@which staticcheck &> /dev/null || go install honnef.co/go/tools/cmd/staticcheck@v0.4
 
 ## Install dependencies
 deps: setup


### PR DESCRIPTION
### Description
Go 1.20 has been released: https://go.dev/doc/devel/release#go1.20
Drop Go version 1.18 and add support for Go 1.20.

https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/200

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
