### PR TITLE
Set version of static check to 0.3

### DIFF
--- a/ci/build.bat
+++ b/ci/build.bat
@@ -9,7 +9,7 @@ IF !ERRORLEVEL! NEQ 0 go install golang.org/x/lint/golint@latest
 where make2help
 IF !ERRORLEVEL! NEQ 0 go install github.com/Songmu/make2help/cmd/make2help@latest
 where staticcheck
-IF !ERRORLEVEL! NEQ 0 go install honnef.co/go/tools/cmd/staticcheck@latest
+IF !ERRORLEVEL! NEQ 0 go install honnef.co/go/tools/cmd/staticcheck@v0.3
 
 echo [INFO] Go mod
 go mod tidy

--- a/gosnowflake.mak
+++ b/gosnowflake.mak
@@ -5,7 +5,7 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 setup:
 	@which golint &> /dev/null  || go install golang.org/x/lint/golint@latest
 	@which make2help &> /dev/null || go install github.com/Songmu/make2help/cmd/make2help@latest
-	@which staticcheck &> /dev/null || go install honnef.co/go/tools/cmd/staticcheck@latest
+	@which staticcheck &> /dev/null || go install honnef.co/go/tools/cmd/staticcheck@v0.3
 
 ## Install dependencies
 deps: setup


### PR DESCRIPTION
### Description
The latest version of static check (0.4) requires Go 1.19 or 1.20. Currently we support 1.18 and 1.19.
This is to force the driver to use 0.3 instead of latest until we support 1.20. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
