### PR TITLE
SNOW-755844: Pointer datatype *time.Time returns <nil> value

### DIFF
--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -292,12 +292,8 @@ func supportedArrayBind(nv *driver.NamedValue) bool {
 		// TODO SNOW-176486 variant, object, array
 
 		// Support for bulk array binding insertion using []interface{}
-		nvValue := reflect.ValueOf(nv)
-		if nvValue.Kind() == reflect.Ptr {
-			value := reflect.Indirect(reflect.ValueOf(nv.Value))
-			if value.Kind() == reflect.Slice || value.Kind() == reflect.Struct {
-				return true
-			}
+		if isInterfaceArrayBinding(nv.Value) {
+			return true
 		}
 		return false
 	}

--- a/converter_test.go
+++ b/converter_test.go
@@ -65,7 +65,6 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: time.Now(), tmode: timestampTzType, out: timestampTzType},
 		{in: time.Now(), tmode: timestampLtzType, out: timestampLtzType},
 		{in: []byte{1, 2, 3}, tmode: binaryType, out: binaryType},
-		{in: []int{1}, tmode: nullType, out: sliceType},
 		{in: Array([]interface{}{int64(123)}), tmode: nullType, out: sliceType},
 		{in: Array([]interface{}{float64(234.56)}), tmode: nullType, out: sliceType},
 		{in: Array([]interface{}{true}), tmode: nullType, out: sliceType},
@@ -76,6 +75,11 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: Array([]interface{}{time.Now()}), tmode: timestampLtzType, out: sliceType},
 		{in: Array([]interface{}{time.Now()}), tmode: dateType, out: sliceType},
 		{in: Array([]interface{}{time.Now()}), tmode: timeType, out: sliceType},
+		{in: Array([]interface{}{time.Now()}, TimestampNTZType), tmode: timestampLtzType, out: sliceType},
+		{in: Array([]interface{}{time.Now()}, TimestampLTZType), tmode: dateType, out: sliceType},
+		{in: Array([]interface{}{time.Now()}, TimestampTZType), tmode: timeType, out: sliceType},
+		{in: Array([]interface{}{time.Now()}, DateType), tmode: timestampNtzType, out: sliceType},
+		{in: Array([]interface{}{time.Now()}, TimeType), tmode: timestampTzType, out: sliceType},
 		// negative
 		{in: 123, tmode: nullType, out: unSupportedType},
 		{in: int8(12), tmode: nullType, out: unSupportedType},
@@ -84,6 +88,7 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: uint8(12), tmode: nullType, out: unSupportedType},
 		{in: uint64(456), tmode: nullType, out: unSupportedType},
 		{in: []byte{100}, tmode: nullType, out: unSupportedType},
+		{in: []int{1}, tmode: nullType, out: unSupportedType},
 		{in: nil, tmode: nullType, out: unSupportedType},
 	}
 	for _, test := range testcases {


### PR DESCRIPTION
Issue: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/246

Starting with gosnowflake 1.6.13, the use of a pointer *time.Time type in user-defined structures used to perform updates/inserts has silently stopped working, and nil value is used instead of the value it points to.
This PR fixes the regression introduced by PR #642. All array binding insertion using []interface{} will now be wrapped in the  interfaceArrayBinding struct, instead of assuming them as the reflect.Slice and reflect.Struct types.

```
type interfaceArrayBinding struct {
	hasTimezone       bool
	tzType            timezoneType
	timezoneTypeArray interface{}
}
```

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
