### PR TITLE
SNOW-752633: honour KeepSessionAlive config in DSN

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -186,6 +186,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 			params.Add(k, *v)
 		}
 	}
+	if cfg.KeepSessionAlive {
+		params.Add("client_session_keep_alive", strconv.FormatBool(cfg.KeepSessionAlive))
+	}
 	if cfg.PrivateKey != nil {
 		privateKeyInBytes, err := marshalPKCS8PrivateKey(cfg.PrivateKey)
 		if err != nil {
@@ -597,6 +600,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		case "token":
 			cfg.Token = value
+		case "client_session_keep_alive":
+			cfg.KeepSessionAlive, err = strconv.ParseBool(value)
+			if err != nil {
+				return
+			}
 		case "privateKey":
 			var decodeErr error
 			block, decodeErr := base64.URLEncoding.DecodeString(value)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -491,6 +491,20 @@ func TestParseDSN(t *testing.T) {
 			ocspMode: ocspModeFailOpen,
 			err:      nil,
 		},
+		{
+			dsn: "u:p@a?database=d?client_session_keep_alive=true",
+			config: &Config{
+				Account: "a", User: "u", Password: "p",
+				Protocol: "https", Host: "a.snowflakecomputing.com", Port: 443,
+				Database: "d", Schema: "",
+				JWTExpireTimeout:          defaultJWTTimeout,
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				ValidateDefaultParameters: ConfigBoolTrue,
+				ClientTimeout:             defaultClientTimeout,
+				KeepSessionAlive:          true,
+			},
+			ocspMode: ocspModeFailOpen,
+		},
 	}
 
 	for i, test := range testcases {
@@ -572,6 +586,10 @@ func TestParseDSN(t *testing.T) {
 			if test.config.ClientTimeout != cfg.ClientTimeout {
 				t.Fatalf("%d: Failed to match ClientTimeout. expected: %v, got: %v",
 					i, test.config.ClientTimeout, cfg.ClientTimeout)
+			}
+			if test.config.KeepSessionAlive != cfg.KeepSessionAlive {
+				t.Fatalf("%d: Failed to match KeepSessionAlive. expected: %v, got: %v",
+					i, test.config.KeepSessionAlive, cfg.KeepSessionAlive)
 			}
 		case test.err != nil:
 			driverErrE, okE := test.err.(*SnowflakeError)
@@ -855,6 +873,15 @@ func TestDSN(t *testing.T) {
 				ClientTimeout: 300 * time.Second,
 			},
 			dsn: "u:p@a.b.c.snowflakecomputing.com:443?clientTimeout=300&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:             "u",
+				Password:         "p",
+				Account:          "a-aofnadsf.somewhere.azure",
+				KeepSessionAlive: true,
+			},
+			dsn: "u:p@a-aofnadsf.somewhere.azure.snowflakecomputing.com:443?ocspFailOpen=true&region=somewhere.azure&validateDefaultParameters=true&client_session_keep_alive=true",
 		},
 	}
 	for _, test := range testcases {


### PR DESCRIPTION
### Description
The to/from DSN functions do not honour the `KeepSessionAlive` config flag, leading to unexpected client timeout errors.

Fixes https://github.com/snowflakedb/gosnowflake/issues/738.


### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
