### PR TITLE
SNOW-559970 Fixed interface conversion error when error is not SnowflakeError type

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -294,7 +294,8 @@ func (sc *snowflakeConn) QueryContext(
 
 	// check the query status to find out if there is a result to fetch
 	_, err = sc.checkQueryStatus(ctx, qid)
-	if err == nil || (err != nil && err.(*SnowflakeError).Number == ErrQueryIsRunning) {
+	snowflakeErr, isSnowflakeError := err.(*SnowflakeError)
+	if err == nil || (isSnowflakeError && snowflakeErr.Number == ErrQueryIsRunning) {
 		// the query is running. Rows object will be returned from here.
 		return sc.buildRowsForRunningQuery(ctx, qid)
 	}


### PR DESCRIPTION
### Description

Issue 289: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/289
The driver panics when it tries to cast a generic error to `SnowflakeError` and access the `SnowflakeError.Number` field:
This PR fixes the interface conversion panic by checking if the casting succeeds before accessing the Number field.

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
