### PR TITLE
SNOW-747896: Clean up the first chunk of data that has been previously used

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -184,7 +184,7 @@ func (scd *snowflakeChunkDownloader) next() (chunkRowType, error) {
 		}
 
 		scd.ChunksMutex.Lock()
-		if scd.CurrentChunkIndex > 1 {
+		if scd.CurrentChunkIndex > 0 {
 			scd.Chunks[scd.CurrentChunkIndex-1] = nil // detach the previously used chunk
 		}
 


### PR DESCRIPTION
### Description

Issue 300: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/300
The data chunk at index 0 is not cleaned up until the end when reset() is called in [rows.go](https://github.com/snowflakedb/gosnowflake/blob/master/rows.go#L174) and consumes memory.
This PR cleans it up by freeing the chunk before reading the next chunk.

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
