### PR TITLE
SNOW-684693 Fix small/large date/time overflow 

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -158,7 +158,13 @@ func valueToString(v driver.Value, tsmode snowflakeType) (*string, error) {
 				s := fmt.Sprintf("%d",
 					(tm.Hour()*3600+tm.Minute()*60+tm.Second())*1e9+tm.Nanosecond())
 				return &s, nil
-			case timestampNtzType, timestampLtzType:
+			case timestampNtzType:
+				fmt.Printf("nanos %v \n", tm.UnixNano())
+				bigIntMilli, _ := new(big.Int).SetString(fmt.Sprintf("%d", tm.UnixMilli()), 10)
+				nanos, _ := new(big.Int).SetString(fmt.Sprintf("%d", 1000000), 10)
+				s := bigIntMilli.Mul(bigIntMilli, nanos).String()
+				return &s, nil
+			case timestampLtzType:
 				s := fmt.Sprintf("%d", tm.UnixNano())
 				return &s, nil
 			case timestampTzType:

--- a/converter.go
+++ b/converter.go
@@ -158,14 +158,12 @@ func valueToString(v driver.Value, tsmode snowflakeType) (*string, error) {
 				s := fmt.Sprintf("%d",
 					(tm.Hour()*3600+tm.Minute()*60+tm.Second())*1e9+tm.Nanosecond())
 				return &s, nil
-			case timestampNtzType:
-				fmt.Printf("nanos %v \n", tm.UnixNano())
-				bigIntMilli, _ := new(big.Int).SetString(fmt.Sprintf("%d", tm.UnixMilli()), 10)
-				nanos, _ := new(big.Int).SetString(fmt.Sprintf("%d", 1000000), 10)
-				s := bigIntMilli.Mul(bigIntMilli, nanos).String()
-				return &s, nil
-			case timestampLtzType:
-				s := fmt.Sprintf("%d", tm.UnixNano())
+			case timestampNtzType, timestampLtzType:
+				unixTime, _ := new(big.Int).SetString(fmt.Sprintf("%d", tm.Unix()), 10)
+				m, _ := new(big.Int).SetString(strconv.FormatInt(1e9, 10), 10)
+				unixTime.Mul(unixTime, m)
+				tmNanos, _ := new(big.Int).SetString(fmt.Sprintf("%d", tm.Nanosecond()), 10)
+				s := unixTime.Add(unixTime, tmNanos).String()
 				return &s, nil
 			case timestampTzType:
 				_, offset := tm.Zone()

--- a/converter_test.go
+++ b/converter_test.go
@@ -7,7 +7,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
-	"log"
 	"math/big"
 	"math/cmplx"
 	"reflect"
@@ -1081,7 +1080,6 @@ func TestSmallTimestampBinding(t *testing.T) {
 		{Ordinal: 2, Value: timeValue},
 	}
 
-	fmt.Printf("parameters: %v\n", parameters)
 	rows, err := sc.QueryContext(ctx, "SELECT ?", parameters)
 	if err != nil {
 		t.Fatalf("failed to run query: %v", err)
@@ -1093,12 +1091,11 @@ func TestSmallTimestampBinding(t *testing.T) {
 		if err := rows.Next(scanValues); err == io.EOF {
 			break
 		} else if err != nil {
-			log.Fatalf("failed to run query: %v", err)
+			t.Fatalf("failed to run query: %v", err)
 		}
 		if scanValues[0] != timeValue {
 			t.Fatalf("unexpected result. expected: %v, got: %v", timeValue, scanValues[0])
 		}
-		fmt.Printf("values: %v\n", scanValues)
 	}
 }
 
@@ -1124,7 +1121,6 @@ func TestLargeTimestampBinding(t *testing.T) {
 		{Ordinal: 2, Value: timeValue},
 	}
 
-	fmt.Printf("parameters: %v\n", parameters)
 	rows, err := sc.QueryContext(ctx, "SELECT ?", parameters)
 	if err != nil {
 		t.Fatalf("failed to run query: %v", err)
@@ -1136,7 +1132,7 @@ func TestLargeTimestampBinding(t *testing.T) {
 		if err := rows.Next(scanValues); err == io.EOF {
 			break
 		} else if err != nil {
-			log.Fatalf("failed to run query: %v", err)
+			t.Fatalf("failed to run query: %v", err)
 		}
 		if scanValues[0] != timeValue {
 			t.Fatalf("unexpected result. expected: %v, got: %v", timeValue, scanValues[0])

--- a/converter_test.go
+++ b/converter_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+	"io"
+	"log"
 	"math/big"
 	"math/cmplx"
 	"reflect"
@@ -1054,5 +1056,90 @@ func TestTimestampLTZLocation(t *testing.T) {
 	}
 	if ts.Location() != time.Local {
 		t.Errorf("expected location to be local, got '%v'", ts.Location())
+	}
+}
+
+func TestSmallTimestampBinding(t *testing.T) {
+	config, err := ParseDSN(dsn)
+	if err != nil {
+		t.Error(err)
+	}
+	ctx := context.Background()
+	sc, err := buildSnowflakeConn(ctx, *config)
+	if err != nil {
+		t.Error(err)
+	}
+	if err = authenticateWithConfig(sc); err != nil {
+		t.Error(err)
+	}
+	timeValue, err := time.Parse("2006-01-02 15:04:05", "1600-10-10 10:10:10")
+	if err != nil {
+		t.Fatalf("failed to parse time: %v", err)
+	}
+	parameters := []driver.NamedValue{
+		{Ordinal: 1, Value: DataTypeTimestampNtz},
+		{Ordinal: 2, Value: timeValue},
+	}
+
+	fmt.Printf("parameters: %v\n", parameters)
+	rows, err := sc.QueryContext(ctx, "SELECT ?", parameters)
+	if err != nil {
+		t.Fatalf("failed to run query: %v", err)
+	}
+	defer rows.Close()
+
+	scanValues := make([]driver.Value, 1)
+	for {
+		if err := rows.Next(scanValues); err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatalf("failed to run query: %v", err)
+		}
+		if scanValues[0] != timeValue {
+			t.Fatalf("unexpected result. expected: %v, got: %v", timeValue, scanValues[0])
+		}
+		fmt.Printf("values: %v\n", scanValues)
+	}
+}
+
+func TestLargeTimestampBinding(t *testing.T) {
+	config, err := ParseDSN(dsn)
+	if err != nil {
+		t.Error(err)
+	}
+	ctx := context.Background()
+	sc, err := buildSnowflakeConn(ctx, *config)
+	if err != nil {
+		t.Error(err)
+	}
+	if err = authenticateWithConfig(sc); err != nil {
+		t.Error(err)
+	}
+	timeValue, err := time.Parse("2006-01-02 15:04:05", "9000-10-10 10:10:10")
+	if err != nil {
+		t.Fatalf("failed to parse time: %v", err)
+	}
+	parameters := []driver.NamedValue{
+		{Ordinal: 1, Value: DataTypeTimestampNtz},
+		{Ordinal: 2, Value: timeValue},
+	}
+
+	fmt.Printf("parameters: %v\n", parameters)
+	rows, err := sc.QueryContext(ctx, "SELECT ?", parameters)
+	if err != nil {
+		t.Fatalf("failed to run query: %v", err)
+	}
+	defer rows.Close()
+
+	scanValues := make([]driver.Value, 1)
+	for {
+		if err := rows.Next(scanValues); err == io.EOF {
+			break
+		} else if err != nil {
+			log.Fatalf("failed to run query: %v", err)
+		}
+		if scanValues[0] != timeValue {
+			t.Fatalf("unexpected result. expected: %v, got: %v", timeValue, scanValues[0])
+		}
 	}
 }


### PR DESCRIPTION
### Description
Fixes #678 
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/310

The epoch nanosecond value for large and small timestamps (i.e. year 6000 / year 9000) cause an overflow with go's int64 type. This PR is to use big int instead of int64 for coverting the timestamp to string.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
