### PR TITLE
[SIG-35025] Check shutdown channel for nil

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -46,6 +46,9 @@ func (hc *heartbeat) start() {
 }
 
 func (hc *heartbeat) stop() {
+	if hc.shutdownChan == nil {
+		return
+	}
 	hc.shutdownChan <- true
 	close(hc.shutdownChan)
 	logger.Info("heartbeat stopped")


### PR DESCRIPTION
### Description
Shutdown can be nil when referenced in close

### Checklist
- [X ] Code compiles correctly
- [ X] Run ``make fmt`` to fix inconsistent formats
- [X ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
