### PR TITLE
Make port/portStr variables in cmd more consistent

### DIFF
--- a/cmd/externalbrowser/externalbrowser.go
+++ b/cmd/externalbrowser/externalbrowser.go
@@ -26,19 +26,23 @@ func getDSN() (string, *sf.Config, error) {
 	account := env("SNOWFLAKE_TEST_ACCOUNT", true)
 	user := env("SNOWFLAKE_TEST_USER", true)
 	host := env("SNOWFLAKE_TEST_HOST", false)
-	port := env("SNOWFLAKE_TEST_PORT", false)
+	portStr := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
-	portStr, err := strconv.Atoi(port)
-	if err != nil {
-		return "", nil, err
+	port := 443 // snowflake default port
+	var err error
+	if len(portStr) > 0 {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	cfg := &sf.Config{
 		Authenticator: sf.AuthTypeExternalBrowser,
 		Account:       account,
 		User:          user,
 		Host:          host,
-		Port:          portStr,
+		Port:          port,
 		Protocol:      protocol,
 	}
 

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -31,23 +31,28 @@ func getDSN() (string, *sf.Config, error) {
 	user := env("SNOWFLAKE_TEST_USER", true)
 	password := env("SNOWFLAKE_TEST_PASSWORD", true)
 	host := env("SNOWFLAKE_TEST_HOST", false)
-	port := env("SNOWFLAKE_TEST_PORT", false)
+	portStr := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
 	params := make(map[string]*string)
 	valueTrue := "true"
 	params["client_session_keep_alive"] = &valueTrue
 
-	portStr, err := strconv.Atoi(port)
-	if err != nil {
-		return "", nil, err
+	port := 443 // snowflake default port
+	var err error
+	if len(portStr) > 0 {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
 	}
+
 	cfg := &sf.Config{
 		Account:  account,
 		User:     user,
 		Password: password,
 		Host:     host,
-		Port:     portStr,
+		Port:     port,
 		Protocol: protocol,
 		Params:   params,
 	}

--- a/cmd/keypair/keypair.go
+++ b/cmd/keypair/keypair.go
@@ -52,7 +52,6 @@ func getDSN() (string, *sf.Config, error) {
 	rsaPrivateKey, _ := privKey.(*rsa.PrivateKey)
 
 	port := 443 // snowflake default port
-	//var err error
 	if len(portStr) > 0 {
 		port, err = strconv.Atoi(portStr)
 		if err != nil {

--- a/cmd/mfa/mfa.go
+++ b/cmd/mfa/mfa.go
@@ -27,12 +27,16 @@ func getDSN() (string, *sf.Config, error) {
 	user := env("SNOWFLAKE_TEST_USER", true)
 	password := env("SNOWFLAKE_TEST_PASSWORD", true)
 	host := env("SNOWFLAKE_TEST_HOST", false)
-	port := env("SNOWFLAKE_TEST_PORT", false)
+	portStr := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
-	portStr, err := strconv.Atoi(port)
-	if err != nil {
-		return "", nil, err
+	port := 443 // snowflake default port
+	var err error
+	if len(portStr) > 0 {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	cfg := &sf.Config{
 		Account:       account,
@@ -40,7 +44,7 @@ func getDSN() (string, *sf.Config, error) {
 		User:          user,
 		Host:          host,
 		Password:      password,
-		Port:          portStr,
+		Port:          port,
 		Protocol:      protocol,
 	}
 

--- a/cmd/noconnpool/noconnpool.go
+++ b/cmd/noconnpool/noconnpool.go
@@ -32,10 +32,17 @@ func getDSN() (string, *sf.Config, error) {
 	user := env("SNOWFLAKE_TEST_USER", true)
 	password := env("SNOWFLAKE_TEST_PASSWORD", true)
 	host := env("SNOWFLAKE_TEST_HOST", false)
-	port := env("SNOWFLAKE_TEST_PORT", false)
+	portStr := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
-	portStr, err := strconv.Atoi(port)
+	port := 443 // snowflake default port
+	var err error
+	if len(portStr) > 0 {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
+	}
 	if err != nil {
 		return "", nil, err
 	}
@@ -44,7 +51,7 @@ func getDSN() (string, *sf.Config, error) {
 		User:     user,
 		Password: password,
 		Host:     host,
-		Port:     portStr,
+		Port:     port,
 		Protocol: protocol,
 	}
 

--- a/cmd/selectmany/selectmany.go
+++ b/cmd/selectmany/selectmany.go
@@ -40,19 +40,23 @@ func getDSN() (string, *sf.Config, error) {
 	user := env("SNOWFLAKE_TEST_USER", true)
 	password := env("SNOWFLAKE_TEST_PASSWORD", true)
 	host := env("SNOWFLAKE_TEST_HOST", false)
-	port := env("SNOWFLAKE_TEST_PORT", false)
+	portStr := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
-	portStr, err := strconv.Atoi(port)
-	if err != nil {
-		return "", nil, err
+	port := 443 // snowflake default port
+	var err error
+	if len(portStr) > 0 {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	cfg := &sf.Config{
 		Account:  account,
 		User:     user,
 		Password: password,
 		Host:     host,
-		Port:     portStr,
+		Port:     port,
 		Protocol: protocol,
 	}
 

--- a/cmd/showparam/showparam.go
+++ b/cmd/showparam/showparam.go
@@ -28,19 +28,23 @@ func getDSN(params map[string]*string) (string, *sf.Config, error) {
 	user := env("SNOWFLAKE_TEST_USER", true)
 	password := env("SNOWFLAKE_TEST_PASSWORD", true)
 	host := env("SNOWFLAKE_TEST_HOST", false)
-	port := env("SNOWFLAKE_TEST_PORT", false)
+	portStr := env("SNOWFLAKE_TEST_PORT", false)
 	protocol := env("SNOWFLAKE_TEST_PROTOCOL", false)
 
-	portStr, err := strconv.Atoi(port)
-	if err != nil {
-		return "", nil, err
+	port := 443 // snowflake default port
+	var err error
+	if len(portStr) > 0 {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	cfg := &sf.Config{
 		Account:  account,
 		User:     user,
 		Password: password,
 		Host:     host,
-		Port:     portStr,
+		Port:     port,
 		Protocol: protocol,
 		Params:   params,
 	}


### PR DESCRIPTION
### Description
There were some inconsistency in setting up port used to connect to Snowflake from example apps.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
