### PR TITLE
SNOW-823072: Use the context object supplied by BeginTx instead of from the parent connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -191,7 +191,7 @@ func (sc *snowflakeConn) BeginTx(
 		false /* isInternal */, isDesc, nil); err != nil {
 		return nil, err
 	}
-	return &snowflakeTx{sc}, nil
+	return &snowflakeTx{sc, ctx}, nil
 }
 
 func (sc *snowflakeConn) cleanup() {

--- a/transaction.go
+++ b/transaction.go
@@ -3,18 +3,20 @@
 package gosnowflake
 
 import (
+	"context"
 	"database/sql/driver"
 )
 
 type snowflakeTx struct {
-	sc *snowflakeConn
+	sc  *snowflakeConn
+	ctx context.Context
 }
 
 func (tx *snowflakeTx) Commit() (err error) {
 	if tx.sc == nil || tx.sc.rest == nil {
 		return driver.ErrBadConn
 	}
-	_, err = tx.sc.exec(tx.sc.ctx, "COMMIT", false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
+	_, err = tx.sc.exec(tx.ctx, "COMMIT", false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
 	if err != nil {
 		return
 	}
@@ -26,7 +28,7 @@ func (tx *snowflakeTx) Rollback() (err error) {
 	if tx.sc == nil || tx.sc.rest == nil {
 		return driver.ErrBadConn
 	}
-	_, err = tx.sc.exec(tx.sc.ctx, "ROLLBACK", false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
+	_, err = tx.sc.exec(tx.ctx, "ROLLBACK", false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
### Description
Fixes #796 
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/378

Commit() and Rollback() are currently not using the same context set in BeginTx(), they are using the context stored in the parent snowflakeConn object. If a connection context has a short deadline, it can result in commit() or rollback() not being called after a transaction due to the deadline exceeded. This is causing locks in customers environment when subsequent sessions hang and fail.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
