### PR TITLE
SNOW-828186 Remove code duplication in transaction.go

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -4,29 +4,47 @@ package gosnowflake
 
 import (
 	"database/sql/driver"
+	"errors"
 )
 
 type snowflakeTx struct {
 	sc *snowflakeConn
 }
 
+type txCommand int
+
+const (
+	commit txCommand = iota
+	rollback
+)
+
+func (cmd txCommand) string() (txStr string, err error) {
+	switch cmd {
+	case commit:
+		return "COMMIT", nil
+	case rollback:
+		return "ROLLBACK", nil
+	}
+	return "", errors.New("unsupported transaction command")
+}
+
 func (tx *snowflakeTx) Commit() (err error) {
-	if tx.sc == nil || tx.sc.rest == nil {
-		return driver.ErrBadConn
-	}
-	_, err = tx.sc.exec(tx.sc.ctx, "COMMIT", false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
-	if err != nil {
-		return
-	}
-	tx.sc = nil
-	return
+	return tx.execTxCommand(commit)
 }
 
 func (tx *snowflakeTx) Rollback() (err error) {
+	return tx.execTxCommand(rollback)
+}
+
+func (tx *snowflakeTx) execTxCommand(command txCommand) (err error) {
+	txStr, err := command.string()
+	if err != nil {
+		return err
+	}
 	if tx.sc == nil || tx.sc.rest == nil {
 		return driver.ErrBadConn
 	}
-	_, err = tx.sc.exec(tx.sc.ctx, "ROLLBACK", false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
+	_, err = tx.sc.exec(tx.sc.ctx, txStr, false /* noResult */, false /* isInternal */, false /* describeOnly */, nil)
 	if err != nil {
 		return
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -20,7 +20,7 @@ const (
 	rollback
 )
 
-func (cmd txCommand) string() (txStr string, err error) {
+func (cmd txCommand) string() (string, error) {
 	switch cmd {
 	case commit:
 		return "COMMIT", nil
@@ -30,18 +30,18 @@ func (cmd txCommand) string() (txStr string, err error) {
 	return "", errors.New("unsupported transaction command")
 }
 
-func (tx *snowflakeTx) Commit() (err error) {
+func (tx *snowflakeTx) Commit() error {
 	return tx.execTxCommand(commit)
 }
 
-func (tx *snowflakeTx) Rollback() (err error) {
+func (tx *snowflakeTx) Rollback() error {
 	return tx.execTxCommand(rollback)
 }
 
 func (tx *snowflakeTx) execTxCommand(command txCommand) (err error) {
 	txStr, err := command.string()
 	if err != nil {
-		return err
+		return
 	}
 	if tx.sc == nil || tx.sc.rest == nil {
 		return driver.ErrBadConn


### PR DESCRIPTION
### Description
Common code was extracted to separate function. In addition to that, an enum representation of transaction command was added to disallow any string being passed as a transaction command.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
