### PR TITLE
SNOW-723750: Panic with readonly file system

### DIFF
--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -748,6 +748,9 @@ func (sfa *snowflakeFileTransferAgent) uploadFilesParallel(fileMetas []*fileMeta
 
 			retryMeta := make([]*fileMetadata, 0)
 			for i, result := range results {
+				if result == nil {
+					return fmt.Errorf("err during upload: %v", errors[i])
+				}
 				result.errorDetails = errors[i]
 				if result.resStatus == renewToken || result.resStatus == renewPresignedURL {
 					retryMeta = append(retryMeta, result)

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -746,7 +746,7 @@ func (sfa *snowflakeFileTransferAgent) uploadFilesParallel(fileMetas []*fileMeta
 			}
 			wg.Wait()
 
-			// append errors with no result associated to separate table
+			// append errors with no result associated to separate array
 			var errorMessages []string
 			for i, result := range results {
 				if result == nil {

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -750,7 +750,11 @@ func (sfa *snowflakeFileTransferAgent) uploadFilesParallel(fileMetas []*fileMeta
 			var errorMessages []string
 			for i, result := range results {
 				if result == nil {
-					errorMessages = append(errorMessages, errors[i].Error())
+					if errors[i] == nil {
+						errorMessages = append(errorMessages, "unknown error")
+					} else {
+						errorMessages = append(errorMessages, errors[i].Error())
+					}
 				}
 			}
 			if errorMessages != nil {

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -557,12 +557,12 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 
 	// Make sure that the test uses read only directory
 	if isWindows {
-		originalTmpDir, envPresent := os.LookupEnv("TMP")
-		os.Setenv("TMP", roPath)
+		originalTmpDir, envPresent := os.LookupEnv("TEMP")
+		os.Setenv("TEMP", roPath)
 		if envPresent {
-			defer os.Setenv("TMP", originalTmpDir)
+			defer os.Setenv("TEMP", originalTmpDir)
 		} else {
-			defer os.Unsetenv("TMP")
+			defer os.Unsetenv("TEMP")
 		}
 	} else {
 		originalTmpDir, envPresent := os.LookupEnv("TMPDIR")

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -556,12 +556,22 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 	}
 
 	// Make sure that the test uses read only directory
-	originalTmpDir, envPresent := os.LookupEnv("TMPDIR")
-	os.Setenv("TMPDIR", roPath)
-	if envPresent {
-		defer os.Setenv("TMPDIR", originalTmpDir)
+	if isWindows {
+		originalTmpDir, envPresent := os.LookupEnv("TMP")
+		os.Setenv("TMP", roPath)
+		if envPresent {
+			defer os.Setenv("TMP", originalTmpDir)
+		} else {
+			defer os.Unsetenv("TMP")
+		}
 	} else {
-		defer os.Unsetenv("TMPDIR")
+		originalTmpDir, envPresent := os.LookupEnv("TMPDIR")
+		os.Setenv("TMPDIR", roPath)
+		if envPresent {
+			defer os.Setenv("TMPDIR", originalTmpDir)
+		} else {
+			defer os.Unsetenv("TMPDIR")
+		}
 	}
 
 	uploadMeta := fileMetadata{

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -597,7 +597,7 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 		fileMetadata:      []*fileMetadata{&uploadMeta},
 	}
 
-	// Enable parallel transfer
+	// Set max parallel uploads to 1
 	sfa.parallel = 1
 
 	err = sfa.uploadFilesParallel([]*fileMetadata{&uploadMeta})

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -534,6 +534,11 @@ func TestUpdateMetadataWithPresignedUrlError(t *testing.T) {
 }
 
 func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
+	// Disable the test on Windows
+	if isWindows {
+		return
+	}
+
 	var err error
 	roPath := t.TempDir()
 	if err != nil {
@@ -556,11 +561,7 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 	}
 
 	// Make sure that the test uses read only directory
-	if isWindows {
-		t.Setenv("TEMP", roPath)
-	} else {
-		t.Setenv("TMPDIR", roPath)
-	}
+	t.Setenv("TMPDIR", roPath)
 
 	uploadMeta := fileMetadata{
 		name:              "data1.txt.gz",

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -556,8 +556,13 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 	}
 
 	// Make sure that the test uses read only directory
+	originalTmpDir, envPresent := os.LookupEnv("TMPDIR")
 	os.Setenv("TMPDIR", roPath)
-	defer os.Unsetenv("TMPDIR")
+	if envPresent {
+		defer os.Setenv("TMPDIR", originalTmpDir)
+	} else {
+		defer os.Unsetenv("TMPDIR")
+	}
 
 	uploadMeta := fileMetadata{
 		name:              "data1.txt.gz",
@@ -589,7 +594,7 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 	if err == nil {
 		t.Fatal("should error when the filesystem is read only")
 	}
-	if !strings.Contains(err.Error(), "err during upload: mkdir") {
+	if !strings.Contains(err.Error(), "errors during file upload:\nmkdir") {
 		t.Fatalf("should error when creating the temporary directory. Instead errored with: %v", err)
 	}
 }

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -557,21 +557,9 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 
 	// Make sure that the test uses read only directory
 	if isWindows {
-		originalTmpDir, envPresent := os.LookupEnv("TEMP")
-		os.Setenv("TEMP", roPath)
-		if envPresent {
-			defer os.Setenv("TEMP", originalTmpDir)
-		} else {
-			defer os.Unsetenv("TEMP")
-		}
+		t.Setenv("TEMP", roPath)
 	} else {
-		originalTmpDir, envPresent := os.LookupEnv("TMPDIR")
-		os.Setenv("TMPDIR", roPath)
-		if envPresent {
-			defer os.Setenv("TMPDIR", originalTmpDir)
-		} else {
-			defer os.Unsetenv("TMPDIR")
-		}
+		t.Setenv("TMPDIR", roPath)
 	}
 
 	uploadMeta := fileMetadata{


### PR DESCRIPTION
### Description
Fixed driver panicking when the temp filesystem is readonly.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
