### PR TITLE
addedd support for sql.Null types

### DIFF
--- a/bindings_test.go
+++ b/bindings_test.go
@@ -861,3 +861,42 @@ func TestBulkArrayMultiPartBindingWithNull(t *testing.T) {
 		dbt.mustExec("DROP TABLE binding_test")
 	})
 }
+
+func TestFunctionNullSelect(t *testing.T) {
+	runTests(t, dsn, func(dbt *DBTest) {
+		dbt.mustExec(`
+		CREATE OR REPLACE FUNCTION NULLPARAMFUNCTION("param1" text, "param2" number, "param3" double)
+		RETURNS TABLE ("res1" text, "res2" number, "res3" double)
+		LANGUAGE SQL
+		AS 'select param1, param2, param3';
+		`)
+		if rows, err := dbt.db.Query("select * from table(NULLPARAMFUNCTION(?, ?, ?))", sql.NullString{}, sql.NullInt64{}, sql.NullFloat64{}); err != nil {
+			t.Fatal(err)
+		} else {
+			if rows.Err() != nil {
+				t.Fatal(err)
+			} else {
+				if !rows.Next() {
+					t.Fatal()
+				} else {
+					var r1 sql.NullString
+					var r2 sql.NullInt64
+					var r3 sql.NullFloat64
+					err = rows.Scan(&r1, &r2, &r3)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if r1.Valid {
+						t.Fatal(err)
+					}
+					if r2.Valid {
+						t.Fatal(err)
+					}
+					if r3.Valid {
+						t.Fatal(err)
+					}
+				}
+			}
+		}
+	})
+}

--- a/connection.go
+++ b/connection.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -398,6 +399,11 @@ func (sc *snowflakeConn) Ping(ctx context.Context) error {
 // CheckNamedValue determines which types are handled by this driver aside from
 // the instances captured by driver.Value
 func (sc *snowflakeConn) CheckNamedValue(nv *driver.NamedValue) error {
+	switch reflect.TypeOf(nv.Value) {
+	case reflect.TypeOf(sql.NullString{}), reflect.TypeOf(sql.NullInt64{}),
+		reflect.TypeOf(sql.NullBool{}), reflect.TypeOf(sql.NullFloat64{}):
+		return nil
+	}
 	if supported := supportedArrayBind(nv); !supported {
 		return driver.ErrSkip
 	}


### PR DESCRIPTION
### Description
Bypass nil value types to the API call so the server can call procedure/function properly.
Fixes #831 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
