### PR TITLE
SNOW-856850: Add missing parameter check in tests

### DIFF
--- a/dsn_test.go
+++ b/dsn_test.go
@@ -131,6 +131,7 @@ func TestParseDSN(t *testing.T) {
 				OCSPFailOpen:              OCSPFailOpenTrue,
 				ValidateDefaultParameters: ConfigBoolTrue,
 				ClientTimeout:             defaultClientTimeout,
+				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
 			},
 			ocspMode: ocspModeFailOpen,
 			err:      nil,
@@ -538,7 +539,8 @@ func TestParseDSN(t *testing.T) {
 				Account: "a", User: "u", Password: "p",
 				Protocol: "https", Host: "a.r.c.snowflakecomputing.com", Port: 443,
 				Database: "db", Schema: "s", ValidateDefaultParameters: ConfigBoolTrue, OCSPFailOpen: OCSPFailOpenTrue,
-				ClientTimeout: 300 * time.Second,
+				ClientTimeout:          300 * time.Second,
+				ExternalBrowserTimeout: defaultExternalBrowserTimeout,
 			},
 			ocspMode: ocspModeFailOpen,
 			err:      nil,
@@ -624,6 +626,10 @@ func TestParseDSN(t *testing.T) {
 			if test.config.ClientTimeout != cfg.ClientTimeout {
 				t.Fatalf("%d: Failed to match ClientTimeout. expected: %v, got: %v",
 					i, test.config.ClientTimeout, cfg.ClientTimeout)
+			}
+			if test.config.ExternalBrowserTimeout != cfg.ExternalBrowserTimeout {
+				t.Fatalf("%d: Failed to match ExternalBrowserTimeout. expected: %v, got: %v",
+					i, test.config.ExternalBrowserTimeout, cfg.ExternalBrowserTimeout)
 			}
 		case test.err != nil:
 			driverErrE, okE := test.err.(*SnowflakeError)


### PR DESCRIPTION
### Description
Add missing parameter ExternalBrowserTimeout check in tests.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
