### PR TITLE
Adding More Visibility into chunk downloader

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -121,8 +121,8 @@ func (scd *snowflakeChunkDownloader) start() error {
 	// start downloading chunks if exists
 	chunkMetaLen := len(scd.ChunkMetas)
 	if chunkMetaLen > 0 {
-		logger.Debugf("MaxChunkDownloadWorkers: %v", MaxChunkDownloadWorkers)
-		logger.Debugf("chunks: %v, total bytes: %d", chunkMetaLen, scd.totalUncompressedSize())
+		logger.WithContext(scd.ctx).Infof("MaxChunkDownloadWorkers: %v", MaxChunkDownloadWorkers)
+		logger.WithContext(scd.ctx).Infof("chunks: %v, total bytes: %d", chunkMetaLen, scd.totalUncompressedSize())
 		scd.ChunksMutex = &sync.Mutex{}
 		scd.DoneDownloadCond = sync.NewCond(scd.ChunksMutex)
 		scd.Chunks = make(map[int][]chunkRowType)
@@ -130,7 +130,7 @@ func (scd *snowflakeChunkDownloader) start() error {
 		scd.ChunksError = make(chan *chunkError, MaxChunkDownloadWorkers)
 		for i := 0; i < chunkMetaLen; i++ {
 			chunk := scd.ChunkMetas[i]
-			logger.Debugf("add chunk to channel ChunksChan: %v, URL: %v, RowCount: %v, UncompressedSize: %v, ChunkResultFormat: %v",
+			logger.WithContext(scd.ctx).Infof("add chunk to channel ChunksChan: %v, URL: %v, RowCount: %v, UncompressedSize: %v, ChunkResultFormat: %v",
 				i+1, chunk.URL, chunk.RowCount, chunk.UncompressedSize, scd.QueryResultFormat)
 			scd.ChunksChan <- i
 		}

--- a/query.go
+++ b/query.go
@@ -39,6 +39,10 @@ type execResponseRowType struct {
 	Nullable   bool   `json:"nullable"`
 }
 
+type ExecResponseChunk struct {
+	execResponseChunk
+}
+
 type execResponseChunk struct {
 	URL              string `json:"url"`
 	RowCount         int    `json:"rowCount"`

--- a/result.go
+++ b/result.go
@@ -20,6 +20,10 @@ type SnowflakeResult interface {
 	GetArrowBatches() ([]*ArrowBatch, error)
 }
 
+type SnowflakeChunkResult interface {
+	GetChunkMetas() []ExecResponseChunk
+}
+
 type snowflakeResult struct {
 	affectedRows int64
 	insertID     int64 // Snowflake doesn't support last insert id

--- a/rows.go
+++ b/rows.go
@@ -163,6 +163,17 @@ func (rows *snowflakeRows) GetArrowBatches() ([]*ArrowBatch, error) {
 	return rows.ChunkDownloader.getArrowBatches(), nil
 }
 
+func (rows *snowflakeRows) GetChunkMetas() []ExecResponseChunk {
+	execResponseChunkPrivate := rows.ChunkDownloader.getChunkMetas()
+	execResponseChunkExport := make([]ExecResponseChunk, len(execResponseChunkPrivate))
+	for i := 0; i < len(execResponseChunkPrivate); i++ {
+		execResponseChunkExport[i] = ExecResponseChunk{
+			execResponseChunkPrivate[i],
+		}
+	}
+	return execResponseChunkExport
+}
+
 func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 	if err = rows.waitForAsyncQueryStatus(); err != nil {
 		return err


### PR DESCRIPTION
### Description
This purpose of the PR is to add all file changes of this [PR](https://github.com/sigmacomputing/gosnowflake/pull/137) to the master branch. This [PR](https://github.com/sigmacomputing/gosnowflake/pull/137) changes are merged to safe stable branch and these changes are not available in master branch. 

Expose GetChunkMetas() SnowflakeResult to get underlying chunk metadata, so we know how many chunks SF gives us, what's the chunk size.

Make `execResponseChunk` public so we can expose it to tracing. 

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
