### PR TITLE
SNOW-859548 Reuse connection in tests

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -32,13 +32,13 @@ func TestInvalidConnection(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Error("should not cause error in the second call of Close")
 	}
-	if _, err := db.Exec("CREATE TABLE OR REPLACE test0(c1 int)"); err == nil {
+	if _, err := db.ExecContext(context.Background(), "CREATE TABLE OR REPLACE test0(c1 int)"); err == nil {
 		t.Error("should fail to run Exec")
 	}
-	if _, err := db.Query("SELECT CURRENT_TIMESTAMP()"); err == nil {
+	if _, err := db.QueryContext(context.Background(), "SELECT CURRENT_TIMESTAMP()"); err == nil {
 		t.Error("should fail to run Query")
 	}
-	if _, err := db.Begin(); err == nil {
+	if _, err := db.BeginTx(context.Background(), nil); err == nil {
 		t.Error("should fail to run Begin")
 	}
 }

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -70,7 +70,7 @@ func TestUnitDownloadWithInvalidLocalPath(t *testing.T) {
 	f.Close()
 
 	runTests(t, dsn, func(dbt *DBTest) {
-		if _, err = dbt.db.Exec("use role sysadmin"); err != nil {
+		if _, err = dbt.exec("use role sysadmin"); err != nil {
 			t.Skip("snowflake admin account not accessible")
 		}
 		dbt.mustExec("rm @~/test_get")
@@ -79,7 +79,7 @@ func TestUnitDownloadWithInvalidLocalPath(t *testing.T) {
 		dbt.mustExec(sqlText)
 
 		sqlText = fmt.Sprintf("get @~/test_get/data.txt file://%v\\get", tmpDir)
-		if _, err = dbt.db.Query(sqlText); err == nil {
+		if _, err = dbt.query(sqlText); err == nil {
 			t.Fatalf("should return local path not directory error.")
 		}
 		dbt.mustExec("rm @~/test_get")

--- a/put_get_user_stage_test.go
+++ b/put_get_user_stage_test.go
@@ -87,6 +87,7 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 		dbt.mustExec(fmt.Sprintf("copy into %v from @%v", dbname, stageName))
 
 		rows := dbt.mustQuery("select count(*) from " + dbname)
+		defer rows.Close()
 		var cnt string
 		if rows.Next() {
 			rows.Scan(&cnt)
@@ -134,6 +135,7 @@ func TestPutLoadFromUserStage(t *testing.T) {
 		rows := dbt.mustQuery(fmt.Sprintf(`copy into gotest_putget_t2 from @%v
 			file_format = (field_delimiter = '|' error_on_column_count_mismatch
 			=false) purge=true`, data.stage))
+		defer rows.Close()
 		var s0, s1, s2, s3, s4, s5 string
 		var s6, s7, s8, s9 interface{}
 		orders100 := fmt.Sprintf("s3://%v/%v/orders_100.csv.gz",

--- a/put_get_with_aws_test.go
+++ b/put_get_with_aws_test.go
@@ -70,6 +70,7 @@ func TestLoadS3(t *testing.T) {
 			AWS_SECRET_KEY='%v') file_format=(skip_header=1 null_if=('')
 			field_optionally_enclosed_by='\"')`,
 			data.awsAccessKeyID, data.awsSecretAccessKey))
+		defer rows.Close()
 		var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9 string
 		cnt := 0
 		for rows.Next() {
@@ -303,6 +304,7 @@ func TestPutGetAWSStage(t *testing.T) {
 		sql := "put 'file://%v' @~/%v auto_compress=false"
 		sqlText := fmt.Sprintf(sql, strings.ReplaceAll(fname, "\\", "\\\\"), stageName)
 		rows := dbt.mustQuery(sqlText)
+		defer rows.Close()
 
 		var s0, s1, s2, s3, s4, s5, s6, s7 string
 		if rows.Next() {

--- a/rows_test.go
+++ b/rows_test.go
@@ -57,7 +57,7 @@ var (
 // Special cases where rows are already closed
 func TestRowsClose(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
-		rows, err := dbt.db.Query("SELECT 1")
+		rows, err := dbt.query("SELECT 1")
 		if err != nil {
 			dbt.Fatal(err)
 		}
@@ -77,7 +77,7 @@ func TestRowsClose(t *testing.T) {
 func TestResultNoRows(t *testing.T) {
 	// DDL
 	runTests(t, dsn, func(dbt *DBTest) {
-		row, err := dbt.db.Exec("CREATE OR REPLACE TABLE test(c1 int)")
+		row, err := dbt.exec("CREATE OR REPLACE TABLE test(c1 int)")
 		if err != nil {
 			t.Fatalf("failed to execute DDL. err: %v", err)
 		}


### PR DESCRIPTION
### Description
All tests opened new connections, even if they could reuse a connection from the pool. Migrating to the pool decreased tests time around 15%.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
