### PR TITLE
Do not re-use error object to prevent state leak

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -82,7 +82,13 @@ func (se *SnowflakeError) exceptionTelemetry(sc *snowflakeConn) *SnowflakeError 
 
 // return populated error fields replacing the default response
 func populateErrorFields(code int, data *execResponse) *SnowflakeError {
-	err := ErrUnknownError
+	err := SnowflakeError{
+		Number:   -1,
+		SQLState: "-1",
+		Message:  "an unknown server side error occurred",
+		QueryID:  "-1",
+	}
+
 	if code != -1 {
 		err.Number = code
 	}
@@ -95,7 +101,7 @@ func populateErrorFields(code int, data *execResponse) *SnowflakeError {
 	if data.Data.QueryID != "" {
 		err.QueryID = data.Data.QueryID
 	}
-	return err
+	return &err
 }
 
 const (


### PR DESCRIPTION
When running concurrent queries we have observed that the error message from the queries was being leaked from one to the other. The fix from PR #834 is not fully effective as the `defer errMutex.Unlock()` will unlock the error object as soon as it gets returned from this function - however since we're returning a pointer - the next query will still change the error message.

I have added 2 tests to show-case behaviour:
1. TestConcurrentExecContextWithUnsuccessfulDataError
2. TestConcurrentExecContextWithErroredHTTPCall

The first test covers the issue described above that was previously attempted to be fixed with #834. If the changes in `errors.go` are undone, this will start failing intermittently. This test contains a small `time.Sleep(...)` to simulate an interleaving thread (which is how we observed the problem in the first place).

The second test show-cases a problem I landed on whilst experimenting with this race condition. This test is **still currently failing due to a data race**. I do not have a fix for this as part of this PR - but I'm happy to add something in - it is a much more involved change as the errors stack trace is:
```
WARNING: DATA RACE
Write at 0x00c0003d4000 by goroutine 51:
  github.com/snowflakedb/gosnowflake.(*snowflakeTelemetry).addLog()
      gosnowflake/telemetry.go:56 +0x150
  github.com/snowflakedb/gosnowflake.(*SnowflakeError).sendExceptionTelemetry()
      gosnowflake/errors.go:70 +0xf8
  github.com/snowflakedb/gosnowflake.(*SnowflakeError).exceptionTelemetry()
      gosnowflake/errors.go:77 +0xfc
  github.com/snowflakedb/gosnowflake.(*snowflakeConn).ExecContext()
      gosnowflake/connection.go:265 +0x4e0
  github.com/snowflakedb/gosnowflake.TestConcurrentExecContextWithErroredHTTPCall.func1()
      gosnowflake/connection_test.go:742 +0x120
```