### PR TITLE
Avoid creating executable files

### DIFF
--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -204,7 +204,7 @@ func (util *snowflakeAzureClient) uploadFile(
 		})
 	} else {
 		var f *os.File
-		f, err = os.OpenFile(dataFile, os.O_RDONLY, readWriteFileMode)
+		f, err = os.Open(dataFile)
 		if err != nil {
 			return err
 		}

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -204,7 +204,7 @@ func (util *snowflakeAzureClient) uploadFile(
 		})
 	} else {
 		var f *os.File
-		f, err = os.OpenFile(dataFile, os.O_RDONLY, os.ModePerm)
+		f, err = os.OpenFile(dataFile, os.O_RDONLY, 0666)
 		if err != nil {
 			return err
 		}
@@ -273,7 +273,7 @@ func (util *snowflakeAzureClient) nativeDownloadFile(
 	if meta.mockAzureClient != nil {
 		blobClient = meta.mockAzureClient
 	}
-	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -204,7 +204,7 @@ func (util *snowflakeAzureClient) uploadFile(
 		})
 	} else {
 		var f *os.File
-		f, err = os.OpenFile(dataFile, os.O_RDONLY, 0666)
+		f, err = os.OpenFile(dataFile, os.O_RDONLY, readWriteFileMode)
 		if err != nil {
 			return err
 		}
@@ -273,7 +273,7 @@ func (util *snowflakeAzureClient) nativeDownloadFile(
 	if meta.mockAzureClient != nil {
 		blobClient = meta.mockAzureClient
 	}
-	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		return err
 	}

--- a/doc.go
+++ b/doc.go
@@ -889,7 +889,7 @@ both an escape character and as a separator in path names.
 To send information from a stream (rather than a file) use code similar to the code below.
 (The ReplaceAll() function is needed on Windows to handle backslashes in the path to the file.)
 
-	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
+	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, 0666)
 	defer func() {
 		if fileStream != nil {
 			fileStream.Close()

--- a/doc.go
+++ b/doc.go
@@ -889,7 +889,7 @@ both an escape character and as a separator in path names.
 To send information from a stream (rather than a file) use code similar to the code below.
 (The ReplaceAll() function is needed on Windows to handle backslashes in the path to the file.)
 
-	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, 0666)
+	fileStream, _ := os.Open(fname)
 	defer func() {
 		if fileStream != nil {
 			fileStream.Close()

--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -176,7 +176,7 @@ func encryptFile(
 	if err != nil {
 		return nil, "", err
 	}
-	infile, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0666)
+	infile, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, readWriteFileMode)
 	if err != nil {
 		return nil, "", err
 	}
@@ -232,7 +232,7 @@ func decryptFile(
 		return "", err
 	}
 	defer tmpOutputFile.Close()
-	infile, err := os.OpenFile(filename, os.O_RDONLY, 0666)
+	infile, err := os.OpenFile(filename, os.O_RDONLY, readWriteFileMode)
 	if err != nil {
 		return "", err
 	}

--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -232,7 +232,7 @@ func decryptFile(
 		return "", err
 	}
 	defer tmpOutputFile.Close()
-	infile, err := os.OpenFile(filename, os.O_RDONLY, readWriteFileMode)
+	infile, err := os.Open(filename)
 	if err != nil {
 		return "", err
 	}

--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -176,7 +176,7 @@ func encryptFile(
 	if err != nil {
 		return nil, "", err
 	}
-	infile, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, os.ModePerm)
+	infile, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0666)
 	if err != nil {
 		return nil, "", err
 	}
@@ -232,7 +232,7 @@ func decryptFile(
 		return "", err
 	}
 	defer tmpOutputFile.Close()
-	infile, err := os.OpenFile(filename, os.O_RDONLY, os.ModePerm)
+	infile, err := os.OpenFile(filename, os.O_RDONLY, 0666)
 	if err != nil {
 		return "", err
 	}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -54,7 +54,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	}
 	defer os.Remove(decryptedFile)
 
-	fd, err = os.OpenFile(decryptedFile, os.O_RDONLY, readWriteFileMode)
+	fd, err = os.Open(decryptedFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,7 +144,7 @@ func encryptDecryptFile(t *testing.T, encMat snowflakeFileEncryption, expected i
 	defer os.Remove(decryptedFile)
 
 	cnt := 0
-	fd, err := os.OpenFile(decryptedFile, os.O_RDONLY, readWriteFileMode)
+	fd, err := os.Open(decryptedFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -238,7 +238,7 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 					return "", err
 				}
 				w := gzip.NewWriter(fOut)
-				fIn, err := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
+				fIn, err := os.Open(fname)
 				if err != nil {
 					return "", err
 				}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -33,7 +33,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	data := "test data"
 	inputFile := "test_encrypt_decrypt_file"
 
-	fd, err := os.OpenFile(inputFile, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+	fd, err := os.Create(inputFile)
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,7 +168,7 @@ func generateKLinesOfNByteRows(numLines int, numBytes int, tmpDir string) (strin
 		}
 	}
 	fname := path.Join(tmpDir, "file"+strconv.FormatInt(int64(numLines*numBytes), 10))
-	f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+	f, err := os.Create(fname)
 	if err != nil {
 		return "", err
 	}
@@ -191,7 +191,7 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 	}
 	for i := 0; i < n; i++ {
 		fname := path.Join(tmpDir, "file"+strconv.FormatInt(int64(i), 10))
-		f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+		f, err := os.Create(fname)
 		if err != nil {
 			return "", err
 		}
@@ -233,7 +233,7 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 				io.ReadAll(gzipErr)
 				gzipCmd.Wait()
 			} else {
-				fOut, err := os.OpenFile(fname+".gz", os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+				fOut, err := os.Create(fname + ".gz")
 				if err != nil {
 					return "", err
 				}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -33,7 +33,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	data := "test data"
 	inputFile := "test_encrypt_decrypt_file"
 
-	fd, err := os.OpenFile(inputFile, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	fd, err := os.OpenFile(inputFile, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,7 +54,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	}
 	defer os.Remove(decryptedFile)
 
-	fd, err = os.OpenFile(decryptedFile, os.O_RDONLY, os.ModePerm)
+	fd, err = os.OpenFile(decryptedFile, os.O_RDONLY, 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,7 +144,7 @@ func encryptDecryptFile(t *testing.T, encMat snowflakeFileEncryption, expected i
 	defer os.Remove(decryptedFile)
 
 	cnt := 0
-	fd, err := os.OpenFile(decryptedFile, os.O_RDONLY, os.ModePerm)
+	fd, err := os.OpenFile(decryptedFile, os.O_RDONLY, 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,7 +168,7 @@ func generateKLinesOfNByteRows(numLines int, numBytes int, tmpDir string) (strin
 		}
 	}
 	fname := path.Join(tmpDir, "file"+strconv.FormatInt(int64(numLines*numBytes), 10))
-	f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return "", err
 	}
@@ -191,7 +191,7 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 	}
 	for i := 0; i < n; i++ {
 		fname := path.Join(tmpDir, "file"+strconv.FormatInt(int64(i), 10))
-		f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+		f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			return "", err
 		}
@@ -233,12 +233,12 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 				io.ReadAll(gzipErr)
 				gzipCmd.Wait()
 			} else {
-				fOut, err := os.OpenFile(fname+".gz", os.O_CREATE|os.O_WRONLY, os.ModePerm)
+				fOut, err := os.OpenFile(fname+".gz", os.O_CREATE|os.O_WRONLY, 0666)
 				if err != nil {
 					return "", err
 				}
 				w := gzip.NewWriter(fOut)
-				fIn, err := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
+				fIn, err := os.OpenFile(fname, os.O_RDONLY, 0666)
 				if err != nil {
 					return "", err
 				}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -33,7 +33,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	data := "test data"
 	inputFile := "test_encrypt_decrypt_file"
 
-	fd, err := os.OpenFile(inputFile, os.O_CREATE|os.O_WRONLY, 0666)
+	fd, err := os.OpenFile(inputFile, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,7 +54,7 @@ func TestEncryptDecryptFile(t *testing.T) {
 	}
 	defer os.Remove(decryptedFile)
 
-	fd, err = os.OpenFile(decryptedFile, os.O_RDONLY, 0666)
+	fd, err = os.OpenFile(decryptedFile, os.O_RDONLY, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,7 +144,7 @@ func encryptDecryptFile(t *testing.T, encMat snowflakeFileEncryption, expected i
 	defer os.Remove(decryptedFile)
 
 	cnt := 0
-	fd, err := os.OpenFile(decryptedFile, os.O_RDONLY, 0666)
+	fd, err := os.OpenFile(decryptedFile, os.O_RDONLY, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,7 +168,7 @@ func generateKLinesOfNByteRows(numLines int, numBytes int, tmpDir string) (strin
 		}
 	}
 	fname := path.Join(tmpDir, "file"+strconv.FormatInt(int64(numLines*numBytes), 10))
-	f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		return "", err
 	}
@@ -191,7 +191,7 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 	}
 	for i := 0; i < n; i++ {
 		fname := path.Join(tmpDir, "file"+strconv.FormatInt(int64(i), 10))
-		f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0666)
+		f, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 		if err != nil {
 			return "", err
 		}
@@ -233,12 +233,12 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 				io.ReadAll(gzipErr)
 				gzipCmd.Wait()
 			} else {
-				fOut, err := os.OpenFile(fname+".gz", os.O_CREATE|os.O_WRONLY, 0666)
+				fOut, err := os.OpenFile(fname+".gz", os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 				if err != nil {
 					return "", err
 				}
 				w := gzip.NewWriter(fOut)
-				fIn, err := os.OpenFile(fname, os.O_RDONLY, 0666)
+				fIn, err := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
 				if err != nil {
 					return "", err
 				}

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -62,7 +62,7 @@ func TestUnitDownloadWithInvalidLocalPath(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, 0666)
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -62,7 +62,7 @@ func TestUnitDownloadWithInvalidLocalPath(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, readWriteFileMode)
+	f, err := os.Create(testData)
 	if err != nil {
 		t.Error(err)
 	}

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -62,7 +62,7 @@ func TestUnitDownloadWithInvalidLocalPath(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, os.ModePerm)
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
 		t.Error(err)
 	}

--- a/file_util.go
+++ b/file_util.go
@@ -39,12 +39,12 @@ func (util *snowflakeFileUtil) compressFileWithGzip(fileName string, tmpDir stri
 	basename := baseName(fileName)
 	gzipFileName := filepath.Join(tmpDir, basename+"_c.gz")
 
-	fr, err := os.OpenFile(fileName, os.O_RDONLY, os.ModePerm)
+	fr, err := os.OpenFile(fileName, os.O_RDONLY, 0666)
 	if err != nil {
 		return "", -1, err
 	}
 	defer fr.Close()
-	fw, err := os.OpenFile(gzipFileName, os.O_WRONLY|os.O_CREATE, os.ModePerm)
+	fw, err := os.OpenFile(gzipFileName, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return "", -1, err
 	}

--- a/file_util.go
+++ b/file_util.go
@@ -19,7 +19,8 @@ type snowflakeFileUtil struct {
 }
 
 const (
-	fileChunkSize = 16 * 4 * 1024
+	fileChunkSize                 = 16 * 4 * 1024
+	readWriteFileMode os.FileMode = 0666
 )
 
 func (util *snowflakeFileUtil) compressFileWithGzipFromStream(srcStream **bytes.Buffer) (*bytes.Buffer, int, error) {
@@ -39,12 +40,12 @@ func (util *snowflakeFileUtil) compressFileWithGzip(fileName string, tmpDir stri
 	basename := baseName(fileName)
 	gzipFileName := filepath.Join(tmpDir, basename+"_c.gz")
 
-	fr, err := os.OpenFile(fileName, os.O_RDONLY, 0666)
+	fr, err := os.OpenFile(fileName, os.O_RDONLY, readWriteFileMode)
 	if err != nil {
 		return "", -1, err
 	}
 	defer fr.Close()
-	fw, err := os.OpenFile(gzipFileName, os.O_WRONLY|os.O_CREATE, 0666)
+	fw, err := os.OpenFile(gzipFileName, os.O_WRONLY|os.O_CREATE, readWriteFileMode)
 	if err != nil {
 		return "", -1, err
 	}

--- a/file_util.go
+++ b/file_util.go
@@ -40,7 +40,7 @@ func (util *snowflakeFileUtil) compressFileWithGzip(fileName string, tmpDir stri
 	basename := baseName(fileName)
 	gzipFileName := filepath.Join(tmpDir, basename+"_c.gz")
 
-	fr, err := os.OpenFile(fileName, os.O_RDONLY, readWriteFileMode)
+	fr, err := os.Open(fileName)
 	if err != nil {
 		return "", -1, err
 	}

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -196,7 +196,7 @@ func (util *snowflakeGcsClient) uploadFile(
 			uploadSrc = meta.realSrcStream
 		}
 	} else {
-		uploadSrc, err = os.OpenFile(dataFile, os.O_RDONLY, readWriteFileMode)
+		uploadSrc, err = os.Open(dataFile)
 		if err != nil {
 			return err
 		}

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -196,7 +196,7 @@ func (util *snowflakeGcsClient) uploadFile(
 			uploadSrc = meta.realSrcStream
 		}
 	} else {
-		uploadSrc, err = os.OpenFile(dataFile, os.O_RDONLY, os.ModePerm)
+		uploadSrc, err = os.OpenFile(dataFile, os.O_RDONLY, 0666)
 		if err != nil {
 			return err
 		}
@@ -314,7 +314,7 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 		return meta.lastError
 	}
 
-	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -196,7 +196,7 @@ func (util *snowflakeGcsClient) uploadFile(
 			uploadSrc = meta.realSrcStream
 		}
 	} else {
-		uploadSrc, err = os.OpenFile(dataFile, os.O_RDONLY, 0666)
+		uploadSrc, err = os.OpenFile(dataFile, os.O_RDONLY, readWriteFileMode)
 		if err != nil {
 			return err
 		}
@@ -314,7 +314,7 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 		return meta.lastError
 	}
 
-	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		return err
 	}

--- a/local_storage_client.go
+++ b/local_storage_client.go
@@ -47,7 +47,7 @@ func (util *localUtil) uploadOneFileWithRetry(meta *fileMetadata) error {
 			return nil
 		}
 	}
-	output, err := os.OpenFile(filepath.Join(user, meta.dstFileName), os.O_CREATE|os.O_WRONLY, 0666)
+	output, err := os.OpenFile(filepath.Join(user, meta.dstFileName), os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (util *localUtil) downloadOneFile(meta *fileMetadata) error {
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(fullDstFileName, data, 0666); err != nil {
+	if err = os.WriteFile(fullDstFileName, data, readWriteFileMode); err != nil {
 		return err
 	}
 	fi, err := os.Stat(fullDstFileName)

--- a/local_storage_client.go
+++ b/local_storage_client.go
@@ -47,7 +47,7 @@ func (util *localUtil) uploadOneFileWithRetry(meta *fileMetadata) error {
 			return nil
 		}
 	}
-	output, err := os.OpenFile(filepath.Join(user, meta.dstFileName), os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	output, err := os.OpenFile(filepath.Join(user, meta.dstFileName), os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (util *localUtil) downloadOneFile(meta *fileMetadata) error {
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(fullDstFileName, data, os.ModePerm); err != nil {
+	if err = os.WriteFile(fullDstFileName, data, 0666); err != nil {
 		return err
 	}
 	fi, err := os.Stat(fullDstFileName)

--- a/local_storage_client_test.go
+++ b/local_storage_client_test.go
@@ -73,7 +73,7 @@ func TestLocalUpload(t *testing.T) {
 	if uploadMeta.resStatus != skipped {
 		t.Fatal("overwrite is false. should have skipped")
 	}
-	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
+	fileStream, _ := os.Open(fname)
 	ctx := WithFileStream(context.Background(), fileStream)
 	uploadMeta.srcStream = getFileStream(ctx)
 

--- a/local_storage_client_test.go
+++ b/local_storage_client_test.go
@@ -25,7 +25,7 @@ func TestLocalUpload(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 	putDir, err := os.MkdirTemp("", "put")
@@ -73,7 +73,7 @@ func TestLocalUpload(t *testing.T) {
 	if uploadMeta.resStatus != skipped {
 		t.Fatal("overwrite is false. should have skipped")
 	}
-	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, 0666)
+	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
 	ctx := WithFileStream(context.Background(), fileStream)
 	uploadMeta.srcStream = getFileStream(ctx)
 
@@ -116,7 +116,7 @@ func TestDownloadLocalFile(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 	putDir, err := os.MkdirTemp("", "put")

--- a/local_storage_client_test.go
+++ b/local_storage_client_test.go
@@ -25,7 +25,7 @@ func TestLocalUpload(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 	putDir, err := os.MkdirTemp("", "put")
@@ -73,7 +73,7 @@ func TestLocalUpload(t *testing.T) {
 	if uploadMeta.resStatus != skipped {
 		t.Fatal("overwrite is false. should have skipped")
 	}
-	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
+	fileStream, _ := os.OpenFile(fname, os.O_RDONLY, 0666)
 	ctx := WithFileStream(context.Background(), fileStream)
 	uploadMeta.srcStream = getFileStream(ctx)
 
@@ -116,7 +116,7 @@ func TestDownloadLocalFile(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 	putDir, err := os.MkdirTemp("", "put")

--- a/ocsp.go
+++ b/ocsp.go
@@ -723,7 +723,7 @@ func initOCSPCache() {
 	ocspResponseCacheLock = &sync.RWMutex{}
 
 	logger.Infof("reading OCSP Response cache file. %v\n", cacheFileName)
-	f, err := os.OpenFile(cacheFileName, os.O_CREATE|os.O_RDONLY, 0666)
+	f, err := os.OpenFile(cacheFileName, os.O_CREATE|os.O_RDONLY, readWriteFileMode)
 	if err != nil {
 		logger.Debugf("failed to open. Ignored. %v\n", err)
 		return

--- a/ocsp.go
+++ b/ocsp.go
@@ -723,7 +723,7 @@ func initOCSPCache() {
 	ocspResponseCacheLock = &sync.RWMutex{}
 
 	logger.Infof("reading OCSP Response cache file. %v\n", cacheFileName)
-	f, err := os.OpenFile(cacheFileName, os.O_CREATE|os.O_RDONLY, os.ModePerm)
+	f, err := os.OpenFile(cacheFileName, os.O_CREATE|os.O_RDONLY, 0666)
 	if err != nil {
 		logger.Debugf("failed to open. Ignored. %v\n", err)
 		return

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -515,7 +515,7 @@ func TestInitOCSPCacheFileCreation(t *testing.T) {
 	defer func() {
 		src, _ = os.Open(tmpFileName)
 		defer src.Close()
-		dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, 0666)
+		dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, readWriteFileMode)
 		defer dst.Close()
 		// copy temporary file contents back to original file
 		if _, err = io.Copy(dst, src); err != nil {

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -515,7 +515,7 @@ func TestInitOCSPCacheFileCreation(t *testing.T) {
 	defer func() {
 		src, _ = os.Open(tmpFileName)
 		defer src.Close()
-		dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, os.ModePerm)
+		dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, 0666)
 		defer dst.Close()
 		// copy temporary file contents back to original file
 		if _, err = io.Copy(dst, src); err != nil {

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -399,7 +399,7 @@ func testPutGet(t *testing.T, isStream bool) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("create or replace table " + tableName +
 			" (a int, b string)")
-		fileStream, err := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
+		fileStream, err := os.Open(fname)
 		if err != nil {
 			t.Error(err)
 		}
@@ -525,7 +525,7 @@ func TestPutGetGcsDownscopedCredential(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("create or replace table " + tableName +
 			" (a int, b string)")
-		fileStream, err := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
+		fileStream, err := os.Open(fname)
 		if err != nil {
 			t.Error(err)
 		}

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -41,7 +41,7 @@ func TestPutError(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	file1 := filepath.Join(tmpDir, "file1")
 	remoteLocation := filepath.Join(tmpDir, "remote_loc")
-	f, err := os.OpenFile(file1, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(file1, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,7 +250,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -291,7 +291,7 @@ func TestPutOverwrite(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, os.ModePerm)
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, 0666)
 	if err != nil {
 		t.Error(err)
 	}
@@ -392,14 +392,14 @@ func testPutGet(t *testing.T, isStream bool) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("create or replace table " + tableName +
 			" (a int, b string)")
-		fileStream, err := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
+		fileStream, err := os.OpenFile(fname, os.O_RDONLY, 0666)
 		if err != nil {
 			t.Error(err)
 		}
@@ -517,7 +517,7 @@ func TestPutGetGcsDownscopedCredential(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -525,7 +525,7 @@ func TestPutGetGcsDownscopedCredential(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("create or replace table " + tableName +
 			" (a int, b string)")
-		fileStream, err := os.OpenFile(fname, os.O_RDONLY, os.ModePerm)
+		fileStream, err := os.OpenFile(fname, os.O_RDONLY, 0666)
 		if err != nil {
 			t.Error(err)
 		}

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -41,7 +41,7 @@ func TestPutError(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	file1 := filepath.Join(tmpDir, "file1")
 	remoteLocation := filepath.Join(tmpDir, "remote_loc")
-	f, err := os.OpenFile(file1, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+	f, err := os.Create(file1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,7 +250,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+	f, err := os.Create(testData)
 	if err != nil {
 		t.Error(err)
 	}
@@ -291,7 +291,7 @@ func TestPutOverwrite(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, readWriteFileMode)
+	f, err := os.Create(testData)
 	if err != nil {
 		t.Error(err)
 	}

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -41,7 +41,7 @@ func TestPutError(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	file1 := filepath.Join(tmpDir, "file1")
 	remoteLocation := filepath.Join(tmpDir, "remote_loc")
-	f, err := os.OpenFile(file1, os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(file1, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,7 +250,7 @@ func TestPutWithAutoCompressFalse(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -291,7 +291,7 @@ func TestPutOverwrite(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	testData := filepath.Join(tmpDir, "data.txt")
-	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, 0666)
+	f, err := os.OpenFile(testData, os.O_CREATE|os.O_RDWR, readWriteFileMode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -392,14 +392,14 @@ func testPutGet(t *testing.T, isStream bool) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("create or replace table " + tableName +
 			" (a int, b string)")
-		fileStream, err := os.OpenFile(fname, os.O_RDONLY, 0666)
+		fileStream, err := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
 		if err != nil {
 			t.Error(err)
 		}
@@ -517,7 +517,7 @@ func TestPutGetGcsDownscopedCredential(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -525,7 +525,7 @@ func TestPutGetGcsDownscopedCredential(t *testing.T) {
 	runTests(t, dsn, func(dbt *DBTest) {
 		dbt.mustExec("create or replace table " + tableName +
 			" (a int, b string)")
-		fileStream, err := os.OpenFile(fname, os.O_RDONLY, 0666)
+		fileStream, err := os.OpenFile(fname, os.O_RDONLY, readWriteFileMode)
 		if err != nil {
 			t.Error(err)
 		}

--- a/put_get_user_stage_test.go
+++ b/put_get_user_stage_test.go
@@ -69,7 +69,7 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 		dbt.mustExec("rm @" + stageName)
 		var fs *os.File
 		if isStream {
-			fs, _ = os.OpenFile(files, os.O_RDONLY, 0666)
+			fs, _ = os.OpenFile(files, os.O_RDONLY, readWriteFileMode)
 			dbt.mustExecContext(WithFileStream(context.Background(), fs),
 				fmt.Sprintf("put 'file://%v' @%v", strings.ReplaceAll(
 					files, "\\", "\\\\"), stageName))

--- a/put_get_user_stage_test.go
+++ b/put_get_user_stage_test.go
@@ -69,7 +69,7 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 		dbt.mustExec("rm @" + stageName)
 		var fs *os.File
 		if isStream {
-			fs, _ = os.OpenFile(files, os.O_RDONLY, readWriteFileMode)
+			fs, _ = os.Open(files)
 			dbt.mustExecContext(WithFileStream(context.Background(), fs),
 				fmt.Sprintf("put 'file://%v' @%v", strings.ReplaceAll(
 					files, "\\", "\\\\"), stageName))

--- a/put_get_user_stage_test.go
+++ b/put_get_user_stage_test.go
@@ -69,7 +69,7 @@ func putGetUserStage(t *testing.T, tmpDir string, numberOfFiles int, numberOfLin
 		dbt.mustExec("rm @" + stageName)
 		var fs *os.File
 		if isStream {
-			fs, _ = os.OpenFile(files, os.O_RDONLY, os.ModePerm)
+			fs, _ = os.OpenFile(files, os.O_RDONLY, 0666)
 			dbt.mustExecContext(WithFileStream(context.Background(), fs),
 				fmt.Sprintf("put 'file://%v' @%v", strings.ReplaceAll(
 					files, "\\", "\\\\"), stageName))

--- a/put_get_with_aws_test.go
+++ b/put_get_with_aws_test.go
@@ -102,7 +102,7 @@ func TestPutWithInvalidToken(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -214,7 +214,7 @@ func TestPretendToPutButList(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -283,7 +283,7 @@ func TestPutGetAWSStage(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = os.WriteFile(fname, b.Bytes(), os.ModePerm); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), 0666); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 

--- a/put_get_with_aws_test.go
+++ b/put_get_with_aws_test.go
@@ -102,7 +102,7 @@ func TestPutWithInvalidToken(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -214,7 +214,7 @@ func TestPretendToPutButList(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err := os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err := os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 
@@ -283,7 +283,7 @@ func TestPutGetAWSStage(t *testing.T) {
 	gzw := gzip.NewWriter(&b)
 	gzw.Write([]byte(originalContents))
 	gzw.Close()
-	if err = os.WriteFile(fname, b.Bytes(), 0666); err != nil {
+	if err = os.WriteFile(fname, b.Bytes(), readWriteFileMode); err != nil {
 		t.Fatal("could not write to gzip file")
 	}
 

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -217,7 +217,7 @@ func (util *snowflakeS3Client) nativeDownloadFile(
 		}
 	}
 
-	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
 	if err != nil {
 		return err
 	}

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -217,7 +217,7 @@ func (util *snowflakeS3Client) nativeDownloadFile(
 		}
 	}
 
-	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -122,7 +122,7 @@ func TestCreateCredentialCache(t *testing.T) {
 	// cleanup
 	src, _ = os.Open(tmpFileName)
 	defer src.Close()
-	dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, 0666)
+	dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, readWriteFileMode)
 	defer dst.Close()
 	// copy temporary file contents back to original file
 	if _, err = io.Copy(dst, src); err != nil {

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -122,7 +122,7 @@ func TestCreateCredentialCache(t *testing.T) {
 	// cleanup
 	src, _ = os.Open(tmpFileName)
 	defer src.Close()
-	dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, os.ModePerm)
+	dst, _ = os.OpenFile(srcFileName, os.O_WRONLY, 0666)
 	defer dst.Close()
 	// copy temporary file contents back to original file
 	if _, err = io.Copy(dst, src); err != nil {


### PR DESCRIPTION
### Description
This PR removes all executable bits in calls to `os.OpenFile()` or `os.WriteFile()`.

Previously, the file mode passed to these functions was `os.ModePerm` (which is equal to 0777, i.e. read/write/execute for everyone), which may have undesirable consequences.  
This value is sometimes used by Go programmers because it is conveniently exported in the `os` package, but it's intended usage is as a bitmask, and not as a file mode.  
I've changed this value to 0666 (i.e. removed the executable bits), like the one used by Go's `os.Create()`.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
