### PR TITLE
SNOW-540086: Increase code coverage on converter.go

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -676,6 +676,7 @@ func TestPrepareQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare query. err: %v", err)
 	}
+	sc.Close()
 }
 
 func TestBeginCreatesTransaction(t *testing.T) {
@@ -695,4 +696,5 @@ func TestBeginCreatesTransaction(t *testing.T) {
 	if tx == nil {
 		t.Fatal("should have created a transaction with connection")
 	}
+	sc.Close()
 }


### PR DESCRIPTION
### Description
Increase code coverage for converter.go to 92.0% to cover critical areas missed.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
