### PR TITLE
SNOW-845282: Allow configuring tmpdir in DSN

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -27,10 +27,10 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 }
 
 // OpenWithConfig creates a new connection with the given Config.
-func (d SnowflakeDriver) OpenWithConfig(
-	ctx context.Context,
-	config Config) (
-	driver.Conn, error) {
+func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (driver.Conn, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
 	if config.Tracing != "" {
 		logger.SetLogLevel(config.Tracing)
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1575,6 +1575,18 @@ func TestOpenWithConfig(t *testing.T) {
 	db.Close()
 }
 
+func TestOpenWithInvalidConfig(t *testing.T) {
+	config, err := ParseDSN("u:p@h?tmpDirPath=%2Fnon-existing")
+	if err != nil {
+		t.Fatalf("failed to parse dsn. err: %v", err)
+	}
+	driver := SnowflakeDriver{}
+	_, err = driver.OpenWithConfig(context.Background(), *config)
+	if err == nil || !strings.Contains(err.Error(), "/non-existing") {
+		t.Fatalf("should fail on missing directory")
+	}
+}
+
 type CountingTransport struct {
 	requests int
 }

--- a/errors.go
+++ b/errors.go
@@ -66,7 +66,7 @@ func (se *SnowflakeError) generateTelemetryExceptionData() *telemetryData {
 }
 
 func (se *SnowflakeError) sendExceptionTelemetry(sc *snowflakeConn, data *telemetryData) error {
-	if sc != nil {
+	if sc != nil && sc.telemetry != nil {
 		return sc.telemetry.addLog(data)
 	}
 	return nil // TODO oob telemetry

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -836,7 +836,7 @@ func (sfa *snowflakeFileTransferAgent) uploadFilesSequential(fileMetas []*fileMe
 
 func (sfa *snowflakeFileTransferAgent) uploadOneFile(meta *fileMetadata) (*fileMetadata, error) {
 	meta.realSrcFileName = meta.srcFileName
-	tmpDir, err := os.MkdirTemp("", "")
+	tmpDir, err := os.MkdirTemp(sfa.sc.cfg.TmpDirPath, "")
 	if err != nil {
 		return nil, err
 	}
@@ -951,7 +951,7 @@ func (sfa *snowflakeFileTransferAgent) downloadFilesParallel(fileMetas []*fileMe
 }
 
 func (sfa *snowflakeFileTransferAgent) downloadOneFile(meta *fileMetadata) (*fileMetadata, error) {
-	tmpDir, err := os.MkdirTemp("", "")
+	tmpDir, err := os.MkdirTemp(sfa.sc.cfg.TmpDirPath, "")
 	if err != nil {
 		return nil, err
 	}

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -65,6 +65,9 @@ func TestPutError(t *testing.T) {
 		options: &SnowflakeFileTransferOptions{
 			RaisePutGetError: false,
 		},
+		sc: &snowflakeConn{
+			cfg: &Config{},
+		},
 	}
 	if err = fta.execute(); err != nil {
 		t.Fatal(err)
@@ -77,6 +80,9 @@ func TestPutError(t *testing.T) {
 		data: data,
 		options: &SnowflakeFileTransferOptions{
 			RaisePutGetError: true,
+		},
+		sc: &snowflakeConn{
+			cfg: &Config{},
 		},
 	}
 	if err = fta.execute(); err != nil {


### PR DESCRIPTION
### Description
Introduces configuring temp dir used for encryption and compression. The change was needed as in some container environments temporary directory is readonly.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
