### PR TITLE
SNOW-859547: Refactor tests to create a new test for each test case

### DIFF
--- a/azure_storage_client_test.go
+++ b/azure_storage_client_test.go
@@ -28,16 +28,18 @@ func TestExtractContainerNameAndPath(t *testing.T) {
 		{"sfc-dev1-regression///", "sfc-dev1-regression", "//"},
 	}
 	for _, test := range testcases {
-		azureLoc, err := azureUtil.extractContainerNameAndPath(test.in)
-		if err != nil {
-			t.Error(err)
-		}
-		if azureLoc.containerName != test.bucket {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.bucket, azureLoc.containerName)
-		}
-		if azureLoc.path != test.path {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.path, azureLoc.path)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			azureLoc, err := azureUtil.extractContainerNameAndPath(test.in)
+			if err != nil {
+				t.Error(err)
+			}
+			if azureLoc.containerName != test.bucket {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.bucket, azureLoc.containerName)
+			}
+			if azureLoc.path != test.path {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.path, azureLoc.path)
+			}
+		})
 	}
 }
 

--- a/converter_test.go
+++ b/converter_test.go
@@ -128,10 +128,12 @@ func TestGoTypeToSnowflake(t *testing.T) {
 		{in: nil, tmode: nullType, out: unSupportedType},
 	}
 	for _, test := range testcases {
-		a := goTypeToSnowflake(test.in, test.tmode)
-		if a != test.out {
-			t.Errorf("failed. in: %v, tmode: %v, expected: %v, got: %v", test.in, test.tmode, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v_%v_%v", test.in, test.out, test.tmode), func(t *testing.T) {
+			a := goTypeToSnowflake(test.in, test.tmode)
+			if a != test.out {
+				t.Errorf("failed. in: %v, tmode: %v, expected: %v, got: %v", test.in, test.tmode, test.out, a)
+			}
+		})
 	}
 }
 
@@ -160,11 +162,13 @@ func TestSnowflakeTypeToGo(t *testing.T) {
 		{in: sliceType, scale: 0, out: reflect.TypeOf("")},
 	}
 	for _, test := range testcases {
-		a := snowflakeTypeToGo(test.in, test.scale)
-		if a != test.out {
-			t.Errorf("failed. in: %v, scale: %v, expected: %v, got: %v",
-				test.in, test.scale, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v_%v", test.in, test.out), func(t *testing.T) {
+			a := snowflakeTypeToGo(test.in, test.scale)
+			if a != test.out {
+				t.Errorf("failed. in: %v, scale: %v, expected: %v, got: %v",
+					test.in, test.scale, test.out, a)
+			}
+		})
 	}
 }
 
@@ -263,12 +267,14 @@ func TestStringToValue(t *testing.T) {
 	}
 
 	for _, tt := range types {
-		rowType = &execResponseRowType{
-			Type: tt,
-		}
-		if err = stringToValue(&dest, *rowType, &source, nil); err == nil {
-			t.Errorf("should raise error. type: %v, value:%v", tt, source)
-		}
+		t.Run(tt, func(t *testing.T) {
+			rowType = &execResponseRowType{
+				Type: tt,
+			}
+			if err = stringToValue(&dest, *rowType, &source, nil); err == nil {
+				t.Errorf("should raise error. type: %v, value:%v", tt, source)
+			}
+		})
 	}
 
 	sources := []string{
@@ -282,12 +288,14 @@ func TestStringToValue(t *testing.T) {
 
 	for _, ss := range sources {
 		for _, tt := range types {
-			rowType = &execResponseRowType{
-				Type: tt,
-			}
-			if err = stringToValue(&dest, *rowType, &ss, nil); err == nil {
-				t.Errorf("should raise error. type: %v, value:%v", tt, source)
-			}
+			t.Run(ss+tt, func(t *testing.T) {
+				rowType = &execResponseRowType{
+					Type: tt,
+				}
+				if err = stringToValue(&dest, *rowType, &ss, nil); err == nil {
+					t.Errorf("should raise error. type: %v, value:%v", tt, source)
+				}
+			})
 		}
 	}
 
@@ -318,15 +326,17 @@ func TestArrayToString(t *testing.T) {
 		{in: driver.NamedValue{Value: &stringArray{"foo", "bar", "baz"}}, typ: textType, out: []string{"foo", "bar", "baz"}},
 	}
 	for _, test := range testcases {
-		s, a := snowflakeArrayToString(&test.in, false)
-		if s != test.typ {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.typ, s)
-		}
-		for i, v := range a {
-			if *v != test.out[i] {
-				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.out[i], a)
+		t.Run(strings.Join(test.out, "_"), func(t *testing.T) {
+			s, a := snowflakeArrayToString(&test.in, false)
+			if s != test.typ {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.typ, s)
 			}
-		}
+			for i, v := range a {
+				if *v != test.out[i] {
+					t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.out[i], a)
+				}
+			}
+		})
 	}
 }
 
@@ -1377,12 +1387,14 @@ func TestTimeTypeValueToString(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		output, err := timeTypeValueToString(tc.in, tc.tsmode)
-		if err != nil {
-			t.Error(err)
-		}
-		if strings.Compare(tc.out, *output) != 0 {
-			t.Errorf("failed to convert time %v of type %v. expected: %v, received: %v", tc.in, tc.tsmode, tc.out, *output)
-		}
+		t.Run(tc.out, func(t *testing.T) {
+			output, err := timeTypeValueToString(tc.in, tc.tsmode)
+			if err != nil {
+				t.Error(err)
+			}
+			if strings.Compare(tc.out, *output) != 0 {
+				t.Errorf("failed to convert time %v of type %v. expected: %v, received: %v", tc.in, tc.tsmode, tc.out, *output)
+			}
+		})
 	}
 }

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -30,19 +30,21 @@ func TestDataTypeMode(t *testing.T) {
 			err: fmt.Errorf(errMsgInvalidByteArray, 123)},
 	}
 	for _, ts := range testcases {
-		tmode, err := dataTypeMode(ts.tp)
-		if ts.err == nil {
-			if err != nil {
-				t.Errorf("failed to get datatype mode: %v", err)
+		t.Run(fmt.Sprintf("%v_%v", ts.tp, ts.tmode), func(t *testing.T) {
+			tmode, err := dataTypeMode(ts.tp)
+			if ts.err == nil {
+				if err != nil {
+					t.Errorf("failed to get datatype mode: %v", err)
+				}
+				if tmode != ts.tmode {
+					t.Errorf("wrong data type: %v", tmode)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("should raise an error: %v", ts.err)
+				}
 			}
-			if tmode != ts.tmode {
-				t.Errorf("wrong data type: %v", tmode)
-			}
-		} else {
-			if err == nil {
-				t.Errorf("should raise an error: %v", ts.err)
-			}
-		}
+		})
 	}
 }
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -654,7 +654,7 @@ func TestParseDSN(t *testing.T) {
 	}
 
 	for i, test := range testcases {
-		t.Run("TestParseDSN", func(t *testing.T) {
+		t.Run(test.dsn, func(t *testing.T) {
 			cfg, err := ParseDSN(test.dsn)
 			switch {
 			case test.err == nil:
@@ -1137,25 +1137,24 @@ func TestDSN(t *testing.T) {
 		},
 	}
 	for _, test := range testcases {
-		dsn, err := DSN(test.cfg)
-		if test.err == nil && err == nil {
-			if dsn != test.dsn {
-				t.Errorf("failed to get DSN. expected: %v, got:\n %v", test.dsn, dsn)
+		t.Run(test.dsn, func(t *testing.T) {
+			dsn, err := DSN(test.cfg)
+			if test.err == nil && err == nil {
+				if dsn != test.dsn {
+					t.Errorf("failed to get DSN. expected: %v, got:\n %v", test.dsn, dsn)
+				}
+				_, err := ParseDSN(dsn)
+				if err != nil {
+					t.Errorf("failed to parse DSN. dsn: %v, err: %v", dsn, err)
+				}
 			}
-			_, err := ParseDSN(dsn)
-			if err != nil {
-				t.Errorf("failed to parse DSN. dsn: %v, err: %v", dsn, err)
+			if test.err != nil && err == nil {
+				t.Errorf("expected error. dsn: %v, err: %v", test.dsn, test.err)
 			}
-			continue
-		}
-		if test.err != nil && err == nil {
-			t.Errorf("expected error. dsn: %v, err: %v", test.dsn, test.err)
-			continue
-		}
-		if err != nil && test.err == nil {
-			t.Errorf("failed to match. err: %v", err)
-			continue
-		}
+			if err != nil && test.err == nil {
+				t.Errorf("failed to match. err: %v", err)
+			}
+		})
 	}
 }
 

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -90,16 +90,18 @@ func TestEncryptDecryptFilePadding(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		tmpDir, err := os.MkdirTemp("", "data")
-		if err != nil {
-			t.Error(err)
-		}
-		tmpDir, err = generateKLinesOfNByteRows(test.numberOfLines, test.numberOfBytesInEachRow, tmpDir)
-		if err != nil {
-			t.Error(err)
-		}
+		t.Run(fmt.Sprintf("%v_%v", test.numberOfBytesInEachRow, test.numberOfLines), func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "data")
+			if err != nil {
+				t.Error(err)
+			}
+			tmpDir, err = generateKLinesOfNByteRows(test.numberOfLines, test.numberOfBytesInEachRow, tmpDir)
+			if err != nil {
+				t.Error(err)
+			}
 
-		encryptDecryptFile(t, encMat, test.numberOfLines, tmpDir)
+			encryptDecryptFile(t, encMat, test.numberOfLines, tmpDir)
+		})
 	}
 }
 

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -116,10 +116,12 @@ func TestUnitGetLocalFilePathFromCommand(t *testing.T) {
 		{"PUT 'file2:///tmp/my_data_file.txt' @~ overwrite=true", ""},
 	}
 	for _, test := range testcases {
-		path := sfa.getLocalFilePathFromCommand(test.command)
-		if path != test.path {
-			t.Fatalf("unexpected file path. expected: %v, but got: %v", test.path, path)
-		}
+		t.Run(test.command, func(t *testing.T) {
+			path := sfa.getLocalFilePathFromCommand(test.command)
+			if path != test.path {
+				t.Fatalf("unexpected file path. expected: %v, but got: %v", test.path, path)
+			}
+		})
 	}
 }
 
@@ -150,11 +152,13 @@ func TestUnitProcessFileCompressionType(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		sfa.srcCompression = test.srcCompression
-		err = sfa.processFileCompressionType()
-		if err != nil {
-			t.Fatalf("failed to process file compression")
-		}
+		t.Run(test.srcCompression, func(t *testing.T) {
+			sfa.srcCompression = test.srcCompression
+			err = sfa.processFileCompressionType()
+			if err != nil {
+				t.Fatalf("failed to process file compression")
+			}
+		})
 	}
 
 	// test invalid compression type error

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -33,10 +33,12 @@ func TestBaseName(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		base := baseName(test.in)
-		if test.out != base {
-			t.Errorf("Failed to get base, input %v, expected: %v, got: %v", test.in, test.out, base)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			base := baseName(test.in)
+			if test.out != base {
+				t.Errorf("Failed to get base, input %v, expected: %v, got: %v", test.in, test.out, base)
+			}
+		})
 	}
 }
 

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -30,13 +30,15 @@ func TestExtractBucketAndPath(t *testing.T) {
 		{"sfc-dev1-regression///", "sfc-dev1-regression", "//"},
 	}
 	for _, test := range testcases {
-		gcsLoc := gcsUtil.extractBucketNameAndPath(test.in)
-		if gcsLoc.bucketName != test.bucket {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.bucket, gcsLoc.bucketName)
-		}
-		if gcsLoc.path != test.path {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.path, gcsLoc.path)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			gcsLoc := gcsUtil.extractBucketNameAndPath(test.in)
+			if gcsLoc.bucketName != test.bucket {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.bucket, gcsLoc.bucketName)
+			}
+			if gcsLoc.path != test.path {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.path, gcsLoc.path)
+			}
+		})
 	}
 }
 
@@ -102,17 +104,19 @@ func TestGenerateFileURL(t *testing.T) {
 		{"sfc-dev1-regression///", "file5", "sfc-dev1-regression", "//file5"},
 	}
 	for _, test := range testcases {
-		gcsURL, err := gcsUtil.generateFileURL(test.location, test.fname)
-		if err != nil {
-			t.Error(err)
-		}
-		expectedURL, err := url.Parse("https://storage.googleapis.com/" + test.bucket + "/" + url.QueryEscape(test.filepath))
-		if err != nil {
-			t.Error(err)
-		}
-		if gcsURL.String() != expectedURL.String() {
-			t.Fatalf("failed. expected: %v but got: %v", expectedURL.String(), gcsURL.String())
-		}
+		t.Run(test.location, func(t *testing.T) {
+			gcsURL, err := gcsUtil.generateFileURL(test.location, test.fname)
+			if err != nil {
+				t.Error(err)
+			}
+			expectedURL, err := url.Parse("https://storage.googleapis.com/" + test.bucket + "/" + url.QueryEscape(test.filepath))
+			if err != nil {
+				t.Error(err)
+			}
+			if gcsURL.String() != expectedURL.String() {
+				t.Fatalf("failed. expected: %v but got: %v", expectedURL.String(), gcsURL.String())
+			}
+		})
 	}
 }
 

--- a/location_test.go
+++ b/location_test.go
@@ -81,23 +81,25 @@ func TestWithOffsetString(t *testing.T) {
 		},
 	}
 	for _, t0 := range testcases {
-		loc, err := LocationWithOffsetString(t0.ss)
-		if t0.err != nil {
-			if t0.err != err {
-				driverError1, ok1 := t0.err.(*SnowflakeError)
-				driverError2, ok2 := err.(*SnowflakeError)
-				if ok1 && ok2 && driverError1.Number != driverError2.Number {
-					t.Fatalf("error expected: %v, got: %v", t0.err, err)
+		t.Run(t0.ss, func(t *testing.T) {
+			loc, err := LocationWithOffsetString(t0.ss)
+			if t0.err != nil {
+				if t0.err != err {
+					driverError1, ok1 := t0.err.(*SnowflakeError)
+					driverError2, ok2 := err.(*SnowflakeError)
+					if ok1 && ok2 && driverError1.Number != driverError2.Number {
+						t.Fatalf("error expected: %v, got: %v", t0.err, err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("%v", err)
+				}
+				if t0.tt != loc.String() {
+					t.Fatalf("location string didn't match. expected: %v, got: %v", t0.tt, loc)
 				}
 			}
-		} else {
-			if err != nil {
-				t.Fatalf("%v", err)
-			}
-			if t0.tt != loc.String() {
-				t.Fatalf("location string didn't match. expected: %v, got: %v", t0.tt, loc)
-			}
-		}
+		})
 	}
 }
 

--- a/multistatement_test.go
+++ b/multistatement_test.go
@@ -448,10 +448,12 @@ func TestUnitGetChildResults(t *testing.T) {
 			{"03aa3265-0405-ab7c-0000-53b106343aba", "12544"}}},
 	}
 	for _, test := range testcases {
-		res := getChildResults(test.ids, test.types)
-		if !reflect.DeepEqual(res, test.out) {
-			t.Fatalf("Child result should be equal, expected %v, actual %v", res, test.out)
-		}
+		t.Run(test.ids, func(t *testing.T) {
+			res := getChildResults(test.ids, test.types)
+			if !reflect.DeepEqual(res, test.out) {
+				t.Fatalf("Child result should be equal, expected %v, actual %v", res, test.out)
+			}
+		})
 	}
 }
 

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -105,11 +105,13 @@ func TestPercentage(t *testing.T) {
 		{14, 28, 0.5},
 	}
 	for _, test := range testcases {
-		spp := snowflakeProgressPercentage{}
-		if spp.percent(test.seen, test.size) != test.expected {
-			t.Fatalf("percentage conversion failed. %v/%v, expected: %v, got: %v",
-				test.seen, test.size, test.expected, spp.percent(test.seen, test.size))
-		}
+		t.Run(fmt.Sprintf("%v_%v_%v", test.seen, test.size, test.expected), func(t *testing.T) {
+			spp := snowflakeProgressPercentage{}
+			if spp.percent(test.seen, test.size) != test.expected {
+				t.Fatalf("percentage conversion failed. %v/%v, expected: %v, got: %v",
+					test.seen, test.size, test.expected, spp.percent(test.seen, test.size))
+			}
+		})
 	}
 }
 

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -33,16 +33,18 @@ func TestExtractBucketNameAndPath(t *testing.T) {
 		{"sfc-dev1-regression///", "sfc-dev1-regression", "//"},
 	}
 	for _, test := range testcases {
-		s3Loc, err := s3util.extractBucketNameAndPath(test.in)
-		if err != nil {
-			t.Error(err)
-		}
-		if s3Loc.bucketName != test.bucket {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.bucket, s3Loc.bucketName)
-		}
-		if s3Loc.s3Path != test.path {
-			t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.path, s3Loc.s3Path)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			s3Loc, err := s3util.extractBucketNameAndPath(test.in)
+			if err != nil {
+				t.Error(err)
+			}
+			if s3Loc.bucketName != test.bucket {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.bucket, s3Loc.bucketName)
+			}
+			if s3Loc.s3Path != test.path {
+				t.Errorf("failed. in: %v, expected: %v, got: %v", test.in, test.path, s3Loc.s3Path)
+			}
+		})
 	}
 }
 

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -148,18 +148,20 @@ func TestStoreTemporaryCredental(t *testing.T) {
 	}
 	sc := getDefaultSnowflakeConn()
 	for _, test := range testcases {
-		writeTemporaryCredential(sc, test.credType, test.token)
-		target := convertTarget(sc.cfg.Host, sc.cfg.User, test.credType)
-		_, ok := localCredCache[target]
-		if !ok {
-			t.Fatalf("failed to write credential to local cache")
-		}
-		tmpCred := readTemporaryCredential(sc, test.credType)
-		if tmpCred == "" {
-			t.Fatalf("failed to read credential from temporary cache")
-		} else {
-			deleteTemporaryCredential(sc, test.credType)
-		}
+		t.Run(test.token, func(t *testing.T) {
+			writeTemporaryCredential(sc, test.credType, test.token)
+			target := convertTarget(sc.cfg.Host, sc.cfg.User, test.credType)
+			_, ok := localCredCache[target]
+			if !ok {
+				t.Fatalf("failed to write credential to local cache")
+			}
+			tmpCred := readTemporaryCredential(sc, test.credType)
+			if tmpCred == "" {
+				t.Fatalf("failed to read credential from temporary cache")
+			} else {
+				deleteTemporaryCredential(sc, test.credType)
+			}
+		})
 	}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -5,6 +5,7 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -108,10 +109,12 @@ func TestIntMin(t *testing.T) {
 		{123, 123, 123},
 	}
 	for _, test := range testcases {
-		a := intMin(test.v1, test.v2)
-		if test.out != a {
-			t.Errorf("failed int min. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v_%v_%v", test.v1, test.v2, test.out), func(t *testing.T) {
+			a := intMin(test.v1, test.v2)
+			if test.out != a {
+				t.Errorf("failed int min. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
+			}
+		})
 	}
 }
 func TestIntMax(t *testing.T) {
@@ -122,10 +125,12 @@ func TestIntMax(t *testing.T) {
 		{123, 123, 123},
 	}
 	for _, test := range testcases {
-		a := intMax(test.v1, test.v2)
-		if test.out != a {
-			t.Errorf("failed int max. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v_%v_%v", test.v1, test.v2, test.out), func(t *testing.T) {
+			a := intMax(test.v1, test.v2)
+			if test.out != a {
+				t.Errorf("failed int max. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
+			}
+		})
 	}
 }
 
@@ -143,10 +148,12 @@ func TestDurationMin(t *testing.T) {
 		{123 * time.Second, 123 * time.Second, 123 * time.Second},
 	}
 	for _, test := range testcases {
-		a := durationMin(test.v1, test.v2)
-		if test.out != a {
-			t.Errorf("failed duratoin max. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v_%v_%v", test.v1, test.v2, test.out), func(t *testing.T) {
+			a := durationMin(test.v1, test.v2)
+			if test.out != a {
+				t.Errorf("failed duratoin max. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
+			}
+		})
 	}
 }
 
@@ -158,10 +165,12 @@ func TestDurationMax(t *testing.T) {
 		{123 * time.Second, 123 * time.Second, 123 * time.Second},
 	}
 	for _, test := range testcases {
-		a := durationMax(test.v1, test.v2)
-		if test.out != a {
-			t.Errorf("failed duratoin max. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v_%v_%v", test.v1, test.v2, test.out), func(t *testing.T) {
+			a := durationMax(test.v1, test.v2)
+			if test.out != a {
+				t.Errorf("failed duratoin max. v1: %v, v2: %v, expected: %v, got: %v", test.v1, test.v2, test.out, a)
+			}
+		})
 	}
 }
 
@@ -208,11 +217,13 @@ func TestToNamedValues(t *testing.T) {
 		},
 	}
 	for _, test := range testcases {
-		a := toNamedValues(test.values)
+		t.Run("", func(t *testing.T) {
+			a := toNamedValues(test.values)
 
-		if !compareNamedValues(test.out, a) {
-			t.Errorf("failed int max. v1: %v, v2: %v, expected: %v, got: %v", test.values, test.out, test.out, a)
-		}
+			if !compareNamedValues(test.out, a) {
+				t.Errorf("failed int max. v1: %v, v2: %v, expected: %v, got: %v", test.values, test.out, test.out, a)
+			}
+		})
 	}
 }
 
@@ -230,10 +241,12 @@ func TestGetMin(t *testing.T) {
 		{[]int{}, -1},
 	}
 	for _, test := range testcases {
-		a := getMin(test.in)
-		if test.out != a {
-			t.Errorf("failed get min. in: %v, expected: %v, got: %v", test.in, test.out, a)
-		}
+		t.Run(fmt.Sprintf("%v", test.out), func(t *testing.T) {
+			a := getMin(test.in)
+			if test.out != a {
+				t.Errorf("failed get min. in: %v, expected: %v, got: %v", test.in, test.out, a)
+			}
+		})
 	}
 }
 
@@ -252,10 +265,12 @@ func TestValidURL(t *testing.T) {
 		{"file://TestForFile", false},
 	}
 	for _, test := range testcases {
-		result := isValidURL(test.in)
-		if test.out != result {
-			t.Errorf("Failed to validate URL, input :%v, expected: %v, got: %v", test.in, test.out, result)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			result := isValidURL(test.in)
+			if test.out != result {
+				t.Errorf("Failed to validate URL, input :%v, expected: %v, got: %v", test.in, test.out, result)
+			}
+		})
 	}
 }
 
@@ -271,10 +286,12 @@ func TestEncodeURL(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		result := urlEncode(test.in)
-		if test.out != result {
-			t.Errorf("Failed to encode string, input %v, expected: %v, got: %v", test.in, test.out, result)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			result := urlEncode(test.in)
+			if test.out != result {
+				t.Errorf("Failed to encode string, input %v, expected: %v, got: %v", test.in, test.out, result)
+			}
+		})
 	}
 }
 
@@ -285,10 +302,12 @@ func TestParseUUID(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		requestID := ParseUUID(test.uuid)
-		if requestID.String() != test.uuid {
-			t.Fatalf("failed to parse uuid")
-		}
+		t.Run(test.uuid, func(t *testing.T) {
+			requestID := ParseUUID(test.uuid)
+			if requestID.String() != test.uuid {
+				t.Fatalf("failed to parse uuid")
+			}
+		})
 	}
 }
 
@@ -305,10 +324,12 @@ func TestEscapeForCSV(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		result := escapeForCSV(test.in)
-		if test.out != result {
-			t.Errorf("Failed to escape string, input %v, expected: %v, got: %v", test.in, test.out, result)
-		}
+		t.Run(test.out, func(t *testing.T) {
+			result := escapeForCSV(test.in)
+			if test.out != result {
+				t.Errorf("Failed to escape string, input %v, expected: %v, got: %v", test.in, test.out, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Description
Added `t.Run` in tests which create subtests. Before first for any test case causes test failure. Now, all test cases are run independently and do not depend on the previous instances. Also, Go and IDE recognise instances as separated tests.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
