### PR TITLE
SNOW-857660: Improve JSON performance

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -106,8 +106,8 @@ func (scd *snowflakeChunkDownloader) start() error {
 		// if the rowsetbase64 retrieved from the server is empty, move on to downloading chunks
 		var err error
 		var loc *time.Location
-		if scd.sc != nil && scd.sc.cfg != nil {
-			loc = getCurrentLocation(scd.sc.cfg.Params)
+		if scd.sc != nil {
+			loc = scd.sc.getCurrentLocation()
 		}
 		firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
 		higherPrecision := higherPrecisionEnabled(scd.ctx)
@@ -271,8 +271,8 @@ func (scd *snowflakeChunkDownloader) startArrowBatches() error {
 	var err error
 	chunkMetaLen := len(scd.ChunkMetas)
 	var loc *time.Location
-	if scd.sc != nil && scd.sc.cfg != nil {
-		loc = getCurrentLocation(scd.sc.cfg.Params)
+	if scd.sc != nil {
+		loc = scd.sc.getCurrentLocation()
 	}
 	firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
 	scd.FirstBatch = &ArrowBatch{
@@ -430,8 +430,8 @@ func decodeChunk(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader
 			return err
 		}
 		var loc *time.Location
-		if scd.sc != nil && scd.sc.cfg != nil {
-			loc = getCurrentLocation(scd.sc.cfg.Params)
+		if scd.sc != nil {
+			loc = scd.sc.getCurrentLocation()
 		}
 		arc := arrowResultChunk{
 			ipcReader,

--- a/connection.go
+++ b/connection.go
@@ -68,6 +68,7 @@ type snowflakeConn struct {
 	SQLState        string
 	telemetry       *snowflakeTelemetry
 	internal        InternalClient
+	location        *time.Location
 }
 
 var (
@@ -604,7 +605,7 @@ type snowflakeArrowStreamChunkDownloader struct {
 
 func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
 	if scd.sc != nil {
-		return getCurrentLocation(scd.sc.cfg.Params)
+		return scd.sc.getCurrentLocation()
 	}
 	return nil
 }

--- a/location.go
+++ b/location.go
@@ -91,16 +91,20 @@ func init() {
 }
 
 // retrieve current location based on connection
-func getCurrentLocation(params map[string]*string) *time.Location {
+func (sc *snowflakeConn) getCurrentLocation() *time.Location {
+	if sc.location != nil {
+		return sc.location
+	}
 	loc := time.Now().Location()
 	var err error
 	paramsMutex.Lock()
-	if tz, ok := params["timezone"]; ok {
+	defer paramsMutex.Unlock()
+	if tz, ok := sc.cfg.Params["timezone"]; ok {
 		loc, err = time.LoadLocation(*tz)
 		if err != nil {
 			loc = time.Now().Location()
 		}
 	}
-	paramsMutex.Unlock()
+	sc.location = loc
 	return loc
 }

--- a/rows.go
+++ b/rows.go
@@ -186,7 +186,7 @@ func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 			// can convert data
 			var loc *time.Location
 			if rows.sc != nil {
-				loc = getCurrentLocation(rows.sc.cfg.Params)
+				loc = rows.sc.getCurrentLocation()
 			}
 			err = stringToValue(&dest[i], rows.ChunkDownloader.getRowType()[i], row.RowSet[i], loc)
 			if err != nil {


### PR DESCRIPTION
### Description
Before my change, for each row we tried to find out the location for string localisation (like formatting dates etc, even if it was not relevant). Checking location was easy if someone specified the location in the connection parameter, but if it was not (and I believe it is usual), we needed to guess this location. This involved very inefficient system call for each row and each column. I changed it so the location is cached for connection. The code handling JSON responses is like 30-50 times faster (!!!). Quick stats: before my change 1M rows (single column) was retrieved in 1,5min. After my changes it takes 3 seconds. In 1,5min we are able to handle nearly 50M of rows.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
