### PR TITLE
SNOW-857660: Init rows location once

### DIFF
--- a/location.go
+++ b/location.go
@@ -95,7 +95,7 @@ func getCurrentLocation(params map[string]*string) *time.Location {
 	loc := time.Now().Location()
 	var err error
 	paramsMutex.Lock()
-	if tz, ok := params["timezone"]; ok {
+	if tz, ok := params["timezone"]; ok && tz != nil {
 		loc, err = time.LoadLocation(*tz)
 		if err != nil {
 			loc = time.Now().Location()

--- a/location_test.go
+++ b/location_test.go
@@ -4,7 +4,10 @@ package gosnowflake
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 )
 
 type tcLocation struct {
@@ -95,5 +98,49 @@ func TestWithOffsetString(t *testing.T) {
 				t.Fatalf("location string didn't match. expected: %v, got: %v", t0.tt, loc)
 			}
 		}
+	}
+}
+
+func TestGetCurrentLocation(t *testing.T) {
+	specificTz := "Pacific/Honolulu"
+	specificLoc, err := time.LoadLocation(specificTz)
+	if err != nil {
+		t.Fatalf("Cannot initialize specific timezone location")
+	}
+	incorrectTz := "Not/exists"
+	testcases := []struct {
+		params map[string]*string
+		loc    *time.Location
+	}{
+		{
+			params: map[string]*string{},
+			loc:    time.Now().Location(),
+		},
+		{
+			params: map[string]*string{
+				"timezone": nil,
+			},
+			loc: time.Now().Location(),
+		},
+		{
+			params: map[string]*string{
+				"timezone": &specificTz,
+			},
+			loc: specificLoc,
+		},
+		{
+			params: map[string]*string{
+				"timezone": &incorrectTz,
+			},
+			loc: time.Now().Location(),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("%v", tc.loc), func(t *testing.T) {
+			loc := getCurrentLocation(tc.params)
+			if !reflect.DeepEqual(*loc, *tc.loc) {
+				t.Fatalf("location mismatch. expected: %v, got: %v", tc.loc, loc)
+			}
+		})
 	}
 }

--- a/rows.go
+++ b/rows.go
@@ -43,6 +43,14 @@ type snowflakeRows struct {
 	status              queryStatus
 	err                 error
 	errChannel          chan error
+	location            *time.Location
+}
+
+func (rows *snowflakeRows) getLocation() *time.Location {
+	if rows.location == nil && rows.sc != nil && rows.sc.cfg != nil {
+		rows.location = getCurrentLocation(rows.sc.cfg.Params)
+	}
+	return rows.location
 }
 
 type snowflakeValue interface{}
@@ -184,11 +192,7 @@ func (rows *snowflakeRows) Next(dest []driver.Value) (err error) {
 		for i, n := 0, len(row.RowSet); i < n; i++ {
 			// could move to chunk downloader so that each go routine
 			// can convert data
-			var loc *time.Location
-			if rows.sc != nil {
-				loc = getCurrentLocation(rows.sc.cfg.Params)
-			}
-			err = stringToValue(&dest[i], rows.ChunkDownloader.getRowType()[i], row.RowSet[i], loc)
+			err = stringToValue(&dest[i], rows.ChunkDownloader.getRowType()[i], row.RowSet[i], rows.getLocation())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description
Initialize location once per query, instead of creating it for each row and column.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
