### PR TITLE
SNOW-892592: Fix panic when SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED=false

### DIFF
--- a/ocsp.go
+++ b/ocsp.go
@@ -716,11 +716,12 @@ func overrideCacheDir() {
 
 // initOCSPCache initializes OCSP Response cache file.
 func initOCSPCache() {
+	ocspResponseCache = make(map[certIDKey][]interface{})
+	ocspResponseCacheLock = &sync.RWMutex{}
+
 	if strings.EqualFold(os.Getenv(cacheServerEnabledEnv), "false") {
 		return
 	}
-	ocspResponseCache = make(map[certIDKey][]interface{})
-	ocspResponseCacheLock = &sync.RWMutex{}
 
 	logger.Infof("reading OCSP Response cache file. %v\n", cacheFileName)
 	f, err := os.OpenFile(cacheFileName, os.O_CREATE|os.O_RDONLY, readWriteFileMode)

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -533,3 +533,21 @@ func TestInitOCSPCacheFileCreation(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestCacheServerDisabled(t *testing.T) {
+	_ = os.Setenv(cacheServerEnabledEnv, "false")
+
+	if _, err := buildSnowflakeConn(context.Background(), Config{
+		Account:  "testaccount",
+		User:     "testuser",
+		Password: "testpassword",
+		Host:     "testaccount.us-east-1.snowflakecomputing.com",
+	}); err != nil {
+		t.Error(err)
+	}
+
+	ocspURL := os.Getenv(cacheServerURLEnv)
+	if ocspURL != "" {
+		t.Fatalf("cache server is disabled. Expected empty url but got %v ", cacheServerURLEnv)
+	}
+}


### PR DESCRIPTION
### Description
https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/608
When testing for https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/593 I found a panic when SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED is false. The initOcspCache() function initializes a mutex lock on the ocsp response cache. If SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED=false it exits the init function before the lock is initialized. The driver tries to access it later and it causes a panic during connection.

This change is to initialize the lock first and then check for SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
