### PR TITLE
SNOW-726742 Remove queryID from snowflakeConn

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -64,8 +64,6 @@ type snowflakeConn struct {
 	cfg             *Config
 	rest            *snowflakeRestful
 	SequenceCounter uint64
-	QueryID         string
-	SQLState        string
 	telemetry       *snowflakeTelemetry
 	internal        InternalClient
 }
@@ -158,8 +156,6 @@ func (sc *snowflakeConn) exec(
 	sc.cfg.Schema = data.Data.FinalSchemaName
 	sc.cfg.Role = data.Data.FinalRoleName
 	sc.cfg.Warehouse = data.Data.FinalWarehouseName
-	sc.QueryID = data.Data.QueryID
-	sc.SQLState = data.Data.SQLState
 	sc.populateSessionParameters(data.Data.Parameters)
 	return data, err
 }
@@ -282,7 +278,7 @@ func (sc *snowflakeConn) ExecContext(
 		return &snowflakeResult{
 			affectedRows: updatedRows,
 			insertID:     -1,
-			queryID:      sc.QueryID,
+			queryID:      data.Data.QueryID,
 		}, nil // last insert id is not supported by Snowflake
 	} else if isMultiStmt(&data.Data) {
 		return sc.handleMultiExec(ctx, data.Data)
@@ -353,7 +349,7 @@ func (sc *snowflakeConn) queryContextInternal(
 
 	rows := new(snowflakeRows)
 	rows.sc = sc
-	rows.queryID = sc.QueryID
+	rows.queryID = data.Data.QueryID
 
 	if isMultiStmt(&data.Data) {
 		// handleMultiQuery is responsible to fill rows with childResults

--- a/multistatement.go
+++ b/multistatement.go
@@ -78,7 +78,7 @@ func (sc *snowflakeConn) handleMultiExec(
 	return &snowflakeResult{
 		affectedRows: updatedRows,
 		insertID:     -1,
-		queryID:      sc.QueryID,
+		queryID:      data.QueryID,
 	}, nil
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -460,6 +460,7 @@ func TestWithArrowBatchesNotImplementedForResult(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	defer sc.Close()
 	if err = authenticateWithConfig(sc); err != nil {
 		t.Error(err)
 	}
@@ -472,12 +473,6 @@ func TestWithArrowBatchesNotImplementedForResult(t *testing.T) {
 	result, err := sc.ExecContext(ctx, "insert into testArrowBatches values (1, 2), (3, 4), (5, 6)", []driver.NamedValue{})
 	if err != nil {
 		t.Error(err)
-	}
-
-	result.(*snowflakeResult).GetStatus()
-	queryID := result.(*snowflakeResult).GetQueryID()
-	if queryID != sc.QueryID {
-		t.Fatalf("failed to get query ID")
 	}
 
 	_, err = result.(*snowflakeResult).GetArrowBatches()


### PR DESCRIPTION
### Description
QueryID was persisted in snowflakeConn and read by some functions. It could cause race conditions if the same connection is reused among threads. Now, the queryId is read from the responses.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
