### PR TITLE
SNOW-895537: Send query context with request

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -387,6 +387,7 @@ func runSnowflakeConnTest(t *testing.T, test func(sct *SCTest)) {
 	}
 
 	sct := &SCTest{t, sc}
+
 	test(sct)
 }
 

--- a/htap.go
+++ b/htap.go
@@ -16,10 +16,10 @@ type queryContext struct {
 }
 
 type queryContextEntry struct {
-	ID        int   `json:"id"`
-	Timestamp int64 `json:"timestamp"`
-	Priority  int   `json:"priority"`
-	Context   any   `json:"context,omitempty"`
+	ID        int    `json:"id"`
+	Timestamp int64  `json:"timestamp"`
+	Priority  int    `json:"priority"`
+	Context   string `json:"context,omitempty"`
 }
 
 type queryContextCache struct {

--- a/query.go
+++ b/query.go
@@ -28,6 +28,22 @@ type execRequest struct {
 	Parameters   map[string]interface{}       `json:"parameters,omitempty"`
 	Bindings     map[string]execBindParameter `json:"bindings,omitempty"`
 	BindStage    string                       `json:"bindStage,omitempty"`
+	QueryContext requestQueryContext          `json:"queryContextDTO,omitempty"`
+}
+
+type requestQueryContext struct {
+	Entries []requestQueryContextEntry `json:"entries,omitempty"`
+}
+
+type requestQueryContextEntry struct {
+	Context   contextData `json:"context,omitempty"`
+	ID        int         `json:"id"`
+	Priority  int         `json:"priority"`
+	Timestamp int64       `json:"timestamp,omitempty"`
+}
+
+type contextData struct {
+	Base64Data string `json:"base64Data,omitempty"`
 }
 
 type execResponseRowType struct {


### PR DESCRIPTION
### Description
Query contexts are now sent to snowflake backend.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
