### PR TITLE
SNOW-898296: Enable HTAP optimisations in tests

### DIFF
--- a/aaa_test.go
+++ b/aaa_test.go
@@ -1,0 +1,15 @@
+package gosnowflake
+
+import "testing"
+
+func TestShowServerVersion(t *testing.T) {
+	runDBTest(t, func(dbt *DBTest) {
+		rows := dbt.mustQuery("SELECT CURRENT_VERSION()")
+		defer rows.Close()
+
+		var version string
+		rows.Next()
+		rows.Scan(&version)
+		println(version)
+	})
+}

--- a/connection.go
+++ b/connection.go
@@ -165,10 +165,18 @@ func (sc *snowflakeConn) exec(
 	}
 
 	logger.WithContext(ctx).Info("Exec/Query SUCCESS")
-	sc.cfg.Database = data.Data.FinalDatabaseName
-	sc.cfg.Schema = data.Data.FinalSchemaName
-	sc.cfg.Role = data.Data.FinalRoleName
-	sc.cfg.Warehouse = data.Data.FinalWarehouseName
+	if data.Data.FinalDatabaseName != "" {
+		sc.cfg.Database = data.Data.FinalDatabaseName
+	}
+	if data.Data.FinalSchemaName != "" {
+		sc.cfg.Schema = data.Data.FinalSchemaName
+	}
+	if data.Data.FinalWarehouseName != "" {
+		sc.cfg.Warehouse = data.Data.FinalWarehouseName
+	}
+	if data.Data.FinalRoleName != "" {
+		sc.cfg.Role = data.Data.FinalRoleName
+	}
 	sc.populateSessionParameters(data.Data.Parameters)
 	return data, err
 }


### PR DESCRIPTION
### Description
Enables htap optimizations - not sending db/schema/warehouse/session parameters.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
