### PR TITLE
SNOW-894815: Fix race conditions and enable TestConcurrentReadOnParams

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -106,9 +106,11 @@ func (scd *snowflakeChunkDownloader) start() error {
 		// if the rowsetbase64 retrieved from the server is empty, move on to downloading chunks
 		var err error
 		var loc *time.Location
+		paramsMutex.Lock()
 		if scd.sc != nil && scd.sc.cfg != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
+		paramsMutex.Unlock()
 		firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
 		higherPrecision := higherPrecisionEnabled(scd.ctx)
 		scd.CurrentChunk, err = firstArrowChunk.decodeArrowChunk(scd.RowSet.RowType, higherPrecision)
@@ -271,9 +273,11 @@ func (scd *snowflakeChunkDownloader) startArrowBatches() error {
 	var err error
 	chunkMetaLen := len(scd.ChunkMetas)
 	var loc *time.Location
+	paramsMutex.Lock()
 	if scd.sc != nil && scd.sc.cfg != nil {
 		loc = getCurrentLocation(scd.sc.cfg.Params)
 	}
+	paramsMutex.Unlock()
 	firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
 	scd.FirstBatch = &ArrowBatch{
 		idx:                0,
@@ -432,9 +436,11 @@ func decodeChunk(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader
 			return err
 		}
 		var loc *time.Location
+		paramsMutex.Lock()
 		if scd.sc != nil && scd.sc.cfg != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
+		paramsMutex.Unlock()
 		arc := arrowResultChunk{
 			ipcReader,
 			0,

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -106,11 +106,9 @@ func (scd *snowflakeChunkDownloader) start() error {
 		// if the rowsetbase64 retrieved from the server is empty, move on to downloading chunks
 		var err error
 		var loc *time.Location
-		paramsMutex.Lock()
 		if scd.sc != nil && scd.sc.cfg != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
-		paramsMutex.Unlock()
 		firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
 		higherPrecision := higherPrecisionEnabled(scd.ctx)
 		scd.CurrentChunk, err = firstArrowChunk.decodeArrowChunk(scd.RowSet.RowType, higherPrecision)
@@ -273,11 +271,9 @@ func (scd *snowflakeChunkDownloader) startArrowBatches() error {
 	var err error
 	chunkMetaLen := len(scd.ChunkMetas)
 	var loc *time.Location
-	paramsMutex.Lock()
 	if scd.sc != nil && scd.sc.cfg != nil {
 		loc = getCurrentLocation(scd.sc.cfg.Params)
 	}
-	paramsMutex.Unlock()
 	firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
 	scd.FirstBatch = &ArrowBatch{
 		idx:                0,
@@ -436,11 +432,9 @@ func decodeChunk(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader
 			return err
 		}
 		var loc *time.Location
-		paramsMutex.Lock()
 		if scd.sc != nil && scd.sc.cfg != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
-		paramsMutex.Unlock()
 		arc := arrowResultChunk{
 			ipcReader,
 			0,

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -106,7 +106,7 @@ func (scd *snowflakeChunkDownloader) start() error {
 		// if the rowsetbase64 retrieved from the server is empty, move on to downloading chunks
 		var err error
 		var loc *time.Location
-		if scd.sc != nil && scd.sc.cfg != nil {
+		if scd.sc != nil && scd.sc.getConnConfig() != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
 		firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
@@ -271,7 +271,7 @@ func (scd *snowflakeChunkDownloader) startArrowBatches() error {
 	var err error
 	chunkMetaLen := len(scd.ChunkMetas)
 	var loc *time.Location
-	if scd.sc != nil && scd.sc.cfg != nil {
+	if scd.sc != nil && scd.sc.getConnConfig() != nil {
 		loc = getCurrentLocation(scd.sc.cfg.Params)
 	}
 	firstArrowChunk := buildFirstArrowChunk(scd.RowSet.RowSetBase64, loc, scd.pool)
@@ -432,7 +432,7 @@ func decodeChunk(scd *snowflakeChunkDownloader, idx int, bufStream *bufio.Reader
 			return err
 		}
 		var loc *time.Location
-		if scd.sc != nil && scd.sc.cfg != nil {
+		if scd.sc != nil && scd.sc.getConnConfig() != nil {
 			loc = getCurrentLocation(scd.sc.cfg.Params)
 		}
 		arc := arrowResultChunk{

--- a/connection.go
+++ b/connection.go
@@ -249,7 +249,9 @@ func (sc *snowflakeConn) cleanup() {
 		sc.rest.Client.CloseIdleConnections()
 	}
 	sc.rest = nil
+	paramsMutex.Lock()
 	sc.cfg = nil
+	paramsMutex.Unlock()
 }
 
 func (sc *snowflakeConn) Close() (err error) {
@@ -648,9 +650,11 @@ type snowflakeArrowStreamChunkDownloader struct {
 }
 
 func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
+	paramsMutex.Lock()
 	if scd.sc != nil {
 		return getCurrentLocation(scd.sc.cfg.Params)
 	}
+	paramsMutex.Unlock()
 	return nil
 }
 func (scd *snowflakeArrowStreamChunkDownloader) TotalRows() int64 { return scd.Total }

--- a/connection.go
+++ b/connection.go
@@ -260,7 +260,7 @@ func (sc *snowflakeConn) Close() (err error) {
 	sc.stopHeartBeat()
 	defer sc.cleanup()
 
-	if sc.cfg != nil && !sc.cfg.KeepSessionAlive {
+	if sc.getConnConfig() != nil && !sc.cfg.KeepSessionAlive {
 		if err = sc.rest.FuncCloseSession(sc.ctx, sc.rest, sc.rest.RequestTimeout); err != nil {
 			logger.Error(err)
 		}

--- a/connection.go
+++ b/connection.go
@@ -650,11 +650,9 @@ type snowflakeArrowStreamChunkDownloader struct {
 }
 
 func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
-	paramsMutex.Lock()
 	if scd.sc != nil {
 		return getCurrentLocation(scd.sc.cfg.Params)
 	}
-	paramsMutex.Unlock()
 	return nil
 }
 func (scd *snowflakeArrowStreamChunkDownloader) TotalRows() int64 { return scd.Total }

--- a/connection_test.go
+++ b/connection_test.go
@@ -476,7 +476,6 @@ func TestExecWithServerSideError(t *testing.T) {
 }
 
 func TestConcurrentReadOnParams(t *testing.T) {
-	t.Skip("Fails randomly")
 	config, err := ParseDSN(dsn)
 	if err != nil {
 		t.Fatal("Failed to parse dsn")

--- a/connection_util.go
+++ b/connection_util.go
@@ -13,6 +13,12 @@ import (
 	"time"
 )
 
+func (sc *snowflakeConn) getConnConfig() *Config {
+	paramsMutex.Lock()
+	defer paramsMutex.Unlock()
+	return sc.cfg
+}
+
 func (sc *snowflakeConn) isClientSessionKeepAliveEnabled() bool {
 	paramsMutex.Lock()
 	v, ok := sc.cfg.Params[sessionClientSessionKeepAlive]
@@ -24,7 +30,7 @@ func (sc *snowflakeConn) isClientSessionKeepAliveEnabled() bool {
 }
 
 func (sc *snowflakeConn) startHeartBeat() {
-	if sc.cfg != nil && !sc.isClientSessionKeepAliveEnabled() {
+	if sc.getConnConfig() != nil && !sc.isClientSessionKeepAliveEnabled() {
 		return
 	}
 	if sc.rest != nil {
@@ -36,7 +42,7 @@ func (sc *snowflakeConn) startHeartBeat() {
 }
 
 func (sc *snowflakeConn) stopHeartBeat() {
-	if sc.cfg != nil && !sc.isClientSessionKeepAliveEnabled() {
+	if sc.getConnConfig() != nil && !sc.isClientSessionKeepAliveEnabled() {
 		return
 	}
 	if sc.rest != nil && sc.rest.HeartBeat != nil {

--- a/htap.go
+++ b/htap.go
@@ -79,7 +79,11 @@ func (qcc *queryContextCache) prune(size int) {
 }
 
 func (qcc *queryContextCache) getQueryContextCacheSize(sc *snowflakeConn) int {
-	if sizeStr, ok := sc.cfg.Params[queryContextCacheSizeParamName]; ok {
+	paramsMutex.Lock()
+	sizeStr, ok := sc.cfg.Params[queryContextCacheSizeParamName]
+	paramsMutex.Unlock()
+
+	if ok {
 		size, err := strconv.Atoi(*sizeStr)
 		if err != nil {
 			logger.Warnf("cannot parse %v as int as query context cache size: %v", sizeStr, err)

--- a/htap.go
+++ b/htap.go
@@ -79,11 +79,7 @@ func (qcc *queryContextCache) prune(size int) {
 }
 
 func (qcc *queryContextCache) getQueryContextCacheSize(sc *snowflakeConn) int {
-	paramsMutex.Lock()
-	sizeStr, ok := sc.cfg.Params[queryContextCacheSizeParamName]
-	paramsMutex.Unlock()
-
-	if ok {
+	if sizeStr, ok := sc.cfg.Params[queryContextCacheSizeParamName]; ok {
 		size, err := strconv.Atoi(*sizeStr)
 		if err != nil {
 			logger.Warnf("cannot parse %v as int as query context cache size: %v", sizeStr, err)

--- a/location.go
+++ b/location.go
@@ -94,11 +94,13 @@ func init() {
 func getCurrentLocation(params map[string]*string) *time.Location {
 	loc := time.Now().Location()
 	var err error
+	paramsMutex.Lock()
 	if tz, ok := params["timezone"]; ok && tz != nil {
 		loc, err = time.LoadLocation(*tz)
 		if err != nil {
 			loc = time.Now().Location()
 		}
 	}
+	paramsMutex.Unlock()
 	return loc
 }

--- a/location.go
+++ b/location.go
@@ -94,13 +94,11 @@ func init() {
 func getCurrentLocation(params map[string]*string) *time.Location {
 	loc := time.Now().Location()
 	var err error
-	paramsMutex.Lock()
 	if tz, ok := params["timezone"]; ok && tz != nil {
 		loc, err = time.LoadLocation(*tz)
 		if err != nil {
 			loc = time.Now().Location()
 		}
 	}
-	paramsMutex.Unlock()
 	return loc
 }

--- a/rows.go
+++ b/rows.go
@@ -47,9 +47,11 @@ type snowflakeRows struct {
 }
 
 func (rows *snowflakeRows) getLocation() *time.Location {
+	paramsMutex.Lock()
 	if rows.location == nil && rows.sc != nil && rows.sc.cfg != nil {
 		rows.location = getCurrentLocation(rows.sc.cfg.Params)
 	}
+	paramsMutex.Unlock()
 	return rows.location
 }
 

--- a/rows.go
+++ b/rows.go
@@ -47,11 +47,9 @@ type snowflakeRows struct {
 }
 
 func (rows *snowflakeRows) getLocation() *time.Location {
-	paramsMutex.Lock()
 	if rows.location == nil && rows.sc != nil && rows.sc.cfg != nil {
 		rows.location = getCurrentLocation(rows.sc.cfg.Params)
 	}
-	paramsMutex.Unlock()
 	return rows.location
 }
 

--- a/rows.go
+++ b/rows.go
@@ -47,7 +47,7 @@ type snowflakeRows struct {
 }
 
 func (rows *snowflakeRows) getLocation() *time.Location {
-	if rows.location == nil && rows.sc != nil && rows.sc.cfg != nil {
+	if rows.location == nil && rows.sc != nil && rows.sc.getConnConfig() != nil {
 		rows.location = getCurrentLocation(rows.sc.cfg.Params)
 	}
 	return rows.location


### PR DESCRIPTION
### Description
Issue: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/614

Fixes 2 race conditions by adding sync.Mutex locks:
- `sc.cfg.Params` map is being read in getQueryContextCacheSize() (same fix as https://github.com/snowflakedb/gosnowflake/pull/706)
- `sc.cfg` is being read in decodeChunk() while cleanup() is trying to write

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
