### PR TITLE
Fix TestConcurrentReadOnParams cleaning up the connection too early

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,6 +48,7 @@ jobs:
               env:
                 PARAMETERS_SECRET: ${{ secrets.PARAMETERS_SECRET }}
                 CLOUD_PROVIDER: ${{ matrix.cloud }}
+                GORACE: history_size=7
               run: ./ci/test.sh
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3

--- a/connection_test.go
+++ b/connection_test.go
@@ -476,19 +476,19 @@ func TestExecWithServerSideError(t *testing.T) {
 }
 
 func TestConcurrentReadOnParams(t *testing.T) {
-	t.Skip("Fails randomly")
 	config, err := ParseDSN(dsn)
 	if err != nil {
 		t.Fatal("Failed to parse dsn")
 	}
 	connector := NewConnector(SnowflakeDriver{}, *config)
 	db := sql.OpenDB(connector)
+	defer db.Close()
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			for c := 0; c < 10; c++ {
-				stmt, err := db.PrepareContext(context.Background(), "SELECT * FROM information_schema.columns WHERE table_schema = ?")
+				stmt, err := db.PrepareContext(context.Background(), "SELECT table_schema FROM information_schema.columns WHERE table_schema = ? LIMIT 1")
 				if err != nil {
 					t.Error(err)
 				}
@@ -499,13 +499,18 @@ func TestConcurrentReadOnParams(t *testing.T) {
 				if rows == nil {
 					continue
 				}
+				rows.Next()
+				var tableName string
+				err = rows.Scan(&tableName)
+				if err != nil {
+					t.Error(err)
+				}
 				_ = rows.Close()
 			}
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	defer db.Close()
 }
 
 func postQueryTest(_ context.Context, _ *snowflakeRestful, _ *url.Values, headers map[string]string, _ []byte, _ time.Duration, _ UUID, _ *Config) (*execResponse, error) {


### PR DESCRIPTION
### Description
This test failed randomly when concurrent threads were run. If no row was read, the connection was returned to the pool too fast, before chunk decoding (in another thread) was finished. Currently, as we read from the rows, this object is not returned to the pool too early.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
