### PR TITLE
Set the result type before calling exec from Ping

### DIFF
--- a/async_test.go
+++ b/async_test.go
@@ -45,6 +45,22 @@ func TestAsyncMode(t *testing.T) {
 	})
 }
 
+func TestAsyncModePing(t *testing.T) {
+	ctx := WithAsyncMode(context.Background())
+
+	runDBTest(t, func(dbt *DBTest) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic during ping: %v", r)
+			}
+		}()
+		err := dbt.conn.PingContext(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestAsyncModeMultiStatement(t *testing.T) {
 	withMultiStmtCtx, _ := WithMultiStatement(context.Background(), 6)
 	ctx := WithAsyncMode(withMultiStmtCtx)

--- a/connection.go
+++ b/connection.go
@@ -439,6 +439,7 @@ func (sc *snowflakeConn) Ping(ctx context.Context) error {
 	noResult := isAsyncMode(ctx)
 	isDesc := isDescribeOnly(ctx)
 	// TODO: handle isInternal
+	ctx = setResultType(ctx, execResultType)
 	_, err := sc.exec(ctx, "SELECT 1", noResult, false, /* isInternal */
 		isDesc, []driver.NamedValue{})
 	return err


### PR DESCRIPTION
If the context has been set to Async Mode, the driver will attempt to inspect the result type. If the result type has not been set, the driver will panic when returning the [partial] result.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
