### PR TITLE
SNOW-878073 Add MaxRetryCount as configurable parameter

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -226,7 +226,7 @@ func postAuth(
 
 	fullURL := sr.getFullURL(loginRequestPath, params)
 	logger.Infof("full URL: %v", fullURL)
-	resp, err := sr.FuncAuthPost(ctx, client, fullURL, headers, bodyCreator, timeout)
+	resp, err := sr.FuncAuthPost(ctx, client, fullURL, headers, bodyCreator, timeout, sr.MaxRetryCount)
 	if err != nil {
 		return nil, err
 	}

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -264,7 +264,7 @@ func getChunk(
 	if err != nil {
 		return nil, err
 	}
-	return newRetryHTTP(ctx, sc.rest.Client, http.NewRequest, u, headers, timeout, sc.currentTimeProvider, sc.cfg).execute()
+	return newRetryHTTP(ctx, sc.rest.Client, http.NewRequest, u, headers, timeout, sc.rest.MaxRetryCount, sc.currentTimeProvider, sc.cfg).execute()
 }
 
 func (scd *snowflakeChunkDownloader) startArrowBatches() error {
@@ -638,7 +638,7 @@ func (f *httpStreamChunkFetcher) fetch(URL string, rows chan<- []*string) error 
 	if err != nil {
 		return err
 	}
-	res, err := newRetryHTTP(context.Background(), f.client, http.NewRequest, fullURL, f.headers, 0, defaultTimeProvider, nil).execute()
+	res, err := newRetryHTTP(context.Background(), f.client, http.NewRequest, fullURL, f.headers, 0, 0, defaultTimeProvider, nil).execute()
 	if err != nil {
 		return err
 	}

--- a/connection.go
+++ b/connection.go
@@ -785,6 +785,7 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 		TokenAccessor:       tokenAccessor,
 		LoginTimeout:        sc.cfg.LoginTimeout,
 		RequestTimeout:      sc.cfg.RequestTimeout,
+		MaxRetryCount:       sc.cfg.MaxRetryCount,
 		FuncPost:            postRestful,
 		FuncGet:             getRestful,
 		FuncAuthPost:        postAuthRestful,

--- a/dsn.go
+++ b/dsn.go
@@ -25,6 +25,7 @@ const (
 	defaultRequestTimeout         = 0 * time.Second   // Timeout for retry for request EXCLUDING clientTimeout
 	defaultJWTTimeout             = 60 * time.Second
 	defaultExternalBrowserTimeout = 120 * time.Second // Timeout for external browser login
+	defaultMaxRetryCount          = 7                 // specifies maximum number of subsequent retries
 	defaultDomain                 = ".snowflakecomputing.com"
 )
 
@@ -74,6 +75,7 @@ type Config struct {
 	ClientTimeout          time.Duration // Timeout for network round trip + read out http response
 	JWTClientTimeout       time.Duration // Timeout for network round trip + read out http response used when JWT token auth is taking place
 	ExternalBrowserTimeout time.Duration // Timeout for external browser login
+	MaxRetryCount          int           // Specifies how many times non-periodic HTTP request can be retried
 
 	Application  string           // application name.
 	InsecureMode bool             // driver doesn't check certificate revocation status
@@ -202,6 +204,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	}
 	if cfg.ExternalBrowserTimeout != defaultExternalBrowserTimeout {
 		params.Add("externalBrowserTimeout", strconv.FormatInt(int64(cfg.ExternalBrowserTimeout/time.Second), 10))
+	}
+	if cfg.MaxRetryCount != defaultMaxRetryCount {
+		params.Add("maxRetryCount", strconv.Itoa(cfg.MaxRetryCount))
 	}
 	if cfg.Application != clientType {
 		params.Add("application", cfg.Application)
@@ -466,6 +471,9 @@ func fillMissingConfigParameters(cfg *Config) error {
 	if cfg.ExternalBrowserTimeout == 0 {
 		cfg.ExternalBrowserTimeout = defaultExternalBrowserTimeout
 	}
+	if cfg.MaxRetryCount == 0 {
+		cfg.MaxRetryCount = defaultMaxRetryCount
+	}
 	if strings.Trim(cfg.Application, " ") == "" {
 		cfg.Application = clientType
 	}
@@ -634,6 +642,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			}
 		case "externalBrowserTimeout":
 			cfg.ExternalBrowserTimeout, err = parseTimeout(value)
+			if err != nil {
+				return err
+			}
+		case "maxRetryCount":
+			cfg.MaxRetryCount, err = strconv.Atoi(value)
 			if err != nil {
 				return err
 			}

--- a/dsn.go
+++ b/dsn.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	defaultClientTimeout          = 300 * time.Second // Timeout for network round trip + read out http response
+	defaultClientTimeout          = 900 * time.Second // Timeout for network round trip + read out http response
 	defaultJWTClientTimeout       = 10 * time.Second  // Timeout for network round trip + read out http response but used for JWT auth
-	defaultLoginTimeout           = 60 * time.Second  // Timeout for retry for login EXCLUDING clientTimeout
+	defaultLoginTimeout           = 300 * time.Second // Timeout for retry for login EXCLUDING clientTimeout
 	defaultRequestTimeout         = 0 * time.Second   // Timeout for retry for request EXCLUDING clientTimeout
 	defaultJWTTimeout             = 60 * time.Second
 	defaultExternalBrowserTimeout = 120 * time.Second // Timeout for external browser login

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -336,6 +336,7 @@ func TestParseDSN(t *testing.T) {
 				ClientTimeout:             defaultClientTimeout,
 				JWTClientTimeout:          defaultJWTClientTimeout,
 				IncludeRetryReason:        ConfigBoolTrue,
+				MaxRetryCount:             defaultMaxRetryCount,
 			},
 			ocspMode: ocspModeFailOpen,
 		},

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -340,6 +340,22 @@ func TestParseDSN(t *testing.T) {
 			ocspMode: ocspModeFailOpen,
 		},
 		{
+			dsn: "u:p@a?database=d&maxRetryCount=20",
+			config: &Config{
+				Account: "a", User: "u", Password: "p",
+				Protocol: "https", Host: "a.snowflakecomputing.com", Port: 443,
+				Database: "d", Schema: "",
+				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				ValidateDefaultParameters: ConfigBoolTrue,
+				ClientTimeout:             defaultClientTimeout,
+				JWTClientTimeout:          defaultJWTClientTimeout,
+				IncludeRetryReason:        ConfigBoolTrue,
+				MaxRetryCount:             20,
+			},
+			ocspMode: ocspModeFailOpen,
+		},
+		{
 			dsn: "u:p@a?database=d",
 			config: &Config{
 				Account: "a", User: "u", Password: "p",
@@ -1207,6 +1223,16 @@ func TestDSN(t *testing.T) {
 				TmpDirPath: "/tmp",
 			},
 			dsn: "u:p@a.b.c.snowflakecomputing.com:443?ocspFailOpen=true&region=b.c&tmpDirPath=%2Ftmp&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:               "u",
+				Password:           "p",
+				Account:            "a.b.c",
+				IncludeRetryReason: ConfigBoolFalse,
+				MaxRetryCount:      30,
+			},
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?includeRetryReason=false&maxRetryCount=30&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{

--- a/ocsp.go
+++ b/ocsp.go
@@ -358,7 +358,7 @@ func checkOCSPCacheServer(
 	ocspS *ocspStatus) {
 	var respd map[string][]interface{}
 	headers := make(map[string]string)
-	res, err := newRetryHTTP(ctx, client, req, ocspServerHost, headers, totalTimeout, defaultTimeProvider, nil).execute()
+	res, err := newRetryHTTP(ctx, client, req, ocspServerHost, headers, totalTimeout, defaultMaxRetryCount, defaultTimeProvider, nil).execute()
 	if err != nil {
 		logger.Errorf("failed to get OCSP cache from OCSP Cache Server. %v", err)
 		return nil, &ocspStatus{
@@ -413,7 +413,7 @@ func retryOCSP(
 	}
 	res, err := newRetryHTTP(
 		ctx, client, req, ocspHost, headers,
-		totalTimeout*time.Duration(multiplier), defaultTimeProvider, nil).doPost().setBody(reqBody).execute()
+		totalTimeout*time.Duration(multiplier), defaultMaxRetryCount, defaultTimeProvider, nil).doPost().setBody(reqBody).execute()
 	if err != nil {
 		return ocspRes, ocspResBytes, &ocspStatus{
 			code: ocspFailedSubmit,
@@ -466,7 +466,7 @@ func fallbackRetryOCSPToGETRequest(
 		multiplier = 3 // up to 3 times for Fail Close mode
 	}
 	res, err := newRetryHTTP(ctx, client, req, ocspHost, headers,
-		totalTimeout*time.Duration(multiplier), defaultTimeProvider, nil).execute()
+		totalTimeout*time.Duration(multiplier), defaultMaxRetryCount, defaultTimeProvider, nil).execute()
 	if err != nil {
 		return ocspRes, ocspResBytes, &ocspStatus{
 			code: ocspFailedSubmit,

--- a/restful_test.go
+++ b/restful_test.go
@@ -22,7 +22,7 @@ func postTestError(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ map[str
 	}, errors.New("failed to run post method")
 }
 
-func postAuthTestError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*http.Response, error) {
+func postAuthTestError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration, _ int) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
@@ -43,7 +43,7 @@ func postTestAppBadGatewayError(_ context.Context, _ *snowflakeRestful, _ *url.U
 	}, nil
 }
 
-func postAuthTestAppBadGatewayError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*http.Response, error) {
+func postAuthTestAppBadGatewayError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration, _ int) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusBadGateway,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
@@ -57,14 +57,14 @@ func postTestAppForbiddenError(_ context.Context, _ *snowflakeRestful, _ *url.UR
 	}, nil
 }
 
-func postAuthTestAppForbiddenError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*http.Response, error) {
+func postAuthTestAppForbiddenError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration, _ int) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusForbidden,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
 	}, nil
 }
 
-func postAuthTestAppUnexpectedError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*http.Response, error) {
+func postAuthTestAppUnexpectedError(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration, _ int) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusInsufficientStorage,
 		Body:       &fakeResponseBody{body: []byte{0x12, 0x34}},
@@ -110,7 +110,7 @@ func postTestRenew(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ map[str
 	}, nil
 }
 
-func postAuthTestAfterRenew(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration) (*http.Response, error) {
+func postAuthTestAfterRenew(_ context.Context, _ *http.Client, _ *url.URL, _ map[string]string, _ bodyCreatorType, _ time.Duration, _ int) (*http.Response, error) {
 	dd := &execResponseData{}
 	er := &execResponse{
 		Data:    *dd,

--- a/retry.go
+++ b/retry.go
@@ -339,7 +339,7 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 			logger.WithContext(r.ctx).Infof("to timeout: %v", totalTimeout)
 			// if any timeout is set
 			totalTimeout -= time.Duration(sleepTime * float64(time.Second))
-			if totalTimeout <= 0 || retryCounter >= r.maxRetryCount {
+			if totalTimeout <= 0 || retryCounter > r.maxRetryCount {
 				if err != nil {
 					return nil, err
 				}

--- a/retry.go
+++ b/retry.go
@@ -17,11 +17,6 @@ import (
 	"time"
 )
 
-const (
-	// defaultMaxRetryCount specifies maximum number of subsequent retries
-	defaultMaxRetryCount = 7
-)
-
 type waitAlgo struct {
 	mutex  *sync.Mutex // required for *rand.Rand usage
 	random *rand.Rand
@@ -248,6 +243,7 @@ type retryHTTP struct {
 	headers             map[string]string
 	bodyCreator         bodyCreatorType
 	timeout             time.Duration
+	maxRetryCount       int
 	currentTimeProvider currentTimeProvider
 	cfg                 *Config
 }
@@ -258,6 +254,7 @@ func newRetryHTTP(ctx context.Context,
 	fullURL *url.URL,
 	headers map[string]string,
 	timeout time.Duration,
+	maxRetryCount int,
 	currentTimeProvider currentTimeProvider,
 	cfg *Config) *retryHTTP {
 	instance := retryHTTP{}
@@ -268,6 +265,7 @@ func newRetryHTTP(ctx context.Context,
 	instance.fullURL = fullURL
 	instance.headers = headers
 	instance.timeout = timeout
+	instance.maxRetryCount = maxRetryCount
 	instance.bodyCreator = emptyBodyCreator
 	instance.currentTimeProvider = currentTimeProvider
 	instance.cfg = cfg
@@ -341,7 +339,7 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 			logger.WithContext(r.ctx).Infof("to timeout: %v", totalTimeout)
 			// if any timeout is set
 			totalTimeout -= time.Duration(sleepTime * float64(time.Second))
-			if totalTimeout <= 0 || retryCounter >= defaultMaxRetryCount {
+			if totalTimeout <= 0 || retryCounter >= r.maxRetryCount {
 				if err != nil {
 					return nil, err
 				}

--- a/retry_test.go
+++ b/retry_test.go
@@ -223,20 +223,14 @@ func TestRetryQuerySuccess(t *testing.T) {
 		t: t,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretrysuccess.snowflakecomputing.com:443/queries/v1/query-request?" + requestIDKey + "=testid")
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 60*time.Second, 3, constTimeProvider(123456), &Config{IncludeRetryReason: ConfigBoolTrue}).doPost().setBody([]byte{0}).execute()
-	if err != nil {
-		t.Fatal("failed to run retry")
-	}
+	assertNilF(t, err, "failed to run retry")
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
-	if err != nil {
-		t.Fatal("failed to parse the URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	retry, err := strconv.Atoi(values.Get(retryCountKey))
 	if err != nil {
 		t.Fatalf("failed to get retry counter: %v", err)
@@ -272,20 +266,14 @@ func TestRetryQuerySuccessWithRetryReasonDisabled(t *testing.T) {
 		t: t,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretrysuccess.snowflakecomputing.com:443/queries/v1/query-request?" + requestIDKey + "=testid")
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 60*time.Second, 3, constTimeProvider(123456), &Config{IncludeRetryReason: ConfigBoolFalse}).doPost().setBody([]byte{0}).execute()
-	if err != nil {
-		t.Fatal("failed to run retry")
-	}
+	assertNilF(t, err, "failed to run retry")
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
-	if err != nil {
-		t.Fatal("failed to parse the URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	retry, err := strconv.Atoi(values.Get(retryCountKey))
 	if err != nil {
 		t.Fatalf("failed to get retry counter: %v", err)
@@ -318,20 +306,14 @@ func TestRetryQuerySuccessWithTimeout(t *testing.T) {
 		t: t,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretrysuccess.snowflakecomputing.com:443/queries/v1/query-request?" + requestIDKey + "=testid")
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 60*time.Second, 3, constTimeProvider(123456), nil).doPost().setBody([]byte{0}).execute()
-	if err != nil {
-		t.Fatal("failed to run retry")
-	}
+	assertNilF(t, err, "failed to run retry")
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
-	if err != nil {
-		t.Fatal("failed to parse the URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	retry, err := strconv.Atoi(values.Get(retryCountKey))
 	if err != nil {
 		t.Fatalf("failed to get retry counter: %v", err)
@@ -348,24 +330,16 @@ func TestRetryQueryFailWithTimeout(t *testing.T) {
 		success:    false,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretryfail.snowflakecomputing.com:443/queries/v1/query-request?" + requestIDKey)
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 15*time.Second, 100, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
-	if err == nil {
-		t.Fatal("should fail to run retry")
-	}
+	assertNotNilF(t, err, "should fail to run retry")
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
-	if err != nil {
-		t.Fatalf("failed to parse the URL: %v", err)
-	}
+	assertNilF(t, err, fmt.Sprintf("failed to parse the URL: %v", err))
 	retry, err := strconv.Atoi(values.Get(retryCountKey))
-	if err != nil {
-		t.Fatalf("failed to get retry counter: %v", err)
-	}
+	assertNilF(t, err, fmt.Sprintf("failed to get retry counter: %v", err))
 	if retry < 2 {
 		t.Fatalf("not enough retries: %v", retry)
 	}
@@ -379,15 +353,11 @@ func TestRetryQueryFailWithMaxRetryCount(t *testing.T) {
 		success:    false,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretryfail.snowflakecomputing.com:443/queries/v1/query-request?" + requestIDKey)
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 15*time.Hour, maxRetryCount, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
-	if err == nil {
-		t.Fatal("should fail to run retry")
-	}
+	assertNotNilF(t, err, "should fail to run retry")
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
 	if err != nil {
@@ -425,35 +395,26 @@ func TestRetryLoginRequest(t *testing.T) {
 		},
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretrylogin.snowflakecomputing.com:443/login-request?request_id=testid")
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 60*time.Second, 3, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
-	if err != nil {
-		t.Fatal("failed to run retry")
-	}
+	assertNilF(t, err, "failed to run retry")
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
-	if err != nil {
-		t.Fatalf("failed to parse the URL: %v", err)
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	if values.Get(retryCountKey) != "" {
 		t.Fatalf("no retry counter should be attached: %v", retryCountKey)
 	}
 	logger.Info("Retry N times for timeouts and Fail")
 	client = &fakeHTTPClient{
-		cnt:     10,
 		success: false,
 		timeout: true,
 	}
 	_, err = newRetryHTTP(context.Background(),
 		client,
-		emptyRequest, urlPtr, make(map[string]string), 10*time.Second, 3, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
-	if err == nil {
-		t.Fatal("should fail to run retry")
-	}
+		emptyRequest, urlPtr, make(map[string]string), 5*time.Second, 3, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
+	assertNotNilF(t, err, "should fail to run retry")
 	values, err = url.ParseQuery(urlPtr.RawQuery)
 	if err != nil {
 		t.Fatalf("failed to parse the URL: %v", err)
@@ -471,9 +432,7 @@ func TestRetryAuthLoginRequest(t *testing.T) {
 		timeout: true,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretrylogin.snowflakecomputing.com:443/login-request?request_id=testid")
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
 	execID := 0
 	bodyCreator := func() ([]byte, error) {
 		execID++
@@ -482,9 +441,7 @@ func TestRetryAuthLoginRequest(t *testing.T) {
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		http.NewRequest, urlPtr, make(map[string]string), 60*time.Second, 3, defaultTimeProvider, nil).doPost().setBodyCreator(bodyCreator).execute()
-	if err != nil {
-		t.Fatal("failed to run retry")
-	}
+	assertNilF(t, err, "failed to run retry")
 	if lastReqBody := string(client.reqBody); lastReqBody != "execID: 3" {
 		t.Fatalf("body should be updated on each request, expected: execID: 3, last body: %v", lastReqBody)
 	}
@@ -497,20 +454,16 @@ func TestLoginRetry429(t *testing.T) {
 		statusCode: 429,
 	}
 	urlPtr, err := url.Parse("https://fakeaccountretrylogin.snowflakecomputing.com:443/login-request?request_id=testid")
-	if err != nil {
-		t.Fatal("failed to parse the test URL")
-	}
+	assertNilF(t, err, "failed to parse the test URL")
+
 	_, err = newRetryHTTP(context.Background(),
 		client,
 		emptyRequest, urlPtr, make(map[string]string), 60*time.Second, 3, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute() // enable doRaise4XXX
-	if err != nil {
-		t.Fatal("failed to run retry")
-	}
+	assertNilF(t, err, "failed to run retry")
+
 	var values url.Values
 	values, err = url.ParseQuery(urlPtr.RawQuery)
-	if err != nil {
-		t.Fatalf("failed to parse the URL: %v", err)
-	}
+	assertNilF(t, err, fmt.Sprintf("failed to parse the URL: %v", err))
 	if values.Get(retryCountKey) != "" {
 		t.Fatalf("no retry counter should be attached: %v", retryCountKey)
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -367,11 +367,12 @@ func TestRetryQueryFailWithTimeout(t *testing.T) {
 		t.Fatalf("failed to get retry counter: %v", err)
 	}
 	if retry < 2 {
-		t.Fatalf("not enough retry counter: %v", retry)
+		t.Fatalf("not enough retries: %v", retry)
 	}
 }
 
 func TestRetryQueryFailWithMaxRetryCount(t *testing.T) {
+	maxRetryCount := 3
 	logger.Info("Retry 3 times until retry reaches MaxRetryCount and Fail")
 	client := &fakeHTTPClient{
 		statusCode: http.StatusTooManyRequests,
@@ -383,7 +384,7 @@ func TestRetryQueryFailWithMaxRetryCount(t *testing.T) {
 	}
 	_, err = newRetryHTTP(context.Background(),
 		client,
-		emptyRequest, urlPtr, make(map[string]string), 15*time.Hour, 3, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
+		emptyRequest, urlPtr, make(map[string]string), 15*time.Hour, maxRetryCount, defaultTimeProvider, nil).doPost().setBody([]byte{0}).execute()
 	if err == nil {
 		t.Fatal("should fail to run retry")
 	}
@@ -392,12 +393,12 @@ func TestRetryQueryFailWithMaxRetryCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse the URL: %v", err)
 	}
-	retry, err := strconv.Atoi(values.Get(retryCountKey))
+	retryCount, err := strconv.Atoi(values.Get(retryCountKey))
 	if err != nil {
 		t.Fatalf("failed to get retry counter: %v", err)
 	}
-	if retry < 2 {
-		t.Fatalf("not enough retry counter: %v", retry)
+	if retryCount < 3 {
+		t.Fatalf("not enough retries: %v; expected %v", retryCount, maxRetryCount)
 	}
 }
 


### PR DESCRIPTION
### Description
Added MaxRetryCount as configurable parameter. It specifies how many times requests can be retried.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
