### PR TITLE
SNOW-856228 easy logging - not fail on directory serch error

### DIFF
--- a/client_configuration.go
+++ b/client_configuration.go
@@ -28,43 +28,37 @@ const (
 
 func getClientConfig(filePathFromConnectionString string) (*ClientConfig, error) {
 	configPredefinedFilePaths := clientConfigPredefinedDirs()
-	filePath, err := findClientConfigFilePath(filePathFromConnectionString, configPredefinedFilePaths)
-	if err != nil {
-		return nil, findClientConfigError(err)
-	}
+	filePath := findClientConfigFilePath(filePathFromConnectionString, configPredefinedFilePaths)
 	if filePath == "" { // we did not find a config file
 		return nil, nil
 	}
 	return parseClientConfiguration(filePath)
 }
 
-func findClientConfigFilePath(filePathFromConnectionString string, configPredefinedDirs []string) (string, error) {
+func findClientConfigFilePath(filePathFromConnectionString string, configPredefinedDirs []string) string {
 	if filePathFromConnectionString != "" {
-		return filePathFromConnectionString, nil
+		return filePathFromConnectionString
 	}
 	envConfigFilePath := os.Getenv(clientConfEnvName)
 	if envConfigFilePath != "" {
-		return envConfigFilePath, nil
+		return envConfigFilePath
 	}
 	return searchForConfigFile(configPredefinedDirs)
 }
 
-func searchForConfigFile(directories []string) (string, error) {
+func searchForConfigFile(directories []string) string {
 	for _, dir := range directories {
 		filePath := path.Join(dir, defaultConfigName)
 		exists, err := existsFile(filePath)
 		if err != nil {
-			return "", err
+			logger.Errorf("Error while searching for the client config in %s directory: %s", dir, err)
+			continue
 		}
 		if exists {
-			return filePath, nil
+			return filePath
 		}
 	}
-	return "", nil
-}
-
-func findClientConfigError(err error) error {
-	return fmt.Errorf("finding client config failed: %w", err)
+	return ""
 }
 
 func existsFile(filePath string) (bool, error) {

--- a/client_configuration_test.go
+++ b/client_configuration_test.go
@@ -18,9 +18,8 @@ func TestFindConfigFileFromConnectionParameters(t *testing.T) {
 	createFile(t, defaultConfigName, "random content", dirs.predefinedDir1)
 	createFile(t, defaultConfigName, "random content", dirs.predefinedDir2)
 
-	clientConfigFilePath, err := findClientConfigFilePath(connParameterConfigPath, predefinedTestDirs(dirs))
+	clientConfigFilePath := findClientConfigFilePath(connParameterConfigPath, predefinedTestDirs(dirs))
 
-	assertNilF(t, err, "get client config error")
 	assertEqualE(t, clientConfigFilePath, connParameterConfigPath, "config file path")
 }
 
@@ -31,9 +30,8 @@ func TestFindConfigFileFromEnvVariable(t *testing.T) {
 	createFile(t, defaultConfigName, "random content", dirs.predefinedDir1)
 	createFile(t, defaultConfigName, "random content", dirs.predefinedDir2)
 
-	clientConfigFilePath, err := findClientConfigFilePath("", predefinedTestDirs(dirs))
+	clientConfigFilePath := findClientConfigFilePath("", predefinedTestDirs(dirs))
 
-	assertNilF(t, err, "get client config error")
 	assertEqualE(t, clientConfigFilePath, envConfigPath, "config file path")
 }
 
@@ -42,9 +40,8 @@ func TestFindConfigFileFromFirstPredefinedDir(t *testing.T) {
 	configPath := createFile(t, defaultConfigName, "random content", dirs.predefinedDir1)
 	createFile(t, defaultConfigName, "random content", dirs.predefinedDir2)
 
-	clientConfigFilePath, err := findClientConfigFilePath("", predefinedTestDirs(dirs))
+	clientConfigFilePath := findClientConfigFilePath("", predefinedTestDirs(dirs))
 
-	assertNilF(t, err, "get client config error")
 	assertEqualE(t, clientConfigFilePath, configPath, "config file path")
 }
 
@@ -53,9 +50,8 @@ func TestFindConfigFileFromSubsequentDirectoryIfNotFoundInPreviousOne(t *testing
 	createFile(t, "wrong_file_name.json", "random content", dirs.predefinedDir1)
 	configPath := createFile(t, defaultConfigName, "random content", dirs.predefinedDir2)
 
-	clientConfigFilePath, err := findClientConfigFilePath("", predefinedTestDirs(dirs))
+	clientConfigFilePath := findClientConfigFilePath("", predefinedTestDirs(dirs))
 
-	assertNilF(t, err, "get client config error")
 	assertEqualE(t, clientConfigFilePath, configPath, "config file path")
 }
 
@@ -64,9 +60,8 @@ func TestNotFindConfigFileWhenNotDefined(t *testing.T) {
 	createFile(t, "wrong_file_name.json", "random content", dirs.predefinedDir1)
 	createFile(t, "wrong_file_name.json", "random content", dirs.predefinedDir2)
 
-	clientConfigFilePath, err := findClientConfigFilePath("", predefinedTestDirs(dirs))
+	clientConfigFilePath := findClientConfigFilePath("", predefinedTestDirs(dirs))
 
-	assertNilF(t, err, "get client config error")
 	assertEqualE(t, clientConfigFilePath, "", "config file path")
 }
 


### PR DESCRIPTION
### Description
Prevent to fail if client config file could not be found because of an unexpected error during the phase of searching in predefined directory.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
