### PR TITLE
fix: remove unsafe interface conversion

### DIFF
--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -219,7 +219,11 @@ func doAuthenticateByExternalBrowser(
 	}
 	defer l.Close()
 
-	callbackPort := l.Addr().(*net.TCPAddr).Port
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		return authenticateByExternalBrowserResult{nil, nil, fmt.Errorf("interface convertion. expected type *net.TCPAddr but got %T", l.Addr())}
+	}
+	callbackPort := addr.Port
 	idpURL, proofKey, err := getIdpURLProofKey(
 		ctx, sr, authenticator, application, account, callbackPort)
 	if err != nil {

--- a/authexternalbrowser_test.go
+++ b/authexternalbrowser_test.go
@@ -133,3 +133,16 @@ func TestAuthenticationTimeout(t *testing.T) {
 		t.Fatal("should have timed out")
 	}
 }
+
+func Test_createLocalTCPListener(t *testing.T) {
+	listener, err := createLocalTCPListener()
+	if err != nil {
+		t.Fatalf("createLocalTCPListener() failed: %v", err)
+	}
+	if listener == nil {
+		t.Fatal("createLocalTCPListener() returned nil listener")
+	}
+
+	// Close the listener after the test.
+	defer listener.Close()
+}

--- a/dsn.go
+++ b/dsn.go
@@ -869,5 +869,9 @@ func parsePrivateKeyFromFile(path string) (*rsa.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return privateKey.(*rsa.PrivateKey), nil
+	pk, ok := privateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("interface convertion. expected type *rsa.PrivateKey, but got %T", privateKey)
+	}
+	return pk, nil
 }

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -54,7 +54,10 @@ func (util *snowflakeGcsClient) getFileHeader(meta *fileMetadata, filename strin
 		if err != nil {
 			return nil, err
 		}
-		accessToken := meta.client.(string)
+		accessToken, ok := meta.client.(string)
+		if !ok {
+			return nil, fmt.Errorf("interface convertion. expected type string but got %T", meta.client)
+		}
 		gcsHeaders := map[string]string{
 			"Authorization": "Bearer " + accessToken,
 		}
@@ -145,7 +148,11 @@ func (util *snowflakeGcsClient) uploadFile(
 		if err != nil {
 			return err
 		}
-		accessToken = meta.client.(string)
+		var ok bool
+		accessToken, ok = meta.client.(string)
+		if !ok {
+			return fmt.Errorf("interface convertion. expected type string but got %T", meta.client)
+		}
 	}
 
 	var contentEncoding string
@@ -271,7 +278,11 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 		if err != nil {
 			return err
 		}
-		accessToken = meta.client.(string)
+		var ok bool
+		accessToken, ok = meta.client.(string)
+		if !ok {
+			return fmt.Errorf("interface convertion. expected type string but got %T", meta.client)
+		}
 		if accessToken != "" {
 			gcsHeaders["Authorization"] = "Bearer " + accessToken
 		}

--- a/statement.go
+++ b/statement.go
@@ -5,6 +5,7 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 )
 
 // SnowflakeStmt represents the prepared statement in driver.
@@ -33,28 +34,56 @@ func (stmt *snowflakeStmt) NumInput() int {
 func (stmt *snowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.ExecContext")
 	result, err := stmt.sc.ExecContext(ctx, stmt.query, args)
-	stmt.lastQueryID = result.(SnowflakeResult).GetQueryID()
+	if err != nil {
+		return nil, err
+	}
+	r, ok := result.(SnowflakeResult)
+	if !ok {
+		return nil, fmt.Errorf("interface convertion. expected type SnowflakeResult but got %T", result)
+	}
+	stmt.lastQueryID = r.GetQueryID()
 	return result, err
 }
 
 func (stmt *snowflakeStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.QueryContext")
 	rows, err := stmt.sc.QueryContext(ctx, stmt.query, args)
-	stmt.lastQueryID = rows.(SnowflakeRows).GetQueryID()
-	return rows, err
+	if err != nil {
+		return nil, err
+	}
+	r, ok := rows.(SnowflakeRows)
+	if !ok {
+		return nil, fmt.Errorf("interface convertion. expected type SnowflakeRows but got %T", rows)
+	}
+	stmt.lastQueryID = r.GetQueryID()
+	return rows, nil
 }
 
 func (stmt *snowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Exec")
 	result, err := stmt.sc.Exec(stmt.query, args)
-	stmt.lastQueryID = result.(SnowflakeResult).GetQueryID()
+	if err != nil {
+		return nil, err
+	}
+	r, ok := result.(SnowflakeResult)
+	if !ok {
+		return nil, fmt.Errorf("interface convertion. expected type SnowflakeResult but got %T", result)
+	}
+	stmt.lastQueryID = r.GetQueryID()
 	return result, err
 }
 
 func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Query")
 	rows, err := stmt.sc.Query(stmt.query, args)
-	stmt.lastQueryID = rows.(SnowflakeRows).GetQueryID()
+	if err != nil {
+		return nil, err
+	}
+	r, ok := rows.(SnowflakeRows)
+	if !ok {
+		return nil, fmt.Errorf("interface convertion. expected type SnowflakeRows but got %T", rows)
+	}
+	stmt.lastQueryID = r.GetQueryID()
 	return rows, err
 }
 

--- a/statement_test.go
+++ b/statement_test.go
@@ -522,8 +522,8 @@ func TestStatementQueryIdForExecs(t *testing.T) {
 func TestStatementQueryExecs(t *testing.T) {
 	ctx := context.Background()
 	runDBTest(t, func(dbt *DBTest) {
-		dbt.mustExec("CREATE TABLE TestStatementQueryIdForExecs (v INTEGER)")
-		defer dbt.mustExec("DROP TABLE IF EXISTS TestStatementQueryIdForExecs")
+		dbt.mustExec("CREATE TABLE TestStatementQueryExecs (v INTEGER)")
+		defer dbt.mustExec("DROP TABLE IF EXISTS TestStatementForExecs")
 
 		testcases := []struct {
 			name    string
@@ -533,7 +533,7 @@ func TestStatementQueryExecs(t *testing.T) {
 		}{
 			{
 				"validExec",
-				"INSERT INTO TestStatementQueryIdForExecs VALUES (1)",
+				"INSERT INTO TestStatementQueryExecs VALUES (1)",
 				func(stmt driver.Stmt) (driver.Result, error) {
 					return stmt.Exec(nil)
 				},
@@ -541,7 +541,7 @@ func TestStatementQueryExecs(t *testing.T) {
 			},
 			{
 				"validExecContext",
-				"INSERT INTO TestStatementQueryIdForExecs VALUES (1)",
+				"INSERT INTO TestStatementQueryExecs VALUES (1)",
 				func(stmt driver.Stmt) (driver.Result, error) {
 					return stmt.(driver.StmtExecContext).ExecContext(ctx, nil)
 				},
@@ -549,7 +549,7 @@ func TestStatementQueryExecs(t *testing.T) {
 			},
 			{
 				"invalidExec",
-				"INSERT INTO TestStatementQueryIdForExecs VALUES (NULL)",
+				"INSERT INTO TestStatementQueryExecs VALUES ('invalid_data')",
 				func(stmt driver.Stmt) (driver.Result, error) {
 					return stmt.Exec(nil)
 				},
@@ -557,7 +557,7 @@ func TestStatementQueryExecs(t *testing.T) {
 			},
 			{
 				"invalidExecContext",
-				"INSERT INTO TestStatementQueryIdForExecs VALUES (NULL)",
+				"INSERT INTO TestStatementQueryExecs VALUES ('invalid_data')",
 				func(stmt driver.Stmt) (driver.Result, error) {
 					return stmt.(driver.StmtExecContext).ExecContext(ctx, nil)
 				},


### PR DESCRIPTION
### Description
Use a multi-valued interface conversion instead of a single-value form to avoid runtime panic.

Fix for #940

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] All tests passing
