### PR TITLE
Support DescribeOnly for QueryArrowStream

### DIFF
--- a/chunk_test.go
+++ b/chunk_test.go
@@ -618,20 +618,21 @@ func TestQueryArrowStreamDescribeOnly(t *testing.T) {
 
 		query := fmt.Sprintf(selectRandomGenerator, numrows)
 		loader, err := sct.sc.QueryArrowStream(WithDescribeOnly(sct.sc.ctx), query)
-		if err != nil {
-			t.Error(err)
-		}
+		assertNilF(t, err, "failed to run query")
 
 		if loader.TotalRows() != 0 {
 			t.Errorf("total numrows did not match expected, wanted 0, got %v", loader.TotalRows())
 		}
 
 		batches, err := loader.GetBatches()
-		if err != nil {
-			t.Error(err)
-		}
+		assertNilF(t, err, "failed to get result")
 		if len(batches) != 0 {
 			t.Errorf("batches length did not match expected, wanted 0, got %v", len(batches))
+		}
+
+		rowtypes := loader.RowTypes()
+		if len(rowtypes) != 2 {
+			t.Errorf("rowTypes length did not match expected, wanted 2, got %v", len(rowtypes))
 		}
 	})
 }

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -611,3 +611,27 @@ func TestQueryArrowStream(t *testing.T) {
 		}
 	})
 }
+
+func TestQueryArrowStreamDescribeOnly(t *testing.T) {
+	runSnowflakeConnTest(t, func(sct *SCTest) {
+		numrows := 50000 // approximately 10 ArrowBatch objects
+
+		query := fmt.Sprintf(selectRandomGenerator, numrows)
+		loader, err := sct.sc.QueryArrowStream(WithDescribeOnly(sct.sc.ctx), query)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if loader.TotalRows() != 0 {
+			t.Errorf("total numrows did not match expected, wanted 0, got %v", loader.TotalRows())
+		}
+
+		batches, err := loader.GetBatches()
+		if err != nil {
+			t.Error(err)
+		}
+		if len(batches) != 0 {
+			t.Errorf("batches length did not match expected, wanted 0, got %v", len(batches))
+		}
+	})
+}

--- a/connection.go
+++ b/connection.go
@@ -482,7 +482,8 @@ func (sc *snowflakeConn) GetQueryStatus(
 func (sc *snowflakeConn) QueryArrowStream(ctx context.Context, query string, bindings ...driver.NamedValue) (ArrowStreamLoader, error) {
 	ctx = WithArrowBatches(context.WithValue(ctx, asyncMode, false))
 	ctx = setResultType(ctx, queryResultType)
-	data, err := sc.exec(ctx, query, false, false /* isinternal */, false, bindings)
+	isDesc := isDescribeOnly(ctx)
+	data, err := sc.exec(ctx, query, false, false /* isinternal */, isDesc, bindings)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("error: %v", err)
 		if data != nil {


### PR DESCRIPTION
### Description
Modify snowflakeConn.QueryArrowStream to take the "describe only" flag on the context into account.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

References #954 