### PR TITLE
SNOW-856228 Disable easy logging

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -738,10 +738,11 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 		queryContextCache:   (&queryContextCache{}).init(),
 		currentTimeProvider: defaultTimeProvider,
 	}
-	err := initEasyLogging(config.ClientConfigFile)
-	if err != nil {
-		return nil, err
-	}
+	// Easy logging is temporarily disabled
+	//err := initEasyLogging(config.ClientConfigFile)
+	//if err != nil {
+	//	return nil, err
+	//}
 	var st http.RoundTripper = SnowflakeTransport
 	if sc.cfg.Transporter == nil {
 		if sc.cfg.InsecureMode {

--- a/doc.go
+++ b/doc.go
@@ -167,46 +167,6 @@ Users can use SetLogger in driver.go to set a customized logger for gosnowflake 
 In order to enable debug logging for the driver, user could use SetLogLevel("debug") in SFLogger interface
 as shown in demo code at cmd/logger.go. To redirect the logs SFlogger.SetOutput method could do the work.
 
-## Easy Logging
-
-The Easy Logging feature allows you to change log level and the location of a log file for the driver.
-This feature was introduced to make tracing of driver's logs easier.
-The feature is activated by a config file which can be:
-
-1. provided as clientConfigFile parameter.
-Remember to URL-encode all special characters on file path if you use DSN string e. g.
-`user:pass@account/db?clientConfigFile=%2Fsome-path%2Fclient_config.json` encodes clientConfigFile `/some-path/client_config.json`
-
-2. provided as environmental variable called `SF_CLIENT_CONFIG_FILE` (e. g. `export SF_CLIENT_CONFIG_FILE=/some-path/client_config.json`)
-
-3. found in the driver location by searching for sf_client_config.json file
-
-4. found in the home location by searching for sf_client_config.json file
-
-5. found in temp directory location by searching for sf_client_config.json file
-
-The search for a config file is executed in the order listed above.
-
-To minimize the number of searches for a configuration file it is executed only:
-- for the first connection
-- for the first connection with clientConfigFile parameter.
-
-The example of the configuration file is:
-```
-
-	{
-	  "common": {
-		"log_level": "INFO",
-		"log_path": "/some-path/some-directory"
-	  }
-	}
-
-```
-
-Available log levels are: OFF, ERROR, WARN, INFO, DEBUG, TRACE. The log levels are case insensitive.
-
-The logs land into `go` subfolder of given directory `/some-path/some-directory` so in this example: /some-path/some-directory/go.
-
 # Query request ID
 
 A specific query request ID can be set in the context and will be passed through

--- a/easy_logging.go
+++ b/easy_logging.go
@@ -35,6 +35,7 @@ func (i *initTrials) reset() {
 	i.configureCounter = 0
 }
 
+//lint:ignore U1000 Ignore unused function
 func initEasyLogging(clientConfigFileInput string) error {
 	if !allowedToInitialize(clientConfigFileInput) {
 		return nil

--- a/easy_logging_test.go
+++ b/easy_logging_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestInitializeEasyLoggingOnlyOnceWhenConfigGivenAsAParameter(t *testing.T) {
+	t.Skip("Skip until easy logging enabled")
 	defer cleanUp()
 	dir := t.TempDir()
 	logLevel := levelError
@@ -35,6 +36,7 @@ func TestInitializeEasyLoggingOnlyOnceWhenConfigGivenAsAParameter(t *testing.T) 
 }
 
 func TestConfigureEasyLoggingOnlyOnceWhenInitializedWithoutConfigFilePath(t *testing.T) {
+	t.Skip("Skip until easy logging enabled")
 	defer cleanUp()
 	dir := t.TempDir()
 	logLevel := levelError
@@ -53,6 +55,7 @@ func TestConfigureEasyLoggingOnlyOnceWhenInitializedWithoutConfigFilePath(t *tes
 }
 
 func TestReconfigureEasyLoggingIfConfigPathWasNotGivenForTheFirstTime(t *testing.T) {
+	t.Skip("Skip until easy logging enabled")
 	defer cleanUp()
 	dir := t.TempDir()
 	tmpDirLogLevel := levelError
@@ -85,6 +88,7 @@ func TestReconfigureEasyLoggingIfConfigPathWasNotGivenForTheFirstTime(t *testing
 }
 
 func TestEasyLoggingFailOnUnknownLevel(t *testing.T) {
+	t.Skip("Skip until easy logging enabled")
 	defer cleanUp()
 	dir := t.TempDir()
 	easyLoggingInitTrials.reset()
@@ -99,6 +103,7 @@ func TestEasyLoggingFailOnUnknownLevel(t *testing.T) {
 }
 
 func TestEasyLoggingFailOnNotExistingConfigFile(t *testing.T) {
+	t.Skip("Skip until easy logging enabled")
 	defer cleanUp()
 	easyLoggingInitTrials.reset()
 
@@ -110,6 +115,7 @@ func TestEasyLoggingFailOnNotExistingConfigFile(t *testing.T) {
 }
 
 func TestLogToConfiguredFile(t *testing.T) {
+	t.Skip("Skip until easy logging enabled")
 	defer cleanUp()
 	dir := t.TempDir()
 	easyLoggingInitTrials.reset()


### PR DESCRIPTION
### Description
Disable easy logging.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
