### PR TITLE
SNOW-968719: Remember queryId for failed queries

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -5,6 +5,7 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 )
 
@@ -35,7 +36,10 @@ func (stmt *snowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedV
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.ExecContext")
 	result, err := stmt.sc.ExecContext(ctx, stmt.query, args)
 	if err != nil {
-		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+		var snowflakeError *SnowflakeError
+		if errors.As(err, &snowflakeError) {
+			stmt.lastQueryID = snowflakeError.QueryID
+		}
 		return nil, err
 	}
 	r, ok := result.(SnowflakeResult)
@@ -50,7 +54,10 @@ func (stmt *snowflakeStmt) QueryContext(ctx context.Context, args []driver.Named
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.QueryContext")
 	rows, err := stmt.sc.QueryContext(ctx, stmt.query, args)
 	if err != nil {
-		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+		var snowflakeError *SnowflakeError
+		if errors.As(err, &snowflakeError) {
+			stmt.lastQueryID = snowflakeError.QueryID
+		}
 		return nil, err
 	}
 	r, ok := rows.(SnowflakeRows)
@@ -65,7 +72,10 @@ func (stmt *snowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Exec")
 	result, err := stmt.sc.Exec(stmt.query, args)
 	if err != nil {
-		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+		var snowflakeError *SnowflakeError
+		if errors.As(err, &snowflakeError) {
+			stmt.lastQueryID = snowflakeError.QueryID
+		}
 		return nil, err
 	}
 	r, ok := result.(SnowflakeResult)
@@ -80,7 +90,10 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Query")
 	rows, err := stmt.sc.Query(stmt.query, args)
 	if err != nil {
-		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+		var snowflakeError *SnowflakeError
+		if errors.As(err, &snowflakeError) {
+			stmt.lastQueryID = snowflakeError.QueryID
+		}
 		return nil, err
 	}
 	r, ok := rows.(SnowflakeRows)

--- a/statement.go
+++ b/statement.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
+// Copyright (c) 2017-2023 Snowflake Computing Inc. All rights reserved.
 
 package gosnowflake
 
@@ -33,28 +33,44 @@ func (stmt *snowflakeStmt) NumInput() int {
 func (stmt *snowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.ExecContext")
 	result, err := stmt.sc.ExecContext(ctx, stmt.query, args)
-	stmt.lastQueryID = result.(SnowflakeResult).GetQueryID()
+	if err != nil {
+		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+	} else {
+		stmt.lastQueryID = result.(SnowflakeResult).GetQueryID()
+	}
 	return result, err
 }
 
 func (stmt *snowflakeStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.QueryContext")
 	rows, err := stmt.sc.QueryContext(ctx, stmt.query, args)
-	stmt.lastQueryID = rows.(SnowflakeRows).GetQueryID()
+	if err != nil {
+		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+	} else {
+		stmt.lastQueryID = rows.(SnowflakeRows).GetQueryID()
+	}
 	return rows, err
 }
 
 func (stmt *snowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Exec")
 	result, err := stmt.sc.Exec(stmt.query, args)
-	stmt.lastQueryID = result.(SnowflakeResult).GetQueryID()
+	if err != nil {
+		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+	} else {
+		stmt.lastQueryID = result.(SnowflakeResult).GetQueryID()
+	}
 	return result, err
 }
 
 func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Query")
 	rows, err := stmt.sc.Query(stmt.query, args)
-	stmt.lastQueryID = rows.(SnowflakeRows).GetQueryID()
+	if err != nil {
+		stmt.lastQueryID = err.(*SnowflakeError).QueryID
+	} else {
+		stmt.lastQueryID = rows.(SnowflakeRows).GetQueryID()
+	}
 	return rows, err
 }
 

--- a/statement.go
+++ b/statement.go
@@ -36,10 +36,7 @@ func (stmt *snowflakeStmt) ExecContext(ctx context.Context, args []driver.NamedV
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.ExecContext")
 	result, err := stmt.sc.ExecContext(ctx, stmt.query, args)
 	if err != nil {
-		var snowflakeError *SnowflakeError
-		if errors.As(err, &snowflakeError) {
-			stmt.lastQueryID = snowflakeError.QueryID
-		}
+		stmt.setQueryIDFromError(err)
 		return nil, err
 	}
 	r, ok := result.(SnowflakeResult)
@@ -54,10 +51,7 @@ func (stmt *snowflakeStmt) QueryContext(ctx context.Context, args []driver.Named
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.QueryContext")
 	rows, err := stmt.sc.QueryContext(ctx, stmt.query, args)
 	if err != nil {
-		var snowflakeError *SnowflakeError
-		if errors.As(err, &snowflakeError) {
-			stmt.lastQueryID = snowflakeError.QueryID
-		}
+		stmt.setQueryIDFromError(err)
 		return nil, err
 	}
 	r, ok := rows.(SnowflakeRows)
@@ -72,10 +66,7 @@ func (stmt *snowflakeStmt) Exec(args []driver.Value) (driver.Result, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Exec")
 	result, err := stmt.sc.Exec(stmt.query, args)
 	if err != nil {
-		var snowflakeError *SnowflakeError
-		if errors.As(err, &snowflakeError) {
-			stmt.lastQueryID = snowflakeError.QueryID
-		}
+		stmt.setQueryIDFromError(err)
 		return nil, err
 	}
 	r, ok := result.(SnowflakeResult)
@@ -90,10 +81,7 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 	logger.WithContext(stmt.sc.ctx).Infoln("Stmt.Query")
 	rows, err := stmt.sc.Query(stmt.query, args)
 	if err != nil {
-		var snowflakeError *SnowflakeError
-		if errors.As(err, &snowflakeError) {
-			stmt.lastQueryID = snowflakeError.QueryID
-		}
+		stmt.setQueryIDFromError(err)
 		return nil, err
 	}
 	r, ok := rows.(SnowflakeRows)
@@ -106,4 +94,11 @@ func (stmt *snowflakeStmt) Query(args []driver.Value) (driver.Rows, error) {
 
 func (stmt *snowflakeStmt) GetQueryID() string {
 	return stmt.lastQueryID
+}
+
+func (stmt *snowflakeStmt) setQueryIDFromError(err error) {
+	var snowflakeError *SnowflakeError
+	if errors.As(err, &snowflakeError) {
+		stmt.lastQueryID = snowflakeError.QueryID
+	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -56,14 +56,14 @@ func TestSetFailedQueryId(t *testing.T) {
 			name:  "query",
 			query: failingQuery,
 			f: func(stmt driver.Stmt) (any, error) {
-				return stmt.(driver.Stmt).Query(nil)
+				return stmt.Query(nil)
 			},
 		},
 		{
 			name:  "exec",
 			query: failingExec,
 			f: func(stmt driver.Stmt) (any, error) {
-				return stmt.(driver.Stmt).Exec(nil)
+				return stmt.Exec(nil)
 			},
 		},
 		{


### PR DESCRIPTION
### Description
Remember queryId for failed queries.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
