### PR TITLE
SNOW-969837: Use macos-latest and sync clock

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
               with:
                 token: ${{ secrets.CODE_COV_UPLOAD_TOKEN }}
     build-test-mac:
-        runs-on: macos-11
+        runs-on: macos-latest
         strategy:
             fail-fast: false
             matrix:
@@ -63,6 +63,8 @@ jobs:
                 go: [ '1.20', '1.19' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Mac
         steps:
+            - name: Sync clock
+              run: sudo sntp -sS time.windows.com
             - uses: actions/checkout@v1
             - name: Setup go
               uses: actions/setup-go@v2


### PR DESCRIPTION
### Description
Use latest macos image and sync time before the tests.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
