### PR TITLE
SNOW-981533 Separate retry strategy for auth endpoints and the remaining ones

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -136,7 +136,7 @@ func (sc *snowflakeConn) checkQueryStatus(
 	if tok, _, _ := sc.rest.TokenAccessor.GetTokens(); tok != "" {
 		headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, tok)
 	}
-	resultPath := fmt.Sprintf("/monitoring/queries/%s", qid)
+	resultPath := fmt.Sprintf("%s/%s", monitoringQueriesPath, qid)
 	url := sc.rest.getFullURL(resultPath, &param)
 
 	res, err := sc.rest.FuncGet(ctx, sc.rest, url, headers, sc.rest.RequestTimeout)

--- a/restful.go
+++ b/restful.go
@@ -37,6 +37,7 @@ const (
 	tokenRequestPath         = "/session/token-request"
 	abortRequestPath         = "/queries/v1/abort-request"
 	authenticatorRequestPath = "/session/authenticator-request"
+	monitoringQueriesPath    = "/monitoring/queries"
 	sessionRequestPath       = "/session"
 	heartBeatPath            = "/session/heartbeat"
 )

--- a/retry_test.go
+++ b/retry_test.go
@@ -494,12 +494,6 @@ func TestIsRetryable(t *testing.T) {
 			expected: false,
 		},
 		{
-			req:      &http.Request{URL: &url.URL{Path: heartBeatPath}},
-			res:      &http.Response{StatusCode: http.StatusBadRequest},
-			err:      nil,
-			expected: false,
-		},
-		{
 			req:      &http.Request{URL: &url.URL{Path: loginRequestPath}},
 			res:      &http.Response{StatusCode: http.StatusNotFound},
 			expected: false,
@@ -525,10 +519,12 @@ func TestIsRetryable(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		result, _ := isRetryableError(tc.req, tc.res, tc.err)
-		if result != tc.expected {
-			t.Fatalf("expected %v, got %v; request: %v, response: %v", tc.expected, result, tc.req, tc.res)
-		}
+		t.Run(fmt.Sprintf("req %v, resp %v", tc.req, tc.res), func(t *testing.T) {
+			result, _ := isRetryableError(tc.req, tc.res, tc.err)
+			if result != tc.expected {
+				t.Fatalf("expected %v, got %v; request: %v, response: %v", tc.expected, result, tc.req, tc.res)
+			}
+		})
 	}
 }
 
@@ -605,8 +601,8 @@ func TestCalculateRetryWait(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("attmept: %v", tc.attempt), func(t *testing.T) {
-			result := defaultWaitAlgo.calculateWaitBeforeRetry(tc.attempt, tc.currWaitTime)
-			assertBetweenE(t, result, tc.minSleepTime, tc.maxSleepTime)
+			result := defaultWaitAlgo.calculateWaitBeforeRetryForAuthRequest(tc.attempt, time.Duration(tc.currWaitTime*float64(time.Second)))
+			assertBetweenE(t, result.Seconds(), tc.minSleepTime, tc.maxSleepTime)
 		})
 	}
 }


### PR DESCRIPTION
### Description
Fixed retry algorithm. Before, only whitelisted endpoints were retried. Now it retries all endpoints. Also, there is a separate backoff logic for authentication endpoints.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
