### PR TITLE
SNOW-982511: Enable HTAP test

### DIFF
--- a/htap_test.go
+++ b/htap_test.go
@@ -338,7 +338,6 @@ func TestQueryContextCacheDisabled(t *testing.T) {
 }
 
 func TestHybridTablesE2E(t *testing.T) {
-	t.Skip("Skipping the test until AWS issue is fixed")
 	if runningOnGithubAction() && !runningOnAWS() {
 		t.Skip("HTAP is enabled only on AWS")
 	}


### PR DESCRIPTION
### Description
Reenable HTAP test.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
