### PR TITLE
SNOW-983911 Add support for querying the vector data type

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -632,12 +632,20 @@ func arrowToValue(
 		case arrow.INT32:
 			values := vectorData.ListValues().(*array.Int32).Int32Values()
 			for i := 0; i < vectorData.Len(); i++ {
-				destcol[i] = values[i*dim : (i+1)*dim]
+				if vectorData.IsNull(i) {
+					destcol[i] = []int32(nil)
+				} else {
+					destcol[i] = values[i*dim : (i+1)*dim]
+				}
 			}
 		case arrow.FLOAT32:
 			values := vectorData.ListValues().(*array.Float32).Float32Values()
 			for i := 0; i < vectorData.Len(); i++ {
-				destcol[i] = values[i*dim : (i+1)*dim]
+				if vectorData.IsNull(i) {
+					destcol[i] = []float32(nil)
+				} else {
+					destcol[i] = values[i*dim : (i+1)*dim]
+				}
 			}
 		default:
 			return fmt.Errorf("unsupported element type %q for a vector", datatype.Elem().String())

--- a/converter_test.go
+++ b/converter_test.go
@@ -857,7 +857,7 @@ func TestArrowToValue(t *testing.T) {
 		},
 		{
 			logical: "vector",
-			values:  [][]int32{{1, 2, 3}, {4, 5, 6}},
+			values:  [][]int32{nil, {1, 2, 3}},
 			builder: array.NewFixedSizeListBuilder(pool, 3, &arrow.Int32Type{}),
 			append: func(b array.Builder, vs interface{}) {
 				for _, v := range vs.([][]int32) {
@@ -865,6 +865,7 @@ func TestArrowToValue(t *testing.T) {
 					vb := lb.ValueBuilder().(*array.Int32Builder)
 					if len(v) == 0 {
 						lb.AppendNull()
+						vb.AppendValues([]int32{-1, -1, -1}, nil)
 						continue
 					}
 
@@ -885,7 +886,7 @@ func TestArrowToValue(t *testing.T) {
 		},
 		{
 			logical: "vector",
-			values:  [][]float32{{1.1, 2.2, 3}, {4.4, 5.5, 6}},
+			values:  [][]float32{nil, {1.1, 2.2, 3}},
 			builder: array.NewFixedSizeListBuilder(pool, 3, &arrow.Float32Type{}),
 			append: func(b array.Builder, vs interface{}) {
 				for _, v := range vs.([][]float32) {
@@ -893,6 +894,7 @@ func TestArrowToValue(t *testing.T) {
 					vb := lb.ValueBuilder().(*array.Float32Builder)
 					if len(v) == 0 {
 						lb.AppendNull()
+						vb.AppendValues([]float32{-1, -1, -1}, nil)
 						continue
 					}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -13,7 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"slices"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -1285,7 +1285,7 @@ func testVector(t *testing.T, json bool) {
 			t.Error(err)
 		}
 		wantInt := []int32{1, 2, 3}
-		if !slices.Equal(gotInt, wantInt) {
+		if !reflect.DeepEqual(gotInt, wantInt) {
 			t.Errorf("incorrect vector deserialized: got %v, want %v", gotInt, wantInt)
 		}
 
@@ -1300,7 +1300,7 @@ func testVector(t *testing.T, json bool) {
 			t.Error(err)
 		}
 		wantFloat := []float32{1.1, 2.2, 3, 4, 5}
-		if !slices.Equal(gotFloat, wantFloat) {
+		if !reflect.DeepEqual(gotFloat, wantFloat) {
 			t.Errorf("incorrect vector deserialized: got %v, want %v", gotFloat, wantFloat)
 		}
 	})

--- a/driver_test.go
+++ b/driver_test.go
@@ -1286,6 +1286,8 @@ func testVectorInt(t *testing.T, json bool) {
 		},
 	}
 	runDBTest(t, func(dbt *DBTest) {
+		dbt.mustExec("alter session set enable_vector_data_type='Enable'")
+		defer dbt.mustExec("alter session unset enable_vector_data_type")
 		if json {
 			dbt.mustExec(forceJSON)
 		}
@@ -1332,9 +1334,12 @@ func testVectorFloat(t *testing.T, json bool) {
 		},
 	}
 	runDBTest(t, func(dbt *DBTest) {
+		dbt.mustExec("alter session set enable_vector_data_type='Enable'")
+		defer dbt.mustExec("alter session unset enable_vector_data_type")
 		if json {
 			dbt.mustExec(forceJSON)
 		}
+
 		for _, tt := range tests {
 			t.Run(tt.msg, func(t *testing.T) {
 				rowsFloat := dbt.mustQuery(tt.query)

--- a/old_driver_test.go
+++ b/old_driver_test.go
@@ -167,6 +167,14 @@ func TestJSONArray(t *testing.T) {
 	testArray(t, true)
 }
 
+func TestJSONVectorInt(t *testing.T) {
+	testVectorInt(t, true)
+}
+
+func TestJSONVectorFloat(t *testing.T) {
+	testVectorFloat(t, true)
+}
+
 func TestLargeSetJSONResultWithDecoder(t *testing.T) {
 	testLargeSetResult(t, 10000, true)
 }

--- a/query.go
+++ b/query.go
@@ -46,14 +46,26 @@ type contextData struct {
 	Base64Data string `json:"base64Data,omitempty"`
 }
 
+type execResponseRowFieldType struct {
+	ByteLength int64                      `json:"byteLength"`
+	Length     int64                      `json:"length"`
+	Type       string                     `json:"type"`
+	Precision  int64                      `json:"precision"`
+	Scale      int64                      `json:"scale"`
+	Nullable   bool                       `json:"nullable"`
+	Fields     []execResponseRowFieldType `json:"fields"`
+}
+
 type execResponseRowType struct {
-	Name       string `json:"name"`
-	ByteLength int64  `json:"byteLength"`
-	Length     int64  `json:"length"`
-	Type       string `json:"type"`
-	Precision  int64  `json:"precision"`
-	Scale      int64  `json:"scale"`
-	Nullable   bool   `json:"nullable"`
+	Name            string                     `json:"name"`
+	ByteLength      int64                      `json:"byteLength"`
+	Length          int64                      `json:"length"`
+	Type            string                     `json:"type"`
+	Precision       int64                      `json:"precision"`
+	Scale           int64                      `json:"scale"`
+	Nullable        bool                       `json:"nullable"`
+	VectorDimension int                        `json:"vectorDimension"`
+	Fields          []execResponseRowFieldType `json:"fields"`
 }
 
 type execResponseChunk struct {

--- a/rows.go
+++ b/rows.go
@@ -147,9 +147,7 @@ func (rows *snowflakeRows) ColumnTypeScanType(index int) reflect.Type {
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
 		return nil
 	}
-	return snowflakeTypeToGo(
-		getSnowflakeType(rows.ChunkDownloader.getRowType()[index].Type),
-		rows.ChunkDownloader.getRowType()[index].Scale)
+	return snowflakeTypeToGo(rows.ChunkDownloader.getRowType()[index])
 }
 
 func (rows *snowflakeRows) GetQueryID() string {


### PR DESCRIPTION
### Description
Added support for parsing vectors from the serialized result set, so queries that return vectors can now be made. To do so, I also had to update `execResponseRowType` to add two new fields that are now being sent back, matching the [change](https://github.com/snowflakedb/snowflake-connector-python/pull/1806) I recently made to the Python connector.


### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
