### PR TITLE
SNOW-991467 Remove 400 & 405 statuses from retry

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -35,8 +35,6 @@ var authEndpoints = []string{
 
 var clientErrorsStatusCodesEligibleForRetry = []int{
 	http.StatusTooManyRequests,
-	http.StatusBadRequest,
-	http.StatusMethodNotAllowed,
 	http.StatusRequestTimeout,
 }
 


### PR DESCRIPTION
### Description
This change excludes statuses 400 & 405 from retry strategy as these should not be retried.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
