### PR TITLE
SNOW-994698 cover corner cases where an unexpected non APIerror occurs during HeadObject

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -21,6 +21,7 @@ func assertNilF(t *testing.T, actual any, descriptions ...string) {
 func assertNotNilE(t *testing.T, actual any, descriptions ...string) {
 	errorOnNonEmpty(t, validateNotNil(actual, descriptions...))
 }
+
 func assertNotNilF(t *testing.T, actual any, descriptions ...string) {
 	fatalOnNonEmpty(t, validateNotNil(actual, descriptions...))
 }

--- a/assert_test.go
+++ b/assert_test.go
@@ -18,6 +18,9 @@ func assertNilF(t *testing.T, actual any, descriptions ...string) {
 	fatalOnNonEmpty(t, validateNil(actual, descriptions...))
 }
 
+func assertNotNilE(t *testing.T, actual any, descriptions ...string) {
+	errorOnNonEmpty(t, validateNotNil(actual, descriptions...))
+}
 func assertNotNilF(t *testing.T, actual any, descriptions ...string) {
 	fatalOnNonEmpty(t, validateNotNil(actual, descriptions...))
 }

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -89,6 +89,9 @@ func (util *snowflakeS3Client) getFileHeader(meta *fileMetadata, filename string
 			meta.lastError = err
 			return nil, fmt.Errorf("error while retrieving header")
 		}
+		meta.resStatus = errStatus
+		meta.lastError = err
+		return nil, fmt.Errorf("unexpected error while retrieving header: %v", err)
 	}
 
 	meta.resStatus = uploaded

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -294,9 +294,10 @@ func TestGetHeaderNonApiError(t *testing.T) {
 			return nil, othErr
 		}),
 	}
+
 	header, err := new(snowflakeS3Client).getFileHeader(&meta, "file.txt")
 	assertEqualF(t, header, nil, fmt.Sprintf("expected nil header, got: %v", header))
-	assertNotNilF(t, err, fmt.Sprintf("expected err to not be nil"))
+	assertNotNilF(t, err, "expected err to not be nil")
 	assertEqualF(t, meta.resStatus, errStatus, fmt.Sprintf("expected %v result status for non-APIerror, got: %v", errStatus, meta.resStatus))
 }
 

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -296,9 +296,9 @@ func TestGetHeaderNonApiError(t *testing.T) {
 	}
 
 	header, err := new(snowflakeS3Client).getFileHeader(&meta, "file.txt")
-	assertEqualF(t, header, nil, fmt.Sprintf("expected nil header, got: %v", header))
-	assertNotNilF(t, err, "expected err to not be nil")
-	assertEqualF(t, meta.resStatus, errStatus, fmt.Sprintf("expected %v result status for non-APIerror, got: %v", errStatus, meta.resStatus))
+	assertNilE(t, header, fmt.Sprintf("expected header to be nil, actual: %v", header))
+	assertNotNilE(t, err, "expected err to not be nil")
+	assertEqualE(t, meta.resStatus, errStatus, fmt.Sprintf("expected %v result status for non-APIerror, got: %v", errStatus, meta.resStatus))
 }
 
 func TestGetHeaderNotFoundError(t *testing.T) {

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -286,12 +286,11 @@ func TestGetHeaderUnexpectedError(t *testing.T) {
 }
 
 func TestGetHeaderNonApiError(t *testing.T) {
-	othErr := errors.New("something went wrong here")
 	meta := fileMetadata{
 		client:    s3.New(s3.Options{}),
 		stageInfo: &execResponseStageInfo{Location: ""},
 		mockHeader: mockHeaderAPI(func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
-			return nil, othErr
+			return nil, errors.New("something went wrong here")
 		}),
 	}
 

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -285,6 +285,21 @@ func TestGetHeaderUnexpectedError(t *testing.T) {
 	}
 }
 
+func TestGetHeaderNonApiError(t *testing.T) {
+	othErr := errors.New("something went wrong here")
+	meta := fileMetadata{
+		client:    s3.New(s3.Options{}),
+		stageInfo: &execResponseStageInfo{Location: ""},
+		mockHeader: mockHeaderAPI(func(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+			return nil, othErr
+		}),
+	}
+	header, err := new(snowflakeS3Client).getFileHeader(&meta, "file.txt")
+	assertEqualF(t, header, nil, fmt.Sprintf("expected nil header, got: %v", header))
+	assertNotNilF(t, err, fmt.Sprintf("expected err to not be nil"))
+	assertEqualF(t, meta.resStatus, errStatus, fmt.Sprintf("expected %v result status for non-APIerror, got: %v", errStatus, meta.resStatus))
+}
+
 func TestGetHeaderNotFoundError(t *testing.T) {
 	meta := fileMetadata{
 		client:    s3.New(s3.Options{}),


### PR DESCRIPTION
 to see if it fixes 1008

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
