### PR TITLE
expose `nullType` so we can write nulls to the warehouse from the driver

### DIFF
--- a/datatype.go
+++ b/datatype.go
@@ -26,8 +26,8 @@ const (
 	binaryType
 	timeType
 	booleanType
-	// the following are not snowflake types per se but internal types
 	nullType
+	// the following are not snowflake types per se but internal types
 	sliceType
 	changeType
 	unSupportedType
@@ -104,6 +104,8 @@ var (
 	DataTypeTime = []byte{timeType.Byte()}
 	// DataTypeBoolean is a BOOLEAN datatype.
 	DataTypeBoolean = []byte{booleanType.Byte()}
+	// DataTypeNull is a NULL datatype.
+	DataTypeNull = []byte{nullType.Byte()}
 )
 
 // dataTypeMode returns the subsequent data type in a string representation.


### PR DESCRIPTION
### Description
I have a use case where I am using conn.ExecContext to insert values into a table. If the type that I am trying to write is a known null, it would be nice if I could pass the null type as an argument to my `"INSERT INTO %s (%s) VALUES (%s)"` query. In this query the first variable is tablePath, the second is columnName, the third is as many ? as is needed given the number of columns. I will then pass the snowflake type and the value. If the desired snowflake type is null, I would like to be able to pass this in. I know I can just pass in []byte which is not any of the publicly supported types, but this would make the code cleaner and less at risk of changes causing failure 

### Checklist
- [X] Code compiles correctly
- [X] Run ``make fmt`` to fix inconsistent formats
- [X] Run ``make lint`` to get lint errors and fix all of them
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
