### PR TITLE
SNOW-916951: Retry okta auth with new token

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -418,6 +418,17 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 		requestMain.Authenticator = AuthTypeOAuth.String()
 		requestMain.Token = sc.cfg.Token
 	case AuthTypeOkta:
+		samlResponse, err := authenticateBySAML(
+			sc.ctx,
+			sc.rest,
+			sc.cfg.OktaURL,
+			sc.cfg.Application,
+			sc.cfg.Account,
+			sc.cfg.User,
+			sc.cfg.Password)
+		if err != nil {
+			return nil, err
+		}
 		requestMain.RawSAMLResponse = string(samlResponse)
 	case AuthTypeJwt:
 		requestMain.Authenticator = AuthTypeJwt.String()
@@ -534,19 +545,6 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 				sc.cleanup()
 				return err
 			}
-		}
-	case AuthTypeOkta:
-		samlResponse, err = authenticateBySAML(
-			sc.ctx,
-			sc.rest,
-			sc.cfg.OktaURL,
-			sc.cfg.Application,
-			sc.cfg.Account,
-			sc.cfg.User,
-			sc.cfg.Password)
-		if err != nil {
-			sc.cleanup()
-			return err
 		}
 	}
 	authData, err = authenticate(


### PR DESCRIPTION
### Description
issue: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/655

The native Okta Authentication fails in retry due to the same token is used in an sso/saml retry.
This PR fixes the retry logic by generating a new token each time it retries.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

