### PR TITLE
SNOW-1016278 Fix panic on empty arrow batches

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -58,6 +58,10 @@ func assertBetweenE(t *testing.T, value float64, min float64, max float64, descr
 	errorOnNonEmpty(t, validateValueBetween(value, min, max, descriptions...))
 }
 
+func assertEmptyE[T any](t *testing.T, actual []T, descriptions ...string) {
+	errorOnNonEmpty(t, validateEmpty(actual, descriptions...))
+}
+
 func fatalOnNonEmpty(t *testing.T, errMsg string) {
 	if errMsg != "" {
 		t.Fatal(formatErrorMessage(errMsg))
@@ -120,6 +124,14 @@ func validateValueBetween(value float64, min float64, max float64, descriptions 
 	}
 	desc := joinDescriptions(descriptions...)
 	return fmt.Sprintf("expected \"%f\" should be between \"%f\" and  \"%f\" but did not. %s", value, min, max, desc)
+}
+
+func validateEmpty[T any](value []T, descriptions ...string) string {
+	if len(value) == 0 {
+		return ""
+	}
+	desc := joinDescriptions(descriptions...)
+	return fmt.Sprintf("expected \"%v\" to be empty. %s", value, desc)
 }
 
 func joinDescriptions(descriptions ...string) string {

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -249,7 +249,7 @@ func (scd *snowflakeChunkDownloader) getRowType() []execResponseRowType {
 }
 
 func (scd *snowflakeChunkDownloader) getArrowBatches() []*ArrowBatch {
-	if scd.FirstBatch.rec == nil {
+	if scd.FirstBatch == nil || scd.FirstBatch.rec == nil {
 		return scd.ArrowBatches
 	}
 	return append([]*ArrowBatch{scd.FirstBatch}, scd.ArrowBatches...)

--- a/chunk_downloader_test.go
+++ b/chunk_downloader_test.go
@@ -41,11 +41,35 @@ func TestWithArrowBatchesWhenQueryReturnsNoRowsWhenUsingNativeGoSQLInterface(t *
 	})
 }
 
-func TestWithArrowBatchesWhenQueryReturnsNoRows(t *testing.T) {
+func TestWithArrowBatchesWhenQueryReturnsRowsAndReadingRows(t *testing.T) {
 	runDBTest(t, func(dbt *DBTest) {
 		rows := dbt.mustQueryContext(WithArrowBatches(context.Background()), "SELECT 1")
 		defer rows.Close()
 		assertFalseF(t, rows.Next())
+	})
+}
+
+func TestWithArrowBatchesWhenQueryReturnsNoRowsAndReadingRows(t *testing.T) {
+	runDBTest(t, func(dbt *DBTest) {
+		rows := dbt.mustQueryContext(WithArrowBatches(context.Background()), "SELECT 1 WHERE 1 = 0")
+		defer rows.Close()
+		assertFalseF(t, rows.Next())
+	})
+}
+
+func TestWithArrowBatchesWhenQueryReturnsNoRowsAndReadingArrowBatches(t *testing.T) {
+	runDBTest(t, func(dbt *DBTest) {
+		var rows driver.Rows
+		var err error
+		err = dbt.conn.Raw(func(x any) error {
+			rows, err = x.(driver.QueryerContext).QueryContext(WithArrowBatches(context.Background()), "SELECT 1 WHERE 1 = 0", nil)
+			return err
+		})
+		assertNilF(t, err)
+		defer rows.Close()
+		batches, err := rows.(SnowflakeRows).GetArrowBatches()
+		assertNilF(t, err)
+		assertEmptyE(t, batches)
 	})
 }
 


### PR DESCRIPTION
### Description
[SNOW-1016278](https://snowflakecomputing.atlassian.net/browse/SNOW-1016278) Fixes getting arrow batches when query returns no results at all.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary


[SNOW-1016278]: https://snowflakecomputing.atlassian.net/browse/SNOW-1016278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ