### PR TITLE
support millisecond and microsecond for arrow batch timestamp

### DIFF
--- a/cmd/arrow/batches/arrow_batches.go
+++ b/cmd/arrow/batches/arrow_batches.go
@@ -51,9 +51,9 @@ func main() {
 	}
 
 	ctx :=
-		sf.WithOriginalTimestamp(
+		sf.WithArrowBatchesTimestampOption(
 			sf.WithArrowAllocator(
-				sf.WithArrowBatches(context.Background()), memory.DefaultAllocator))
+				sf.WithArrowBatches(context.Background()), memory.DefaultAllocator), sf.UseOriginalTimestamp)
 
 	query := "SELECT SEQ4(), 'example ' || (SEQ4() * 2), " +
 		" TO_TIMESTAMP_NTZ('9999-01-01 13:13:13.' || LPAD(SEQ4(),9,'0'))  ltz " +

--- a/converter.go
+++ b/converter.go
@@ -39,13 +39,18 @@ const (
 	TimeType
 )
 
-type SnowflakeArrowBatchesTimestampOption int
+type snowflakeArrowBatchesTimestampOption int
 
 const (
-	UseNanosecondTimestamp SnowflakeArrowBatchesTimestampOption = iota
+	// arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.
+	UseNanosecondTimestamp snowflakeArrowBatchesTimestampOption = iota
+	// arrow.Timestamp in microsecond precision
 	UseMicrosecondTimestamp
+	// arrow.Timestamp in millisecond precision
 	UseMillisecondTimestamp
+	// arrow.Timestamp in second precision
 	UseSecondTimestamp
+	// original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
 	UseOriginalTimestamp
 )
 
@@ -978,12 +983,12 @@ func higherPrecisionEnabled(ctx context.Context) bool {
 	return ok && d
 }
 
-func getArrowBatchesTimestampOption(ctx context.Context) SnowflakeArrowBatchesTimestampOption {
+func getArrowBatchesTimestampOption(ctx context.Context) snowflakeArrowBatchesTimestampOption {
 	v := ctx.Value(arrowBatchesTimestampOption)
 	if v == nil {
 		return UseNanosecondTimestamp
 	}
-	o, ok := v.(SnowflakeArrowBatchesTimestampOption)
+	o, ok := v.(snowflakeArrowBatchesTimestampOption)
 	if !ok {
 		return UseNanosecondTimestamp
 	}
@@ -1102,7 +1107,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 	return array.NewRecord(s, cols, numRows), nil
 }
 
-func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.Location, timestampOption SnowflakeArrowBatchesTimestampOption) (*arrow.Schema, error) {
+func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.Location, timestampOption snowflakeArrowBatchesTimestampOption) (*arrow.Schema, error) {
 	var fields []arrow.Field
 	for i := 0; i < len(sc.Fields()); i++ {
 		f := sc.Field(i)

--- a/converter.go
+++ b/converter.go
@@ -42,10 +42,11 @@ const (
 type SnowflakeArrowBatchesTimestampOption int
 
 const (
-	UseDefaultNanosecondTimestamp SnowflakeArrowBatchesTimestampOption = iota
-	UseOriginalTimestamp
+	UseNanosecondTimestamp SnowflakeArrowBatchesTimestampOption = iota
 	UseMicrosecondTimestamp
 	UseMillisecondTimestamp
+	UseSecondTimestamp
+	UseOriginalTimestamp
 )
 
 type interfaceArrayBinding struct {
@@ -980,11 +981,11 @@ func higherPrecisionEnabled(ctx context.Context) bool {
 func getArrowBatchesTimestampOption(ctx context.Context) SnowflakeArrowBatchesTimestampOption {
 	v := ctx.Value(arrowBatchesTimestampOption)
 	if v == nil {
-		return UseDefaultNanosecondTimestamp
+		return UseNanosecondTimestamp
 	}
 	o, ok := v.(SnowflakeArrowBatchesTimestampOption)
 	if !ok {
-		return UseDefaultNanosecondTimestamp
+		return UseNanosecondTimestamp
 	}
 	return o
 }
@@ -1050,7 +1051,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 					unit = arrow.Microsecond
 				case UseMillisecondTimestamp:
 					unit = arrow.Millisecond
-				case UseDefaultNanosecondTimestamp:
+				case UseNanosecondTimestamp:
 					unit = arrow.Nanosecond
 				}
 				var tb *array.TimestampBuilder
@@ -1070,7 +1071,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 							ar = arrow.Timestamp(ts.UnixMicro())
 						case UseMillisecondTimestamp:
 							ar = arrow.Timestamp(ts.UnixMilli())
-						case UseDefaultNanosecondTimestamp:
+						case UseNanosecondTimestamp:
 							ar = arrow.Timestamp(ts.UnixNano())
 							// in case of overflow in arrow timestamp return error
 							// this could only happen for nanosecond case

--- a/converter.go
+++ b/converter.go
@@ -42,15 +42,15 @@ const (
 type snowflakeArrowBatchesTimestampOption int
 
 const (
-	// arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.
+	// UseNanosecondTimestamp uses arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.
 	UseNanosecondTimestamp snowflakeArrowBatchesTimestampOption = iota
-	// arrow.Timestamp in microsecond precision
+	// UseMicrosecondTimestamp uses arrow.Timestamp in microsecond precision
 	UseMicrosecondTimestamp
-	// arrow.Timestamp in millisecond precision
+	// UseMillisecondTimestamp uses arrow.Timestamp in millisecond precision
 	UseMillisecondTimestamp
-	// arrow.Timestamp in second precision
+	// UseSecondTimestamp uses arrow.Timestamp in second precision
 	UseSecondTimestamp
-	// original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
+	// UseOriginalTimestamp uses original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
 	UseOriginalTimestamp
 )
 

--- a/converter.go
+++ b/converter.go
@@ -1051,6 +1051,8 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 					unit = arrow.Microsecond
 				case UseMillisecondTimestamp:
 					unit = arrow.Millisecond
+				case UseSecondTimestamp:
+					unit = arrow.Second
 				case UseNanosecondTimestamp:
 					unit = arrow.Nanosecond
 				}
@@ -1071,6 +1073,8 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 							ar = arrow.Timestamp(ts.UnixMicro())
 						case UseMillisecondTimestamp:
 							ar = arrow.Timestamp(ts.UnixMilli())
+						case UseSecondTimestamp:
+							ar = arrow.Timestamp(ts.Unix())
 						case UseNanosecondTimestamp:
 							ar = arrow.Timestamp(ts.UnixNano())
 							// in case of overflow in arrow timestamp return error
@@ -1132,6 +1136,8 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 				t = &arrow.TimestampType{Unit: arrow.Microsecond}
 			} else if timestampOption == UseMillisecondTimestamp {
 				t = &arrow.TimestampType{Unit: arrow.Millisecond}
+			} else if timestampOption == UseSecondTimestamp {
+				t = &arrow.TimestampType{Unit: arrow.Second}
 			} else {
 				t = &arrow.TimestampType{Unit: arrow.Nanosecond}
 			}
@@ -1143,6 +1149,8 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 				t = &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: loc.String()}
 			} else if timestampOption == UseMillisecondTimestamp {
 				t = &arrow.TimestampType{Unit: arrow.Millisecond, TimeZone: loc.String()}
+			} else if timestampOption == UseSecondTimestamp {
+				t = &arrow.TimestampType{Unit: arrow.Second, TimeZone: loc.String()}
 			} else {
 				t = &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: loc.String()}
 			}

--- a/converter_test.go
+++ b/converter_test.go
@@ -1227,6 +1227,7 @@ func TestArrowToRecord(t *testing.T) {
 				return -1
 			},
 		},
+		// microsecond timestamp_ntz
 		{
 			logical:                     "timestamp_ntz",
 			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
@@ -1255,6 +1256,7 @@ func TestArrowToRecord(t *testing.T) {
 				return -1
 			},
 		},
+		// millisecond timestamp_ntz
 		{
 			logical:                     "timestamp_ntz",
 			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
@@ -1277,6 +1279,35 @@ func TestArrowToRecord(t *testing.T) {
 				srcvs := src.([]time.Time)
 				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
 					if !srcvs[i].Equal(t.ToTime(arrow.Millisecond)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		// second timestamp_ntz
+		{
+			logical:                     "timestamp_ntz",
+			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Second), localTime.Truncate(time.Millisecond)},
+			arrowBatchesTimestampOption: UseSecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampNtzStruct}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampNtzStruct),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Second)) {
 						return i
 					}
 				}
@@ -1403,6 +1434,93 @@ func TestArrowToRecord(t *testing.T) {
 				return -1
 			},
 		},
+		// microsecond timestamp_ltz
+		{
+			logical:                     "timestamp_ltz",
+			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Microsecond), localTime.Truncate(time.Microsecond)},
+			arrowBatchesTimestampOption: UseMicrosecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampNtzStruct}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampNtzStruct),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Microsecond)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		// millisecond timestamp_ltz
+		{
+			logical:                     "timestamp_ltz",
+			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Millisecond), localTime.Truncate(time.Millisecond)},
+			arrowBatchesTimestampOption: UseMillisecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampNtzStruct}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampNtzStruct),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Millisecond)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		// second timestamp_ltz
+		{
+			logical:                     "timestamp_ltz",
+			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Second), localTime.Truncate(time.Second)},
+			arrowBatchesTimestampOption: UseSecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampNtzStruct}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampNtzStruct),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Second)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
 		{
 			logical:  "timestamp_ltz",
 			physical: "error",
@@ -1522,6 +1640,96 @@ func TestArrowToRecord(t *testing.T) {
 				srcvs := src.([]time.Time)
 				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
 					if !srcvs[i].Equal(t.ToTime(arrow.Nanosecond)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		// microsecond timestamp_tz
+		{
+			logical:                     "timestamp_tz",
+			physical:                    "struct3", // timestamp_tz with scale 4..9 -> int64 + int32 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Microsecond), localTime.Truncate(time.Microsecond)},
+			arrowBatchesTimestampOption: UseMicrosecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampTzStructWithFraction}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampTzStructWithFraction),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+					sb.FieldBuilder(2).(*array.Int32Builder).Append(int32(0)) // timezone index - not important in tests
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Microsecond)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		// millisecond timestamp_tz
+		{
+			logical:                     "timestamp_tz",
+			physical:                    "struct3", // timestamp_tz with scale 4..9 -> int64 + int32 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Millisecond), localTime.Truncate(time.Millisecond)},
+			arrowBatchesTimestampOption: UseMillisecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampTzStructWithFraction}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampTzStructWithFraction),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+					sb.FieldBuilder(2).(*array.Int32Builder).Append(int32(0)) // timezone index - not important in tests
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Millisecond)) {
+						return i
+					}
+				}
+				return -1
+			},
+		},
+		// second timestamp_tz
+		{
+			logical:                     "timestamp_tz",
+			physical:                    "struct3", // timestamp_tz with scale 4..9 -> int64 + int32 + int32
+			values:                      []time.Time{time.Now().Truncate(time.Second), localTime.Truncate(time.Second)},
+			arrowBatchesTimestampOption: UseSecondTimestamp,
+			nrows:                       2,
+			rowType:                     execResponseRowType{Scale: 9},
+			sc:                          arrow.NewSchema([]arrow.Field{{Type: timestampTzStructWithFraction}}, nil),
+			builder:                     array.NewStructBuilder(pool, timestampTzStructWithFraction),
+			append: func(b array.Builder, vs interface{}) {
+				sb := b.(*array.StructBuilder)
+				valids = []bool{true, true}
+				sb.AppendValues(valids)
+				for _, t := range vs.([]time.Time) {
+					sb.FieldBuilder(0).(*array.Int64Builder).Append(t.Unix())
+					sb.FieldBuilder(1).(*array.Int32Builder).Append(int32(t.Nanosecond()))
+					sb.FieldBuilder(2).(*array.Int32Builder).Append(int32(0)) // timezone index - not important in tests
+				}
+			},
+			compare: func(src interface{}, convertedRec arrow.Record) int {
+				srcvs := src.([]time.Time)
+				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
+					if !srcvs[i].Equal(t.ToTime(arrow.Second)) {
 						return i
 					}
 				}

--- a/converter_test.go
+++ b/converter_test.go
@@ -915,7 +915,7 @@ func TestArrowToRecord(t *testing.T) {
 		rowType                     execResponseRowType
 		values                      interface{}
 		error                       string
-		arrowBatchesTimestampOption SnowflakeArrowBatchesTimestampOption
+		arrowBatchesTimestampOption snowflakeArrowBatchesTimestampOption
 		nrows                       int
 		builder                     array.Builder
 		append                      func(b array.Builder, vs interface{})

--- a/converter_test.go
+++ b/converter_test.go
@@ -1635,6 +1635,8 @@ func TestArrowToRecord(t *testing.T) {
 			switch tc.arrowBatchesTimestampOption {
 			case UseOriginalTimestamp:
 				ctx = WithArrowBatchesTimestampOption(ctx, UseOriginalTimestamp)
+			case UseSecondTimestamp:
+				ctx = WithArrowBatchesTimestampOption(ctx, UseSecondTimestamp)
 			case UseMillisecondTimestamp:
 				ctx = WithArrowBatchesTimestampOption(ctx, UseMillisecondTimestamp)
 			case UseMicrosecondTimestamp:

--- a/converter_test.go
+++ b/converter_test.go
@@ -1249,7 +1249,6 @@ func TestArrowToRecord(t *testing.T) {
 				srcvs := src.([]time.Time)
 				for i, t := range convertedRec.Column(0).(*array.Timestamp).TimestampValues() {
 					if !srcvs[i].Equal(t.ToTime(arrow.Microsecond)) {
-						fmt.Println(srcvs[i], t.ToTime(arrow.Microsecond))
 						return i
 					}
 				}
@@ -1641,7 +1640,7 @@ func TestArrowToRecord(t *testing.T) {
 			case UseMicrosecondTimestamp:
 				ctx = WithArrowBatchesTimestampOption(ctx, UseMicrosecondTimestamp)
 			default:
-				ctx = WithArrowBatchesTimestampOption(ctx, UseDefaultNanosecondTimestamp)
+				ctx = WithArrowBatchesTimestampOption(ctx, UseNanosecondTimestamp)
 			}
 
 			transformedRec, err := arrowToRecord(ctx, rawRec, pool, []execResponseRowType{meta}, localTime.Location())

--- a/converter_test.go
+++ b/converter_test.go
@@ -1289,7 +1289,7 @@ func TestArrowToRecord(t *testing.T) {
 		{
 			logical:                     "timestamp_ntz",
 			physical:                    "struct", // timestamp_ntz with scale 4..9 -> int64 + int32
-			values:                      []time.Time{time.Now().Truncate(time.Second), localTime.Truncate(time.Millisecond)},
+			values:                      []time.Time{time.Now().Truncate(time.Second), localTime.Truncate(time.Second)},
 			arrowBatchesTimestampOption: UseSecondTimestamp,
 			nrows:                       2,
 			rowType:                     execResponseRowType{Scale: 9},

--- a/doc.go
+++ b/doc.go
@@ -486,9 +486,10 @@ Consequently, Snowflake uses a custom timestamp format in Arrow, which differs o
 
 If you want to use timestamps in Arrow batches, you have two options:
 
- 1. The Go driver can reduce timestamp struct into simple Arrow Timestamp, if all timestamp values fit into Arrow timestamp field.
+ 1. The Go driver can reduce timestamp struct into simple Arrow Timestamp, if you set `WithArrowBatchesTimestampOption` to nanosecond, microsecond, millisecond or second.
+    For nanosecond, some timestamp values might not fit into Arrow timestamp. E.g after year 2262 or before 1677.
  2. You can use native Snowflake values. In that case you will receive complex structs as described above. To transform Snowflake values into the Golang time.Time struct you can use `ArrowSnowflakeTimestampToTime`.
-    To enable this feature, you must use `WithOriginalTimestamp` context.
+    To enable this feature, you must use `WithArrowBatchesTimestampOption` context with value set to`UseOriginalTimestamp`.
 
 # Binding Parameters
 

--- a/util.go
+++ b/util.go
@@ -110,10 +110,11 @@ func WithArrowAllocator(ctx context.Context, pool memory.Allocator) context.Cont
 
 // WithArrowBatchesTimestampOption in combination with WithArrowBatches returns a context
 // that allows users to retrieve arrow.Record with different timestamp options.
-// UseDefaultNanosecondTimestamp: arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.
-// UseOriginalTimestamp: original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
+// UseNanosecondTimestamp: arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.
 // UseMicrosecondTimestamp: arrow.Timestamp in microsecond precision
 // UseMillisecondTimestamp: arrow.Timestamp in millisecond precision
+// UseSecondTimestamp: arrow.Timestamp in second precision
+// UseOriginalTimestamp: original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
 func WithArrowBatchesTimestampOption(ctx context.Context, option SnowflakeArrowBatchesTimestampOption) context.Context {
 	return context.WithValue(ctx, arrowBatchesTimestampOption, option)
 }

--- a/util.go
+++ b/util.go
@@ -108,6 +108,14 @@ func WithArrowAllocator(ctx context.Context, pool memory.Allocator) context.Cont
 	return context.WithValue(ctx, arrowAlloc, pool)
 }
 
+// Deprecated: please use WithArrowBatchesTimestampOption instead.
+// WithOriginalTimestamp in combination with WithArrowBatches returns a context
+// that allows users to retrieve arrow.Record with original timestamp struct returned by Snowflake.
+// It can be used in case arrow.Timestamp cannot fit original timestamp values.
+func WithOriginalTimestamp(ctx context.Context) context.Context {
+	return context.WithValue(ctx, arrowBatchesTimestampOption, UseOriginalTimestamp)
+}
+
 // WithArrowBatchesTimestampOption in combination with WithArrowBatches returns a context
 // that allows users to retrieve arrow.Record with different timestamp options.
 // UseNanosecondTimestamp: arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.

--- a/util.go
+++ b/util.go
@@ -109,8 +109,11 @@ func WithArrowAllocator(ctx context.Context, pool memory.Allocator) context.Cont
 }
 
 // WithArrowBatchesTimestampOption in combination with WithArrowBatches returns a context
-// that allows users to retrieve arrow.Record with original timestamp struct returned by Snowflake.
-// It can be used in case arrow.Timestamp cannot fit original timestamp values.
+// that allows users to retrieve arrow.Record with different timestamp options.
+// UseDefaultNanosecondTimestamp: arrow.Timestamp in nanosecond precision, could cause ErrTooHighTimestampPrecision if arrow.Timestamp cannot fit original timestamp values.
+// UseOriginalTimestamp: original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
+// UseMicrosecondTimestamp: arrow.Timestamp in microsecond precision
+// UseMillisecondTimestamp: arrow.Timestamp in millisecond precision
 func WithArrowBatchesTimestampOption(ctx context.Context, option SnowflakeArrowBatchesTimestampOption) context.Context {
 	return context.WithValue(ctx, arrowBatchesTimestampOption, option)
 }

--- a/util.go
+++ b/util.go
@@ -108,10 +108,11 @@ func WithArrowAllocator(ctx context.Context, pool memory.Allocator) context.Cont
 	return context.WithValue(ctx, arrowAlloc, pool)
 }
 
-// Deprecated: please use WithArrowBatchesTimestampOption instead.
 // WithOriginalTimestamp in combination with WithArrowBatches returns a context
 // that allows users to retrieve arrow.Record with original timestamp struct returned by Snowflake.
 // It can be used in case arrow.Timestamp cannot fit original timestamp values.
+//
+// Deprecated: please use WithArrowBatchesTimestampOption instead.
 func WithOriginalTimestamp(ctx context.Context) context.Context {
 	return context.WithValue(ctx, arrowBatchesTimestampOption, UseOriginalTimestamp)
 }
@@ -123,7 +124,7 @@ func WithOriginalTimestamp(ctx context.Context) context.Context {
 // UseMillisecondTimestamp: arrow.Timestamp in millisecond precision
 // UseSecondTimestamp: arrow.Timestamp in second precision
 // UseOriginalTimestamp: original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
-func WithArrowBatchesTimestampOption(ctx context.Context, option SnowflakeArrowBatchesTimestampOption) context.Context {
+func WithArrowBatchesTimestampOption(ctx context.Context, option snowflakeArrowBatchesTimestampOption) context.Context {
 	return context.WithValue(ctx, arrowBatchesTimestampOption, option)
 }
 

--- a/util.go
+++ b/util.go
@@ -19,18 +19,18 @@ import (
 type contextKey string
 
 const (
-	multiStatementCount     contextKey = "MULTI_STATEMENT_COUNT"
-	asyncMode               contextKey = "ASYNC_MODE_QUERY"
-	queryIDChannel          contextKey = "QUERY_ID_CHANNEL"
-	snowflakeRequestIDKey   contextKey = "SNOWFLAKE_REQUEST_ID"
-	fetchResultByID         contextKey = "SF_FETCH_RESULT_BY_ID"
-	fileStreamFile          contextKey = "STREAMING_PUT_FILE"
-	fileTransferOptions     contextKey = "FILE_TRANSFER_OPTIONS"
-	enableHigherPrecision   contextKey = "ENABLE_HIGHER_PRECISION"
-	arrowBatches            contextKey = "ARROW_BATCHES"
-	arrowAlloc              contextKey = "ARROW_ALLOC"
-	enableOriginalTimestamp contextKey = "ENABLE_ORIGINAL_TIMESTAMP"
-	queryTag                contextKey = "QUERY_TAG"
+	multiStatementCount         contextKey = "MULTI_STATEMENT_COUNT"
+	asyncMode                   contextKey = "ASYNC_MODE_QUERY"
+	queryIDChannel              contextKey = "QUERY_ID_CHANNEL"
+	snowflakeRequestIDKey       contextKey = "SNOWFLAKE_REQUEST_ID"
+	fetchResultByID             contextKey = "SF_FETCH_RESULT_BY_ID"
+	fileStreamFile              contextKey = "STREAMING_PUT_FILE"
+	fileTransferOptions         contextKey = "FILE_TRANSFER_OPTIONS"
+	enableHigherPrecision       contextKey = "ENABLE_HIGHER_PRECISION"
+	arrowBatches                contextKey = "ARROW_BATCHES"
+	arrowAlloc                  contextKey = "ARROW_ALLOC"
+	arrowBatchesTimestampOption contextKey = "ARROW_BATCHES_TIMESTAMP_OPTION"
+	queryTag                    contextKey = "QUERY_TAG"
 )
 
 const (
@@ -108,11 +108,11 @@ func WithArrowAllocator(ctx context.Context, pool memory.Allocator) context.Cont
 	return context.WithValue(ctx, arrowAlloc, pool)
 }
 
-// WithOriginalTimestamp in combination with WithArrowBatches returns a context
+// WithArrowBatchesTimestampOption in combination with WithArrowBatches returns a context
 // that allows users to retrieve arrow.Record with original timestamp struct returned by Snowflake.
 // It can be used in case arrow.Timestamp cannot fit original timestamp values.
-func WithOriginalTimestamp(ctx context.Context) context.Context {
-	return context.WithValue(ctx, enableOriginalTimestamp, true)
+func WithArrowBatchesTimestampOption(ctx context.Context, option SnowflakeArrowBatchesTimestampOption) context.Context {
+	return context.WithValue(ctx, arrowBatchesTimestampOption, option)
 }
 
 // WithQueryTag returns a context that will set the given tag as the QUERY_TAG


### PR DESCRIPTION
### Description
Address https://github.com/snowflakedb/gosnowflake/issues/910 when driver only needs microsecond or millisecond precision. 

In our use case, the connector passes the arrow record from Snowflake to another service for decoding. If we only want microsecond precision, we can avoid the need to port the `arrowSnowflakeTimestampToTime` logic.


it would be best if we don't need to repack Snowflake response from Snowflake internal format to arrow timestamps in driver. I understand that might require your backend work. In the meanwhile we can have the driver change as a short term solution. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
