### PR TITLE
add enableArrowBatchesUtf8Validation to replace invalid utf8 chars in arrow batch

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -1120,7 +1120,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 					if col.(*array.String).IsValid(i) {
 						stringValue := col.(*array.String).Value(i)
 						if !utf8.ValidString(stringValue) {
-							logger.Error("Invalid utf8 detected!")
+							logger.Error("Invalid UTF-8 characters detected while reading query response, column: ", srcColumnMeta.Name)
 							stringValue = strings.ToValidUTF8(stringValue, "�")
 						}
 						tb.Append(stringValue)

--- a/converter.go
+++ b/converter.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/apache/arrow/go/v14/arrow/array"
@@ -983,6 +984,15 @@ func higherPrecisionEnabled(ctx context.Context) bool {
 	return ok && d
 }
 
+func arrowBatchesUtf8ValidationEnabled(ctx context.Context) bool {
+	v := ctx.Value(enableArrowBatchesUtf8Validation)
+	if v == nil {
+		return false
+	}
+	d, ok := v.(bool)
+	return ok && d
+}
+
 func getArrowBatchesTimestampOption(ctx context.Context) snowflakeArrowBatchesTimestampOption {
 	v := ctx.Value(arrowBatchesTimestampOption)
 	if v == nil {
@@ -1098,6 +1108,26 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 					}
 				}
 
+				newCol = tb.NewArray()
+				defer newCol.Release()
+			}
+		case textType:
+			if arrowBatchesUtf8ValidationEnabled(ctx) && col.DataType().ID() == arrow.STRING {
+				tb := array.NewStringBuilder(pool)
+				defer tb.Release()
+
+				for i := 0; i < int(numRows); i++ {
+					if col.(*array.String).IsValid(i) {
+						stringValue := col.(*array.String).Value(i)
+						if !utf8.ValidString(stringValue) {
+							logger.Error("Invalid utf8 detected!")
+							stringValue = strings.ToValidUTF8(stringValue, "�")
+						}
+						tb.Append(stringValue)
+					} else {
+						tb.AppendNull()
+					}
+				}
 				newCol = tb.NewArray()
 				defer newCol.Release()
 			}

--- a/doc.go
+++ b/doc.go
@@ -495,6 +495,16 @@ If you want to use timestamps in Arrow batches, you have two options:
  2. You can use native Snowflake values. In that case you will receive complex structs as described above. To transform Snowflake values into the Golang time.Time struct you can use `ArrowSnowflakeTimestampToTime`.
     To enable this feature, you must use `WithArrowBatchesTimestampOption` context with value set to`UseOriginalTimestamp`.
 
+### Invalid UTF-8 characters in Arrow batches
+Snowflake previously allowed users to upload data with invalid UTF-8 characters. Consequently, Arrow records containing string columns in Snowflake could include these invalid UTF-8 characters.
+However, according to the Arrow specifications (https://arrow.apache.org/docs/cpp/api/datatype.html
+and https://github.com/apache/arrow/blob/a03d957b5b8d0425f9d5b6c98b6ee1efa56a1248/go/arrow/datatype.go#L73-L74),
+Arrow string columns should only contain UTF-8 characters.
+
+To address this issue and prevent potential downstream disruptions, the context `enableArrowBatchesUtf8Validation`, is introduced.
+When enabled, this feature iterates through all values in string columns, identifying and replacing any invalid characters with `�`.
+This ensures that Arrow records conform to the UTF-8 standards, preventing validation failures in downstream services like the Rust Arrow library that impose strict validation checks.
+
 # Binding Parameters
 
 Binding allows a SQL statement to use a value that is stored in a Golang variable.

--- a/util.go
+++ b/util.go
@@ -130,6 +130,10 @@ func WithArrowBatchesTimestampOption(ctx context.Context, option snowflakeArrowB
 	return context.WithValue(ctx, arrowBatchesTimestampOption, option)
 }
 
+// WithArrowBatchesUtf8Validation in combination with WithArrowBatches returns a context that
+// will validate and replace invalid UTF-8 characters in string columns with the replacement character
+// Theoretically, this should not be necessary, because arrow string column is only intended to contain valid UTF-8 characters.
+// However, in practice, it is possible that the data in the string column is not valid UTF-8.
 func WithArrowBatchesUtf8Validation(ctx context.Context) context.Context {
 	return context.WithValue(ctx, enableArrowBatchesUtf8Validation, true)
 

--- a/util.go
+++ b/util.go
@@ -20,18 +20,19 @@ import (
 type contextKey string
 
 const (
-	multiStatementCount         contextKey = "MULTI_STATEMENT_COUNT"
-	asyncMode                   contextKey = "ASYNC_MODE_QUERY"
-	queryIDChannel              contextKey = "QUERY_ID_CHANNEL"
-	snowflakeRequestIDKey       contextKey = "SNOWFLAKE_REQUEST_ID"
-	fetchResultByID             contextKey = "SF_FETCH_RESULT_BY_ID"
-	fileStreamFile              contextKey = "STREAMING_PUT_FILE"
-	fileTransferOptions         contextKey = "FILE_TRANSFER_OPTIONS"
-	enableHigherPrecision       contextKey = "ENABLE_HIGHER_PRECISION"
-	arrowBatches                contextKey = "ARROW_BATCHES"
-	arrowAlloc                  contextKey = "ARROW_ALLOC"
-	arrowBatchesTimestampOption contextKey = "ARROW_BATCHES_TIMESTAMP_OPTION"
-	queryTag                    contextKey = "QUERY_TAG"
+	multiStatementCount              contextKey = "MULTI_STATEMENT_COUNT"
+	asyncMode                        contextKey = "ASYNC_MODE_QUERY"
+	queryIDChannel                   contextKey = "QUERY_ID_CHANNEL"
+	snowflakeRequestIDKey            contextKey = "SNOWFLAKE_REQUEST_ID"
+	fetchResultByID                  contextKey = "SF_FETCH_RESULT_BY_ID"
+	fileStreamFile                   contextKey = "STREAMING_PUT_FILE"
+	fileTransferOptions              contextKey = "FILE_TRANSFER_OPTIONS"
+	enableHigherPrecision            contextKey = "ENABLE_HIGHER_PRECISION"
+	enableArrowBatchesUtf8Validation contextKey = "ENABLE_ARROW_BATCHES_UTF8_VALIDATION"
+	arrowBatches                     contextKey = "ARROW_BATCHES"
+	arrowAlloc                       contextKey = "ARROW_ALLOC"
+	arrowBatchesTimestampOption      contextKey = "ARROW_BATCHES_TIMESTAMP_OPTION"
+	queryTag                         contextKey = "QUERY_TAG"
 )
 
 const (
@@ -127,6 +128,11 @@ func WithOriginalTimestamp(ctx context.Context) context.Context {
 // UseOriginalTimestamp: original timestamp struct returned by Snowflake. It can be used in case arrow.Timestamp cannot fit original timestamp values.
 func WithArrowBatchesTimestampOption(ctx context.Context, option snowflakeArrowBatchesTimestampOption) context.Context {
 	return context.WithValue(ctx, arrowBatchesTimestampOption, option)
+}
+
+func WithArrowBatchesUtf8Validation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, enableArrowBatchesUtf8Validation, true)
+
 }
 
 // WithQueryTag returns a context that will set the given tag as the QUERY_TAG


### PR DESCRIPTION
### Description


For historical reasons, snowflake used to allow users to upload invalid utf-8 characters. This caused arrow record to contain invalid utf-8 characters in arrow string columns. 

However by definition arrow.String column should contain utf-8 characters only, see https://arrow.apache.org/docs/cpp/api/datatype.html, 
https://github.com/apache/arrow/blob/a03d957b5b8d0425f9d5b6c98b6ee1efa56a1248/go/arrow/datatype.go#L73-L74

This could cause other upstream services that consume the bad arrow record to break, e.g Rust arrow lib force some basic validation, and this bad arrow record will fail the validation. 

This change introduce `enableArrowBatchesUtf8Validation`, when enabled, will iterate all values of string columns and replace any invalid character. 

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
