### PR TITLE
SNOW-999076: Fix application directory

### DIFF
--- a/client_configuration.go
+++ b/client_configuration.go
@@ -96,6 +96,9 @@ func clientConfigPredefinedDirs() []string {
 	} else {
 		predefinedDirs = append(predefinedDirs, homeDir)
 	}
+	if predefinedDirs == nil {
+		return []string{}
+	}
 	return predefinedDirs
 }
 

--- a/client_configuration.go
+++ b/client_configuration.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -82,12 +83,20 @@ func existsFile(filePath string) (bool, error) {
 }
 
 func clientConfigPredefinedDirs() []string {
+	var predefinedDirs []string
+	exeFile, err := os.Executable()
+	if err != nil {
+		logger.Warnf("Unable to access the application directory for client configuration search, err: %v", err)
+	} else {
+		predefinedDirs = append(predefinedDirs, filepath.Dir(exeFile))
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		logger.Warnf("Unable to access Home directory for client configuration search, err: %v", err)
-		return []string{"."}
+	} else {
+		predefinedDirs = append(predefinedDirs, homeDir)
 	}
-	return []string{".", homeDir}
+	return predefinedDirs
 }
 
 // ClientConfig config root

--- a/client_configuration_test.go
+++ b/client_configuration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -71,13 +72,15 @@ func TestNotFindConfigFileWhenNotDefined(t *testing.T) {
 }
 
 func TestCreatePredefinedDirs(t *testing.T) {
+	exeDir, _ := os.Executable()
+	appDir := filepath.Dir(exeDir)
 	homeDir, err := os.UserHomeDir()
 	assertNilF(t, err, "get home dir error")
 
 	locations := clientConfigPredefinedDirs()
 
 	assertEqualF(t, len(locations), 2, "size")
-	assertEqualE(t, locations[0], ".", "driver directory")
+	assertEqualE(t, locations[0], appDir, "driver directory")
 	assertEqualE(t, locations[1], homeDir, "home directory")
 }
 


### PR DESCRIPTION
### Description
Fix application directory which is used to get the config file.

### Checklist
- [x] Code compiles correctly
- [x] Run ``make fmt`` to fix inconsistent formats
- [x] Run ``make lint`` to get lint errors and fix all of them
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
