### PR TITLE
SNOW-903604 Zombie dbus processes generated by one of our dependencies github.com/99designs/keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Support
+
+For official support and urgent, production-impacting issues, please [contact Snowflake Support](https://community.snowflake.com/s/article/How-To-Submit-a-Support-Case-in-Snowflake-Lodge).
+
 # Go Snowflake Driver
 
 <a href="https://codecov.io/github/snowflakedb/gosnowflake?branch=master">
@@ -45,7 +49,7 @@ For detailed documentation and basic usage examples, please see the documentatio
 
 # Sample Programs
 
-Snowflake provides a set of sample programs to test with. Set the environment variable ``$GOPATH`` to the top directory of your workspace, e.g., ``~/go`` and make certain to 
+Snowflake provides a set of sample programs to test with. Set the environment variable ``$GOPATH`` to the top directory of your workspace, e.g., ``~/go`` and make certain to
 include ``$GOPATH/bin`` in the environment variable ``$PATH``. Run the ``make`` command to build all sample programs.
 
 ```
@@ -93,7 +97,7 @@ make test
 
 ## Capturing Code Coverage
 
-Configure your testing environment as described above and run ``make cov``. The coverage percentage will be printed on the console when the testing completes. 
+Configure your testing environment as described above and run ``make cov``. The coverage percentage will be printed on the console when the testing completes.
 
 ```
 make cov
@@ -111,8 +115,15 @@ go tool cover -html=coverage.txt
 
 You may use your preferred editor to edit the driver code. Make certain to run ``make fmt lint`` before submitting any pull request to Snowflake. This command formats your source code according to the standard Go style and detects any coding style issues.
 
-## Support
+## Runaway `dbus-daemon` processes on certain OS
+This only affects certain Linux distributions, one of them is confirmed to be RHEL. Due to a bug in one of the dependencies (`keyring`),
+on the affected OS, each invocation of a program depending on gosnowflake (or any other program depending on the same `keyring`),
+will generate a new instance of `dbus-daemon` fork which can, due to not being cleaned up, eventually fill the fd limits.
 
-For official support, contact Snowflake support at:
-[https://support.snowflake.net/](https://support.snowflake.net/).
+Until we replace the offending dependency with one which doesn't have the bug, a workaround needs to be applied, which can be:
+* cleaning up the runaway processes periodically
+* setting envvar `DBUS_SESSION_BUS_ADDRESS=$XDG_RUNTIME_DIR/bus` (if that socket exists, or create it) or even `DBUS_SESSION_BUS_ADDRESS=/dev/null`
 
+The driver will try to detect automatically, whether your runtime is susceptible for this bug or not, and if so, log a message on `Warning` loglevel.
+
+Details in [issue 773](https://github.com/snowflakedb/gosnowflake/issues/773)

--- a/driver.go
+++ b/driver.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"os"
+	"runtime"
 	"sync"
 )
 
@@ -57,6 +58,14 @@ func runningOnGithubAction() bool {
 var logger = CreateDefaultLogger()
 
 func init() {
+	if runtime.GOOS == "linux" {
+		// TODO: delete this once we replaced 99designs/keyring (SNOW-1017659) and/or keyring#103 is resolved
+		leak, logMsg := canDbusLeakProcesses()
+		if leak {
+			// 99designs/keyring#103 -> gosnowflake#773
+			logger.Warn(logMsg)
+		}
+	}
 	sql.Register("snowflake", &SnowflakeDriver{})
 	logger.SetLogLevel("error")
 	if runningOnGithubAction() {

--- a/util.go
+++ b/util.go
@@ -301,9 +301,8 @@ func isDbusDaemonRunning() bool {
 	if err != nil {
 		// process not running, pidof not available (sysvinit-tools, busybox, etc missing)
 		return false
-	} else {
-		return true
-	}
+	} 
+	return true
 }
 
 func canDbusLeakProcesses() (bool, string) {

--- a/util.go
+++ b/util.go
@@ -298,11 +298,9 @@ func isDbusDaemonRunning() bool {
 	// TODO: delete this once we replaced 99designs/keyring (SNOW-1017659) and/or keyring#103 is resolved
 	cmd := exec.Command("pidof", "dbus-daemon")
 	_, err := cmd.Output()
-	if err != nil {
-		// process not running, pidof not available (sysvinit-tools, busybox, etc missing)
-		return false
-	} 
-	return true
+
+	// false: process not running, pidof not available (sysvinit-tools, busybox, etc missing)
+	return err == nil
 }
 
 func canDbusLeakProcesses() (bool, string) {

--- a/util.go
+++ b/util.go
@@ -310,7 +310,7 @@ func canDbusLeakProcesses() (bool, string) {
 
 	valDbus, haveDbus := os.LookupEnv("DBUS_SESSION_BUS_ADDRESS")
 	if !haveDbus || strings.Contains(valDbus, "unix:abstract") {
-		// if DBUS_SESSION_BUS_ADDRESS is not set or set to an abstract socket, it's not necessarily a problem, only
+		// if DBUS_SESSION_BUS_ADDRESS is not set or set to an abstract socket, it's not necessarily a problem, only if dbus-daemon is running
 		if isDbusDaemonRunning() {
 			// we're probably susceptible to https://github.com/99designs/keyring/issues/103 here
 			leak = true


### PR DESCRIPTION
SNOW-903604 Zombie dbus processes generated by one of our dependencies github.com/99designs/keyring

After long consideration and discussion how we want to address the issue we decided to go with only documenting for now, which is what i tried to do here, alongside with trying to detect if the OS is susceptible for the issue (not all Linux are)

If so, log a warning of the issue + workaround which is the same as documented in the README now.

Of course this is by no means a solution - long term solution will be to possibly replace the current keyring implementation.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
