### PR TITLE
SNOW-1230690 Add UnsupportedArg check when requesting S3 accelerated …

### DIFF
--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -616,6 +616,11 @@ func (sfa *snowflakeFileTransferAgent) transferAccelerateConfig() error {
 					return nil
 				} else if ae.ErrorCode() == "MethodNotAllowed" {
 					return nil
+				} else if strings.EqualFold(ae.ErrorCode(), "UnsupportedArgument") {
+					// In AWS China and US Gov partitions, Transfer Acceleration is not supported
+					// https://docs.amazonaws.cn/en_us/aws/latest/userguide/s3.html#feature-diff
+					// https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
+					return nil
 				}
 			}
 			return err


### PR DESCRIPTION
…config

### Description
In AWS China and US Gov partitions, Transfer Acceleration is not supported and when requested it returns "UnsupportedArgument" error. This PR introduces handling of this error.


### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
