### PR TITLE
ArrowBatch high precision fails when using compute divide from int64 to bigDecimal

### DIFF
--- a/arrow_test.go
+++ b/arrow_test.go
@@ -54,35 +54,24 @@ func TestArrowBatchHighPrecision(t *testing.T) {
 			return err
 		})
 
-		if err != nil {
-			t.Error(err, "error running select query")
-		}
+		assertNilF(t, err, "error running select query")
 
 		sfRows, isSfRows := rows.(SnowflakeRows)
 		assertTrueF(t, isSfRows, "rows should be snowflakeRows")
 
 		arrowBatches, err := sfRows.GetArrowBatches()
-		if err != nil {
-			t.Error(err, "error getting arrow batches")
-		}
-
-		if len(arrowBatches) == 0 {
-			t.Fatal("should have at least one batch")
-		}
+		assertNilF(t, err, "error getting arrow batches")
+		assertNotEqualF(t, len(arrowBatches), 0, "should have at least one batch")
 
 		c, err := arrowBatches[0].Fetch()
-		if err != nil {
-			t.Error(err, "error fetching first batch")
-		}
+		assertNilF(t, err, "error fetching first batch")
 
 		chunk := *c
-		if len(chunk) == 0 {
-			t.Fatal("should have at least one chunk")
-		}
+		assertNotEqualF(t, len(chunk), 0, "should have at least one chunk")
 
 		strVal := chunk[0].Column(0).ValueStr(0)
-		expected := "1.0"
-		assertEqualF(t, strVal, expected, fmt.Sprintf("should have returned 1.0, but got: %s", strVal))
+		expected := "0.1"
+		assertEqualF(t, strVal, expected, fmt.Sprintf("should have returned 0.1, but got: %s", strVal))
 	})
 }
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -35,6 +35,10 @@ func assertEqualF(t *testing.T, actual any, expected any, descriptions ...string
 	fatalOnNonEmpty(t, validateEqual(actual, expected, descriptions...))
 }
 
+func assertNotEqualF(t *testing.T, actual any, expected any, descriptions ...string) {
+	fatalOnNonEmpty(t, validateNotEqual(actual, expected, descriptions...))
+}
+
 func assertBytesEqualE(t *testing.T, actual []byte, expected []byte, descriptions ...string) {
 	errorOnNonEmpty(t, validateBytesEqual(actual, expected, descriptions...))
 }
@@ -109,6 +113,14 @@ func validateEqual(actual any, expected any, descriptions ...string) string {
 	}
 	desc := joinDescriptions(descriptions...)
 	return fmt.Sprintf("expected \"%s\" to be equal to \"%s\" but was not. %s", actual, expected, desc)
+}
+
+func validateNotEqual(actual any, expected any, descriptions ...string) string {
+	if expected != actual {
+		return ""
+	}
+	desc := joinDescriptions(descriptions...)
+	return fmt.Sprintf("expected \"%s\" not to be equal to \"%s\" but they were the same. %s", actual, expected, desc)
 }
 
 func validateBytesEqual(actual []byte, expected []byte, descriptions ...string) string {

--- a/converter.go
+++ b/converter.go
@@ -1039,7 +1039,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 					return nil, err
 				}
 				defer newCol.Release()
-			} else if srcColumnMeta.Scale != 0 {
+			} else if srcColumnMeta.Scale != 0 && col.DataType().ID() != arrow.INT64 {
 				result, err := compute.Divide(ctxAlloc, compute.ArithmeticOptions{NoCheckOverflow: true},
 					&compute.ArrayDatum{Value: newCol.Data()},
 					compute.NewDatum(math.Pow10(int(srcColumnMeta.Scale))))
@@ -1048,6 +1048,23 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 				}
 				defer result.Release()
 				newCol = result.(*compute.ArrayDatum).MakeArray()
+				defer newCol.Release()
+			} else if srcColumnMeta.Scale != 0 && col.DataType().ID() == arrow.INT64 {
+				// gosnowflake driver uses compute.Divide() which could bring `integer value not in range: -9007199254740992 to 9007199254740992` error
+				// before we figure this out, we can convert to arrow.Decimal and follow the same code path as above.
+				values := col.(*array.Int64).Int64Values()
+				decimalValues := make([]decimal128.Num, len(values))
+				for i, val := range values {
+					decimalValues[i] = decimal128.FromI64(val)
+				}
+				builder := array.NewDecimal128Builder(memory.NewCheckedAllocator(memory.NewGoAllocator()), &arrow.Decimal128Type{Precision: int32(srcColumnMeta.Precision), Scale: int32(srcColumnMeta.Scale)})
+				builder.AppendValues(decimalValues, nil)
+				decimalArray := builder.NewArray()
+				builder.Release()
+				newCol, err = compute.CastArray(ctx, decimalArray, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
+				if err != nil {
+					return nil, err
+				}
 				defer newCol.Release()
 			}
 		case timeType:

--- a/converter.go
+++ b/converter.go
@@ -1051,20 +1051,17 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 				defer newCol.Release()
 			} else if srcColumnMeta.Scale != 0 && col.DataType().ID() == arrow.INT64 {
 				// gosnowflake driver uses compute.Divide() which could bring `integer value not in range: -9007199254740992 to 9007199254740992` error
-				// before we figure this out, we can convert to arrow.Decimal and follow the same code path as above.
+				// if we convert int64 to BigDecimal and then use compute.CastArray to convert BigDecimal to float64, we won't have enough precision.
+				// e.g 0.1 as (38,19) will result 0.09999999999999999
 				values := col.(*array.Int64).Int64Values()
-				decimalValues := make([]decimal128.Num, len(values))
+				floatValues := make([]float64, len(values))
 				for i, val := range values {
-					decimalValues[i] = decimal128.FromI64(val)
+					floatValues[i], _ = intToBigFloat(val, srcColumnMeta.Scale).Float64()
 				}
-				builder := array.NewDecimal128Builder(memory.NewCheckedAllocator(memory.NewGoAllocator()), &arrow.Decimal128Type{Precision: int32(srcColumnMeta.Precision), Scale: int32(srcColumnMeta.Scale)})
-				builder.AppendValues(decimalValues, nil)
-				decimalArray := builder.NewArray()
+				builder := array.NewFloat64Builder(memory.NewCheckedAllocator(memory.NewGoAllocator()))
+				builder.AppendValues(floatValues, nil)
+				newCol = builder.NewArray()
 				builder.Release()
-				newCol, err = compute.CastArray(ctx, decimalArray, compute.UnsafeCastOptions(arrow.PrimitiveTypes.Float64))
-				if err != nil {
-					return nil, err
-				}
 				defer newCol.Release()
 			}
 		case timeType:


### PR DESCRIPTION
### Description

SNOW-XXX Please explain the changes you made here.
Currently, if you run the query `select '0.1':: DECIMAL(38, 19) as c` with arrow batching turned on, the result will error with `invalid: integer value 1000000000000000000 not in range: -9007199254740992 to 9007199254740992`. The error is thrown by compute.Divide(), when receiving int64 value for a BigDecimal column.
The fix is to convert int64 array to arrow.Decimal array, and follow a different code path (line 943 - line 955) where compute.Divide() is not involved.

The error originates from arrow library: https://github.com/apache/arrow/issues/36998


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
