### PR TITLE
Allow enableHigherPrecision to be used in arrow batches 

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -1005,10 +1005,20 @@ func getArrowBatchesTimestampOption(ctx context.Context) snowflakeArrowBatchesTi
 	return o
 }
 
+func useArrowBatchesOriginalBigDecimal(ctx context.Context) bool {
+	v := ctx.Value(arrowBatchesOriginalBigDecimal)
+	if v == nil {
+		return false
+	}
+	d, ok := v.(bool)
+	return ok && d
+}
+
 func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocator, rowType []execResponseRowType, loc *time.Location) (arrow.Record, error) {
 	arrowBatchesTimestampOption := getArrowBatchesTimestampOption(ctx)
+	useArrowBatchesOriginalBigDecimal := useArrowBatchesOriginalBigDecimal(ctx)
 
-	s, err := recordToSchema(record.Schema(), rowType, loc, arrowBatchesTimestampOption)
+	s, err := recordToSchema(record.Schema(), rowType, loc, arrowBatchesTimestampOption, useArrowBatchesOriginalBigDecimal)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1036,9 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 		switch snowflakeType {
 		case fixedType:
 			var toType arrow.DataType
-			if col.DataType().ID() == arrow.DECIMAL || col.DataType().ID() == arrow.DECIMAL256 {
+			if useArrowBatchesOriginalBigDecimal {
+				// do nothing - return decimal as is
+			} else if col.DataType().ID() == arrow.DECIMAL || col.DataType().ID() == arrow.DECIMAL256 {
 				if srcColumnMeta.Scale == 0 {
 					toType = arrow.PrimitiveTypes.Int64
 				} else {
@@ -1151,7 +1163,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 	return array.NewRecord(s, cols, numRows), nil
 }
 
-func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.Location, timestampOption snowflakeArrowBatchesTimestampOption) (*arrow.Schema, error) {
+func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.Location, timestampOption snowflakeArrowBatchesTimestampOption, useArrowBatchesOriginalBigDecimal bool) (*arrow.Schema, error) {
 	var fields []arrow.Field
 	for i := 0; i < len(sc.Fields()); i++ {
 		f := sc.Field(i)
@@ -1163,13 +1175,17 @@ func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.L
 		case fixedType:
 			switch f.Type.ID() {
 			case arrow.DECIMAL:
-				if srcColumnMeta.Scale == 0 {
+				if useArrowBatchesOriginalBigDecimal {
+					converted = false
+				} else if srcColumnMeta.Scale == 0 {
 					t = &arrow.Int64Type{}
 				} else {
 					t = &arrow.Float64Type{}
 				}
 			default:
-				if srcColumnMeta.Scale != 0 {
+				if useArrowBatchesOriginalBigDecimal {
+					converted = false
+				} else if srcColumnMeta.Scale != 0 {
 					t = &arrow.Float64Type{}
 				} else {
 					converted = false

--- a/converter_test.go
+++ b/converter_test.go
@@ -909,20 +909,20 @@ func TestArrowToRecord(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		logical                           string
-		physical                          string
-		sc                                *arrow.Schema
-		rowType                           execResponseRowType
-		values                            interface{}
-		expected                          interface{}
-		error                             string
-		arrowBatchesTimestampOption       snowflakeArrowBatchesTimestampOption
-		enableArrowBatchesUtf8Validation  bool
-		useArrowBatchesOriginalBigDecimal bool
-		nrows                             int
-		builder                           array.Builder
-		append                            func(b array.Builder, vs interface{})
-		compare                           func(src interface{}, expected interface{}, rec arrow.Record) int
+		logical                          string
+		physical                         string
+		sc                               *arrow.Schema
+		rowType                          execResponseRowType
+		values                           interface{}
+		expected                         interface{}
+		error                            string
+		arrowBatchesTimestampOption      snowflakeArrowBatchesTimestampOption
+		enableArrowBatchesUtf8Validation bool
+		withHigherPrecision              bool
+		nrows                            int
+		builder                          array.Builder
+		append                           func(b array.Builder, vs interface{})
+		compare                          func(src interface{}, expected interface{}, rec arrow.Record) int
 	}{
 		{
 			logical:  "fixed",
@@ -965,13 +965,13 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
-			logical:                           "fixed",
-			physical:                          "number(38,0)",
-			sc:                                arrow.NewSchema([]arrow.Field{{Type: &arrow.Decimal128Type{Precision: 38, Scale: 0}}}, nil),
-			values:                            []string{"10000000000000000000000000000000000000", "-12345678901234567890123456789012345678"},
-			useArrowBatchesOriginalBigDecimal: true,
-			nrows:                             2,
-			builder:                           array.NewDecimal128Builder(pool, &arrow.Decimal128Type{Precision: 38, Scale: 0}),
+			logical:             "fixed",
+			physical:            "number(38,0)",
+			sc:                  arrow.NewSchema([]arrow.Field{{Type: &arrow.Decimal128Type{Precision: 38, Scale: 0}}}, nil),
+			values:              []string{"10000000000000000000000000000000000000", "-12345678901234567890123456789012345678"},
+			withHigherPrecision: true,
+			nrows:               2,
+			builder:             array.NewDecimal128Builder(pool, &arrow.Decimal128Type{Precision: 38, Scale: 0}),
 			append: func(b array.Builder, vs interface{}) {
 				for _, s := range vs.([]string) {
 					num, ok := stringIntToDecimal(s)
@@ -1028,14 +1028,14 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
-			logical:                           "fixed",
-			physical:                          "number(38,37)",
-			rowType:                           execResponseRowType{Scale: 37},
-			sc:                                arrow.NewSchema([]arrow.Field{{Type: &arrow.Decimal128Type{Precision: 38, Scale: 37}}}, nil),
-			values:                            []string{"1.2345678901234567890123456789012345678", "-9.999999999999999"},
-			useArrowBatchesOriginalBigDecimal: true,
-			nrows:                             2,
-			builder:                           array.NewDecimal128Builder(pool, &arrow.Decimal128Type{Precision: 38, Scale: 37}),
+			logical:             "fixed",
+			physical:            "number(38,37)",
+			rowType:             execResponseRowType{Scale: 37},
+			sc:                  arrow.NewSchema([]arrow.Field{{Type: &arrow.Decimal128Type{Precision: 38, Scale: 37}}}, nil),
+			values:              []string{"1.2345678901234567890123456789012345678", "-9.999999999999999"},
+			withHigherPrecision: true,
+			nrows:               2,
+			builder:             array.NewDecimal128Builder(pool, &arrow.Decimal128Type{Precision: 38, Scale: 37}),
 			append: func(b array.Builder, vs interface{}) {
 				for _, s := range vs.([]string) {
 					num, err := decimal128.FromString(s, 38, 37)
@@ -1116,15 +1116,15 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
-			logical:                           "fixed",
-			physical:                          "int8",
-			rowType:                           execResponseRowType{Scale: 1},
-			sc:                                arrow.NewSchema([]arrow.Field{{Type: &arrow.Int8Type{}}}, nil),
-			values:                            []int8{10, 16},
-			useArrowBatchesOriginalBigDecimal: true,
-			nrows:                             2,
-			builder:                           array.NewInt8Builder(pool),
-			append:                            func(b array.Builder, vs interface{}) { b.(*array.Int8Builder).AppendValues(vs.([]int8), valids) },
+			logical:             "fixed",
+			physical:            "int8",
+			rowType:             execResponseRowType{Scale: 1},
+			sc:                  arrow.NewSchema([]arrow.Field{{Type: &arrow.Int8Type{}}}, nil),
+			values:              []int8{10, 16},
+			withHigherPrecision: true,
+			nrows:               2,
+			builder:             array.NewInt8Builder(pool),
+			append:              func(b array.Builder, vs interface{}) { b.(*array.Int8Builder).AppendValues(vs.([]int8), valids) },
 			compare: func(src interface{}, expected interface{}, convertedRec arrow.Record) int {
 				srcvs := src.([]int8)
 				for i, f := range convertedRec.Column(0).(*array.Int8).Int8Values() {
@@ -1156,15 +1156,15 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
-			logical:                           "fixed",
-			physical:                          "int16",
-			rowType:                           execResponseRowType{Scale: 1},
-			sc:                                arrow.NewSchema([]arrow.Field{{Type: &arrow.Int16Type{}}}, nil),
-			values:                            []int16{20, 26},
-			useArrowBatchesOriginalBigDecimal: true,
-			nrows:                             2,
-			builder:                           array.NewInt16Builder(pool),
-			append:                            func(b array.Builder, vs interface{}) { b.(*array.Int16Builder).AppendValues(vs.([]int16), valids) },
+			logical:             "fixed",
+			physical:            "int16",
+			rowType:             execResponseRowType{Scale: 1},
+			sc:                  arrow.NewSchema([]arrow.Field{{Type: &arrow.Int16Type{}}}, nil),
+			values:              []int16{20, 26},
+			withHigherPrecision: true,
+			nrows:               2,
+			builder:             array.NewInt16Builder(pool),
+			append:              func(b array.Builder, vs interface{}) { b.(*array.Int16Builder).AppendValues(vs.([]int16), valids) },
 			compare: func(src interface{}, expected interface{}, convertedRec arrow.Record) int {
 				srcvs := src.([]int16)
 				for i, f := range convertedRec.Column(0).(*array.Int16).Int16Values() {
@@ -1196,15 +1196,15 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
-			logical:                           "fixed",
-			physical:                          "int32",
-			rowType:                           execResponseRowType{Scale: 2},
-			sc:                                arrow.NewSchema([]arrow.Field{{Type: &arrow.Int32Type{}}}, nil),
-			values:                            []int32{200, 265},
-			useArrowBatchesOriginalBigDecimal: true,
-			nrows:                             2,
-			builder:                           array.NewInt32Builder(pool),
-			append:                            func(b array.Builder, vs interface{}) { b.(*array.Int32Builder).AppendValues(vs.([]int32), valids) },
+			logical:             "fixed",
+			physical:            "int32",
+			rowType:             execResponseRowType{Scale: 2},
+			sc:                  arrow.NewSchema([]arrow.Field{{Type: &arrow.Int32Type{}}}, nil),
+			values:              []int32{200, 265},
+			withHigherPrecision: true,
+			nrows:               2,
+			builder:             array.NewInt32Builder(pool),
+			append:              func(b array.Builder, vs interface{}) { b.(*array.Int32Builder).AppendValues(vs.([]int32), valids) },
 			compare: func(src interface{}, expected interface{}, convertedRec arrow.Record) int {
 				srcvs := src.([]int32)
 				for i, f := range convertedRec.Column(0).(*array.Int32).Int32Values() {
@@ -1236,15 +1236,15 @@ func TestArrowToRecord(t *testing.T) {
 			},
 		},
 		{
-			logical:                           "fixed",
-			physical:                          "int64",
-			rowType:                           execResponseRowType{Scale: 5},
-			sc:                                arrow.NewSchema([]arrow.Field{{Type: &arrow.Int64Type{}}}, nil),
-			values:                            []int64{12345, 234567},
-			useArrowBatchesOriginalBigDecimal: true,
-			nrows:                             2,
-			builder:                           array.NewInt64Builder(pool),
-			append:                            func(b array.Builder, vs interface{}) { b.(*array.Int64Builder).AppendValues(vs.([]int64), valids) },
+			logical:             "fixed",
+			physical:            "int64",
+			rowType:             execResponseRowType{Scale: 5},
+			sc:                  arrow.NewSchema([]arrow.Field{{Type: &arrow.Int64Type{}}}, nil),
+			values:              []int64{12345, 234567},
+			withHigherPrecision: true,
+			nrows:               2,
+			builder:             array.NewInt64Builder(pool),
+			append:              func(b array.Builder, vs interface{}) { b.(*array.Int64Builder).AppendValues(vs.([]int64), valids) },
 			compare: func(src interface{}, expected interface{}, convertedRec arrow.Record) int {
 				srcvs := src.([]int64)
 				for i, f := range convertedRec.Column(0).(*array.Int64).Int64Values() {
@@ -2024,8 +2024,8 @@ func TestArrowToRecord(t *testing.T) {
 				ctx = WithArrowBatchesUtf8Validation(ctx)
 			}
 
-			if tc.useArrowBatchesOriginalBigDecimal {
-				ctx = WithArrowBatchesOriginalBigDecimal(ctx)
+			if tc.withHigherPrecision {
+				ctx = WithHigherPrecision(ctx)
 			}
 
 			transformedRec, err := arrowToRecord(ctx, rawRec, pool, []execResponseRowType{meta}, localTime.Location())

--- a/doc.go
+++ b/doc.go
@@ -505,9 +505,8 @@ To address this issue and prevent potential downstream disruptions, the context 
 When enabled, this feature iterates through all values in string columns, identifying and replacing any invalid characters with `�`.
 This ensures that Arrow records conform to the UTF-8 standards, preventing validation failures in downstream services like the Rust Arrow library that impose strict validation checks.
 
-### BigDecimal in Arrow batches
-Snowflake returns BigDecimal natively (from backend to driver)
-To preserve BigDecimal values within Arrow batches, set the `arrowBatchesOriginalBigDecimal` value to true in the context using `WithArrowBatchesOriginalBigDecimal`.
+### WithHigherPrecision in Arrow batches
+To preserve BigDecimal values within Arrow batches, set the `enableHigherPrecision` value to true in the context using `WithHigherPrecision`.
 This offers two main benefits: it helps avoid precision loss and defers the conversion to upstream services.
 Alternatively, without this setting, all non-zero scale numbers will be converted to float64, potentially resulting in loss of precision.
 

--- a/doc.go
+++ b/doc.go
@@ -507,7 +507,7 @@ This ensures that Arrow records conform to the UTF-8 standards, preventing valid
 
 ### BigDecimal in Arrow batches
 Snowflake returns BigDecimal natively (from backend to driver)
-To preserve BigDecimal values within Arrow batches, set the `arrowBatchesOriginalBigDecimal“ value to true in the context using `WithArrowBatchesOriginalBigDecimal“.
+To preserve BigDecimal values within Arrow batches, set the `arrowBatchesOriginalBigDecimal` value to true in the context using `WithArrowBatchesOriginalBigDecimal`.
 This offers two main benefits: it helps avoid precision loss and defers the conversion to upstream services.
 Alternatively, without this setting, all non-zero scale numbers will be converted to float64, potentially resulting in loss of precision.
 

--- a/doc.go
+++ b/doc.go
@@ -505,6 +505,12 @@ To address this issue and prevent potential downstream disruptions, the context 
 When enabled, this feature iterates through all values in string columns, identifying and replacing any invalid characters with `�`.
 This ensures that Arrow records conform to the UTF-8 standards, preventing validation failures in downstream services like the Rust Arrow library that impose strict validation checks.
 
+### BigDecimal in Arrow batches
+Snowflake returns BigDecimal natively (from backend to driver)
+To preserve BigDecimal values within Arrow batches, set the `arrowBatchesOriginalBigDecimal“ value to true in the context using `WithArrowBatchesOriginalBigDecimal“.
+This offers two main benefits: it helps avoid precision loss and defers the conversion to upstream services.
+Alternatively, without this setting, all non-zero scale numbers will be converted to float64, potentially resulting in loss of precision.
+
 # Binding Parameters
 
 Binding allows a SQL statement to use a value that is stored in a Golang variable.

--- a/doc.go
+++ b/doc.go
@@ -506,9 +506,10 @@ When enabled, this feature iterates through all values in string columns, identi
 This ensures that Arrow records conform to the UTF-8 standards, preventing validation failures in downstream services like the Rust Arrow library that impose strict validation checks.
 
 ### WithHigherPrecision in Arrow batches
-To preserve BigDecimal values within Arrow batches, set the `enableHigherPrecision` value to true in the context using `WithHigherPrecision`.
+To preserve BigDecimal values within Arrow batches, use `WithHigherPrecision`.
 This offers two main benefits: it helps avoid precision loss and defers the conversion to upstream services.
 Alternatively, without this setting, all non-zero scale numbers will be converted to float64, potentially resulting in loss of precision.
+Zero-scale numbers (DECIMAL256, DECIMAL128) will be converted to int64, which could lead to overflow.
 
 # Binding Parameters
 

--- a/util.go
+++ b/util.go
@@ -32,6 +32,7 @@ const (
 	arrowBatches                     contextKey = "ARROW_BATCHES"
 	arrowAlloc                       contextKey = "ARROW_ALLOC"
 	arrowBatchesTimestampOption      contextKey = "ARROW_BATCHES_TIMESTAMP_OPTION"
+	arrowBatchesOriginalBigDecimal   contextKey = "ARROW_BATCHES_ORIGINAL_BIG_DECIMAL"
 	queryTag                         contextKey = "QUERY_TAG"
 )
 
@@ -137,6 +138,13 @@ func WithArrowBatchesTimestampOption(ctx context.Context, option snowflakeArrowB
 func WithArrowBatchesUtf8Validation(ctx context.Context) context.Context {
 	return context.WithValue(ctx, enableArrowBatchesUtf8Validation, true)
 
+}
+
+// WithArrowBatchesOriginalBigDecimal in combination with WithArrowBatches returns a context that
+// preserve the original BigDecimal returned by Snowflake.
+// To decode the BigDecimal, metadata including scale information is required.
+func WithArrowBatchesOriginalBigDecimal(ctx context.Context) context.Context {
+	return context.WithValue(ctx, arrowBatchesOriginalBigDecimal, true)
 }
 
 // WithQueryTag returns a context that will set the given tag as the QUERY_TAG

--- a/util.go
+++ b/util.go
@@ -32,7 +32,6 @@ const (
 	arrowBatches                     contextKey = "ARROW_BATCHES"
 	arrowAlloc                       contextKey = "ARROW_ALLOC"
 	arrowBatchesTimestampOption      contextKey = "ARROW_BATCHES_TIMESTAMP_OPTION"
-	arrowBatchesOriginalBigDecimal   contextKey = "ARROW_BATCHES_ORIGINAL_BIG_DECIMAL"
 	queryTag                         contextKey = "QUERY_TAG"
 )
 
@@ -94,6 +93,7 @@ func WithDescribeOnly(ctx context.Context) context.Context {
 // WithHigherPrecision returns a context that enables higher precision by
 // returning a *big.Int or *big.Float variable when querying rows for column
 // types with numbers that don't fit into its native Golang counterpart
+// When used in combination with WithArrowBatches, original BigDecimal in arrow batches will be preserved.
 func WithHigherPrecision(ctx context.Context) context.Context {
 	return context.WithValue(ctx, enableHigherPrecision, true)
 }
@@ -138,13 +138,6 @@ func WithArrowBatchesTimestampOption(ctx context.Context, option snowflakeArrowB
 func WithArrowBatchesUtf8Validation(ctx context.Context) context.Context {
 	return context.WithValue(ctx, enableArrowBatchesUtf8Validation, true)
 
-}
-
-// WithArrowBatchesOriginalBigDecimal in combination with WithArrowBatches returns a context that
-// preserve the original BigDecimal returned by Snowflake.
-// To decode the BigDecimal, metadata including scale information is required.
-func WithArrowBatchesOriginalBigDecimal(ctx context.Context) context.Context {
-	return context.WithValue(ctx, arrowBatchesOriginalBigDecimal, true)
 }
 
 // WithQueryTag returns a context that will set the given tag as the QUERY_TAG


### PR DESCRIPTION
### Description

### enableHigherPrecision in Arrow batches
Snowflake returns BigDecimal natively (from backend to driver)
To preserve BigDecimal values within Arrow batches, set the `enableHigherPrecision` value to true in the context using `WithHigherPrecision“.

### Benefits
This offers two main benefits: it helps avoid precision loss and defers the conversion to upstream services.
Alternatively, without this setting, all non-zero scale numbers will be converted to float64, potentially resulting in loss of precision.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
