### PR TITLE
Allow caller to set log fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,41 @@ Install [jq](https://stedolan.github.io/jq) so that the parameters can get parse
 make test
 ```
 
+## customizing Logging Tags
+
+If you would like to ensure that certain tags are always present in the logs, `RegisterClientLogContextHook` can be used in your init function. See example below.
+```
+import "github.com/snowflakedb/gosnowflake"
+
+func init() {
+    // each time the logger is used, the logs will contain a REQUEST_ID field with requestID the value extracted 
+    // from the context
+	gosnowflake.RegisterClientLogContextHook("REQUEST_ID", func(ctx context.Context) interface{} {
+		return requestIdFromContext(ctx)
+	})
+}
+```
+
+## Setting Log Level
+If you want to change the log level, `SetLogLevel` can be used in your init function like this:
+```
+import "github.com/snowflakedb/gosnowflake"
+
+func init() {
+    // The following line changes the log level to debug
+	_ = gosnowflake.GetLogger().SetLogLevel("debug")
+}
+```
+The following is a list of options you can pass in to set the level from least to most verbose: 
+- `"OFF"`
+- `"error"`
+- `"warn"`
+- `"print"`
+- `"trace"`
+- `"debug"`
+- `"info"`
+
+
 ## Capturing Code Coverage
 
 Configure your testing environment as described above and run ``make cov``. The coverage percentage will be printed on the console when the testing completes.

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -131,7 +131,7 @@ func getIdpURLProofKey(
 		return "", "", err
 	}
 	if !respd.Success {
-		logger.Errorln("Authentication FAILED")
+		logger.WithContext(ctx).Errorln("Authentication FAILED")
 		sr.TokenAccessor.SetTokens("", "", -1)
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
@@ -287,7 +287,7 @@ func doAuthenticateByExternalBrowser(
 			n, err := c.Read(b)
 			if err != nil {
 				if err != io.EOF {
-					logger.Infof("error reading from socket. err: %v", err)
+					logger.WithContext(ctx).Infof("error reading from socket. err: %v", err)
 					errAccept = &SnowflakeError{
 						Number:      ErrFailedToGetExternalBrowserResponse,
 						SQLState:    SQLStateConnectionRejected,

--- a/authokta.go
+++ b/authokta.go
@@ -92,7 +92,7 @@ func authenticateBySAML(
 		return nil, err
 	}
 	if !respd.Success {
-		logger.Errorln("Authentication FAILED")
+		logger.WithContext(ctx).Errorln("Authentication FAILED")
 		sr.TokenAccessor.SetTokens("", "", -1)
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
@@ -215,7 +215,7 @@ func postAuthSAML(
 	params.Add(requestIDKey, getOrGenerateRequestIDFromContext(ctx).String())
 	fullURL := sr.getFullURL(authenticatorRequestPath, params)
 
-	logger.Infof("fullURL: %v", fullURL)
+	logger.WithContext(ctx).Infof("fullURL: %v", fullURL)
 	resp, err := sr.FuncPost(ctx, sr, fullURL, headers, body, timeout, defaultTimeProvider, nil)
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func postAuthOKTA(
 	fullURL string,
 	timeout time.Duration) (
 	data *authOKTAResponse, err error) {
-	logger.Infof("fullURL: %v", fullURL)
+	logger.WithContext(ctx).Infof("fullURL: %v", fullURL)
 	targetURL, err := url.Parse(fullURL)
 	if err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func postAuthOKTA(
 	}
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Errorf("failed to extract HTTP response body. err: %v", err)
+		logger.WithContext(ctx).Errorf("failed to extract HTTP response body. err: %v", err)
 		return nil, err
 	}
 	logger.WithContext(ctx).Infof("HTTP: %v, URL: %v", resp.StatusCode, fullURL)

--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -175,7 +175,7 @@ func (bu *bindUploader) createCSVRecord(data []interface{}) []byte {
 		if ok {
 			b.WriteString(escapeForCSV(value))
 		} else if !reflect.ValueOf(data[i]).IsNil() {
-			logger.Debugf("Cannot convert value to string in createCSVRecord. value: %v", data[i])
+			logger.WithContext(bu.ctx).Debugf("Cannot convert value to string in createCSVRecord. value: %v", data[i])
 		}
 	}
 	b.WriteString("\n")

--- a/connection.go
+++ b/connection.go
@@ -163,7 +163,7 @@ func (sc *snowflakeConn) exec(
 	if !sc.cfg.DisableQueryContextCache && data.Data.QueryContext != nil {
 		queryContext, err := extractQueryContext(data)
 		if err != nil {
-			logger.WithContext(ctx).Errorf("error while decoding query context: ", err)
+			logger.WithContext(ctx).Errorf("error while decoding query context: %v", err)
 		} else {
 			sc.queryContextCache.add(sc, queryContext.Entries...)
 		}

--- a/connection_util.go
+++ b/connection_util.go
@@ -159,7 +159,7 @@ func (sc *snowflakeConn) populateSessionParameters(parameters []nameValueParamet
 				v = vv
 			}
 		}
-		logger.Debugf("parameter. name: %v, value: %v", param.Name, v)
+		logger.WithContext(sc.ctx).Debugf("parameter. name: %v, value: %v", param.Name, v)
 		paramsMutex.Lock()
 		sc.cfg.Params[strings.ToLower(param.Name)] = &v
 		paramsMutex.Unlock()
@@ -288,12 +288,12 @@ func populateChunkDownloader(
 
 func (sc *snowflakeConn) setupOCSPPrivatelink(app string, host string) error {
 	ocspCacheServer := fmt.Sprintf("http://ocsp.%v/ocsp_response_cache.json", host)
-	logger.Debugf("OCSP Cache Server for Privatelink: %v\n", ocspCacheServer)
+	logger.WithContext(sc.ctx).Debugf("OCSP Cache Server for Privatelink: %v\n", ocspCacheServer)
 	if err := os.Setenv(cacheServerURLEnv, ocspCacheServer); err != nil {
 		return err
 	}
 	ocspRetryHostTemplate := fmt.Sprintf("http://ocsp.%v/retry/", host) + "%v/%v"
-	logger.Debugf("OCSP Retry URL for Privatelink: %v\n", ocspRetryHostTemplate)
+	logger.WithContext(sc.ctx).Debugf("OCSP Retry URL for Privatelink: %v\n", ocspRetryHostTemplate)
 	if err := os.Setenv(ocspRetryURLEnv, ocspRetryHostTemplate); err != nil {
 		return err
 	}

--- a/converter.go
+++ b/converter.go
@@ -137,7 +137,7 @@ func snowflakeTypeToGo(ctx context.Context, dbtype snowflakeType, scale int64, f
 			return reflect.TypeOf("")
 		}
 		if len(fields) != 1 {
-			logger.Warn("Unexpected fields number: " + strconv.Itoa(len(fields)))
+			logger.WithContext(ctx).Warn("Unexpected fields number: " + strconv.Itoa(len(fields)))
 			return reflect.TypeOf("")
 		}
 		switch getSnowflakeType(fields[0].Type) {
@@ -173,7 +173,7 @@ func snowflakeTypeToGo(ctx context.Context, dbtype snowflakeType, scale int64, f
 		}
 		return reflect.TypeOf(map[any]any{})
 	}
-	logger.Errorf("unsupported dbtype is specified. %v", dbtype)
+	logger.WithContext(ctx).Errorf("unsupported dbtype is specified. %v", dbtype)
 	return reflect.TypeOf("")
 }
 
@@ -200,7 +200,7 @@ func snowflakeTypeToGoForMaps[K comparable](ctx context.Context, valueMetadata f
 	case timeType, dateType, timestampTzType, timestampNtzType, timestampLtzType:
 		return reflect.TypeOf(map[K]time.Time{})
 	}
-	logger.Errorf("unsupported dbtype is specified for map value")
+	logger.WithContext(ctx).Errorf("unsupported dbtype is specified for map value")
 	return reflect.TypeOf("")
 }
 
@@ -1735,7 +1735,7 @@ func arrowToRecord(ctx context.Context, record arrow.Record, pool memory.Allocat
 					if col.(*array.String).IsValid(i) {
 						stringValue := col.(*array.String).Value(i)
 						if !utf8.ValidString(stringValue) {
-							logger.Error("Invalid UTF-8 characters detected while reading query response, column: ", srcColumnMeta.Name)
+							logger.WithContext(ctx).Error("Invalid UTF-8 characters detected while reading query response, column: ", srcColumnMeta.Name)
 							stringValue = strings.ToValidUTF8(stringValue, "�")
 						}
 						tb.Append(stringValue)

--- a/driver.go
+++ b/driver.go
@@ -35,7 +35,7 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 	if config.Tracing != "" {
 		logger.SetLogLevel(config.Tracing)
 	}
-	logger.Info("OpenWithConfig")
+	logger.WithContext(ctx).Info("OpenWithConfig")
 	sc, err := buildSnowflakeConn(ctx, config)
 	if err != nil {
 		return nil, err

--- a/errors.go
+++ b/errors.go
@@ -75,7 +75,7 @@ func (se *SnowflakeError) sendExceptionTelemetry(sc *snowflakeConn, data *teleme
 func (se *SnowflakeError) exceptionTelemetry(sc *snowflakeConn) *SnowflakeError {
 	data := se.generateTelemetryExceptionData()
 	if err := se.sendExceptionTelemetry(sc, data); err != nil {
-		logger.Debugf("failed to log to telemetry: %v", data)
+		logger.WithContext(sc.ctx).Debugf("failed to log to telemetry: %v", data)
 	}
 	return se
 }

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -686,13 +686,13 @@ func (sfa *snowflakeFileTransferAgent) upload(
 	}
 
 	if len(smallFileMetadata) > 0 {
-		logger.Infof("uploading %v small files", len(smallFileMetadata))
+		logger.WithContext(sfa.sc.ctx).Infof("uploading %v small files", len(smallFileMetadata))
 		if err = sfa.uploadFilesParallel(smallFileMetadata); err != nil {
 			return err
 		}
 	}
 	if len(largeFileMetadata) > 0 {
-		logger.Infof("uploading %v large files", len(largeFileMetadata))
+		logger.WithContext(sfa.sc.ctx).Infof("uploading %v large files", len(largeFileMetadata))
 		if err = sfa.uploadFilesSequential(largeFileMetadata); err != nil {
 			return err
 		}

--- a/log.go
+++ b/log.go
@@ -28,13 +28,15 @@ var clientLogContextHooks = map[string]ClientLogContextHook{}
 // fields based on the Context.
 type ClientLogContextHook func(context.Context) string
 
-// RegisterClientLogContextHook registers a hook that can be used to extract fields
+// RegisterLogContextHook registers a hook that can be used to extract fields
 // from the Context and associated with log messages using the provided key. This
 // function is not thread-safe and should only be called on startup.
 func RegisterLogContextHook(contextKey string, ctxExtractor ClientLogContextHook) {
 	clientLogContextHooks[contextKey] = ctxExtractor
 }
 
+// LogKeys registers string-typed context keys to be written to the logs when
+// logger.WithContext is used
 var LogKeys = [...]contextKey{SFSessionIDKey, SFSessionUserKey}
 
 // SFLogger Snowflake logger interface to expose FieldLogger defined in logrus

--- a/log_test.go
+++ b/log_test.go
@@ -292,8 +292,8 @@ func TestLogKeysWithRegisterContextVariableToLog(t *testing.T) {
 	sessionIDContextValue := "sessionID"
 	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIDContextValue)
 
-	userContextValue := "madison"
-	ctx = context.WithValue(ctx, SFSessionUserKey, sessionIDContextValue)
+	userContextValue := "testUser"
+	ctx = context.WithValue(ctx, SFSessionUserKey, userContextValue)
 
 	// test that RegisterContextVariableToLog works with non string keys
 	logKey := "REQUEST_ID"

--- a/log_test.go
+++ b/log_test.go
@@ -4,7 +4,9 @@ package gosnowflake
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -249,5 +251,75 @@ func TestLogLevelFunctions(t *testing.T) {
 		!strings.Contains(strbuf, "warning") &&
 		!strings.Contains(strbuf, "error") {
 		t.Fatalf("unexpected output in log: %v", strbuf)
+	}
+}
+
+type testRequestIdCtxKey struct{}
+
+func TestLogKeysDefault(t *testing.T) {
+	logger := CreateDefaultLogger()
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+
+	ctx := context.Background()
+
+	// set the sessionID on the context to see if we have it in the logs
+	sessionIdContextValue := "sessionID"
+	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIdContextValue)
+
+	userContextValue := "madison"
+	ctx = context.WithValue(ctx, SFSessionUserKey, userContextValue)
+
+	// base case (not using RegisterContextVariableToLog to add additional types )
+	logger.WithContext(ctx).Info("test")
+	var strbuf = buf.String()
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionIDKey, sessionIdContextValue)) {
+		t.Fatalf("expected that sfSessionIdKey would be in logs if logger.WithContext was used, but got: %v", strbuf)
+	}
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionUserKey, userContextValue)) {
+		t.Fatalf("expected that SFSessionUserKey would be in logs if logger.WithContext was used, but got: %v", strbuf)
+	}
+}
+
+func TestLogKeysWithRegisterContextVariableToLog(t *testing.T) {
+	logger := CreateDefaultLogger()
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+
+	ctx := context.Background()
+
+	// set the sessionID on the context to see if we have it in the logs
+	sessionIdContextValue := "sessionID"
+	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIdContextValue)
+
+	userContextValue := "madison"
+	ctx = context.WithValue(ctx, SFSessionUserKey, userContextValue)
+
+	// test that RegisterContextVariableToLog works with non string keys
+	logKey := "REQUEST_ID"
+	contextIntVal := 123
+	ctx = context.WithValue(ctx, testRequestIdCtxKey{}, contextIntVal)
+
+	getRequestKeyFunc := func(ctx context.Context) string {
+		if requestContext, ok := ctx.Value(testRequestIdCtxKey{}).(int); ok {
+			return fmt.Sprint(requestContext)
+		}
+		return ""
+	}
+
+	RegisterLogContextHook(logKey, getRequestKeyFunc)
+
+	// base case (not using RegisterContextVariableToLog to add additional types )
+	logger.WithContext(ctx).Info("test")
+	var strbuf = buf.String()
+
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionIDKey, sessionIdContextValue)) {
+		t.Fatalf("expected that sfSessionIdKey would be in logs if logger.WithContext and RegisterContextVariableToLog was used, but got: %v", strbuf)
+	}
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionUserKey, userContextValue)) {
+		t.Fatalf("expected that SFSessionUserKey would be in logs if logger.WithContext and RegisterContextVariableToLog was used, but got: %v", strbuf)
+	}
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", logKey, fmt.Sprint(contextIntVal))) {
+		t.Fatalf("expected that REQUEST_ID would be in logs if logger.WithContext and RegisterContextVariableToLog was used, but got: %v", strbuf)
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -254,7 +254,7 @@ func TestLogLevelFunctions(t *testing.T) {
 	}
 }
 
-type testRequestIdCtxKey struct{}
+type testRequestIDCtxKey struct{}
 
 func TestLogKeysDefault(t *testing.T) {
 	logger := CreateDefaultLogger()
@@ -264,8 +264,8 @@ func TestLogKeysDefault(t *testing.T) {
 	ctx := context.Background()
 
 	// set the sessionID on the context to see if we have it in the logs
-	sessionIdContextValue := "sessionID"
-	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIdContextValue)
+	sessionIDContextValue := "sessionID"
+	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIDContextValue)
 
 	userContextValue := "madison"
 	ctx = context.WithValue(ctx, SFSessionUserKey, userContextValue)
@@ -273,7 +273,7 @@ func TestLogKeysDefault(t *testing.T) {
 	// base case (not using RegisterContextVariableToLog to add additional types )
 	logger.WithContext(ctx).Info("test")
 	var strbuf = buf.String()
-	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionIDKey, sessionIdContextValue)) {
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionIDKey, sessionIDContextValue)) {
 		t.Fatalf("expected that sfSessionIdKey would be in logs if logger.WithContext was used, but got: %v", strbuf)
 	}
 	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionUserKey, userContextValue)) {
@@ -289,19 +289,19 @@ func TestLogKeysWithRegisterContextVariableToLog(t *testing.T) {
 	ctx := context.Background()
 
 	// set the sessionID on the context to see if we have it in the logs
-	sessionIdContextValue := "sessionID"
-	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIdContextValue)
+	sessionIDContextValue := "sessionID"
+	ctx = context.WithValue(ctx, SFSessionIDKey, sessionIDContextValue)
 
 	userContextValue := "madison"
-	ctx = context.WithValue(ctx, SFSessionUserKey, userContextValue)
+	ctx = context.WithValue(ctx, SFSessionUserKey, sessionIDContextValue)
 
 	// test that RegisterContextVariableToLog works with non string keys
 	logKey := "REQUEST_ID"
 	contextIntVal := 123
-	ctx = context.WithValue(ctx, testRequestIdCtxKey{}, contextIntVal)
+	ctx = context.WithValue(ctx, testRequestIDCtxKey{}, contextIntVal)
 
 	getRequestKeyFunc := func(ctx context.Context) string {
-		if requestContext, ok := ctx.Value(testRequestIdCtxKey{}).(int); ok {
+		if requestContext, ok := ctx.Value(testRequestIDCtxKey{}).(int); ok {
 			return fmt.Sprint(requestContext)
 		}
 		return ""
@@ -313,7 +313,7 @@ func TestLogKeysWithRegisterContextVariableToLog(t *testing.T) {
 	logger.WithContext(ctx).Info("test")
 	var strbuf = buf.String()
 
-	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionIDKey, sessionIdContextValue)) {
+	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionIDKey, sessionIDContextValue)) {
 		t.Fatalf("expected that sfSessionIdKey would be in logs if logger.WithContext and RegisterContextVariableToLog was used, but got: %v", strbuf)
 	}
 	if !strings.Contains(strbuf, fmt.Sprintf("%s=%s", SFSessionUserKey, userContextValue)) {

--- a/multistatement.go
+++ b/multistatement.go
@@ -51,7 +51,7 @@ func (sc *snowflakeConn) handleMultiExec(
 		if isDml(childResultType) {
 			childData, err := sc.getQueryResultResp(ctx, resultPath)
 			if err != nil {
-				logger.Errorf("error: %v", err)
+				logger.WithContext(ctx).Errorf("error: %v", err)
 				return nil, err
 			}
 			if childData != nil && !childData.Success {

--- a/restful.go
+++ b/restful.go
@@ -233,7 +233,7 @@ func postRestfulQueryHelper(
 	requestID UUID,
 	cfg *Config) (
 	data *execResponse, err error) {
-	logger.Infof("params: %v", params)
+	logger.WithContext(ctx).Infof("params: %v", params)
 	params.Add(requestIDKey, requestID.String())
 	params.Add(requestGUIDKey, NewUUID().String())
 	token, _, _ := sr.TokenAccessor.GetTokens()
@@ -281,7 +281,7 @@ func postRestfulQueryHelper(
 				fullURL = sr.getFullURL(respd.Data.GetResultURL, nil)
 			}
 
-			logger.Info("ping pong")
+			logger.WithContext(ctx).Info("ping pong")
 			token, _, _ = sr.TokenAccessor.GetTokens()
 			headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
 

--- a/retry.go
+++ b/retry.go
@@ -306,7 +306,7 @@ func (r *retryHTTP) execute() (res *http.Response, err error) {
 	var retryReasonUpdater retryReasonUpdater
 
 	for {
-		logger.Debugf("retry count: %v", retryCounter)
+		logger.WithContext(r.ctx).Debugf("retry count: %v", retryCounter)
 		body, err := r.bodyCreator()
 		if err != nil {
 			return nil, err

--- a/rows.go
+++ b/rows.go
@@ -137,7 +137,7 @@ func (rows *snowflakeRows) Columns() []string {
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
 		return make([]string, 0)
 	}
-	logger.Debug("Rows.Columns")
+	logger.WithContext(rows.ctx).Debug("Rows.Columns")
 	ret := make([]string, len(rows.ChunkDownloader.getRowType()))
 	for i, n := 0, len(rows.ChunkDownloader.getRowType()); i < n; i++ {
 		ret[i] = rows.ChunkDownloader.getRowType()[i].Name

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -62,7 +62,7 @@ func createCredentialCacheDir() {
 
 func setCredential(sc *snowflakeConn, credType, token string) {
 	if token == "" {
-		logger.Debug("no token provided")
+		logger.WithContext(sc.ctx).Debug("no token provided")
 	} else {
 		var target string
 		if runtime.GOOS == "windows" {
@@ -76,7 +76,7 @@ func setCredential(sc *snowflakeConn, credType, token string) {
 				Data: []byte(token),
 			}
 			if err := ring.Set(item); err != nil {
-				logger.Debugf("Failed to write to Windows credential manager. Err: %v", err)
+				logger.WithContext(sc.ctx).Debugf("Failed to write to Windows credential manager. Err: %v", err)
 			}
 		} else if runtime.GOOS == "darwin" {
 			target = convertTarget(sc.cfg.Host, sc.cfg.User, credType)
@@ -89,13 +89,13 @@ func setCredential(sc *snowflakeConn, credType, token string) {
 				Data: []byte(token),
 			}
 			if err := ring.Set(item); err != nil {
-				logger.Debugf("Failed to write to keychain. Err: %v", err)
+				logger.WithContext(sc.ctx).Debugf("Failed to write to keychain. Err: %v", err)
 			}
 		} else if runtime.GOOS == "linux" {
 			createCredentialCacheDir()
 			writeTemporaryCredential(sc, credType, token)
 		} else {
-			logger.Debug("OS not supported for Local Secure Storage")
+			logger.WithContext(sc.ctx).Debug("OS not supported for Local Secure Storage")
 		}
 	}
 }
@@ -111,7 +111,7 @@ func getCredential(sc *snowflakeConn, credType string) {
 		})
 		i, err := ring.Get(target)
 		if err != nil {
-			logger.Debugf("Failed to read target or could not find it in Windows Credential Manager. Error: %v", err)
+			logger.WithContext(sc.ctx).Debugf("Failed to read target or could not find it in Windows Credential Manager. Error: %v", err)
 		}
 		cred = string(i.Data)
 	} else if runtime.GOOS == "darwin" {
@@ -122,19 +122,19 @@ func getCredential(sc *snowflakeConn, credType string) {
 		account := strings.ToUpper(sc.cfg.User)
 		i, err := ring.Get(account)
 		if err != nil {
-			logger.Debugf("Failed to find the item in keychain or item does not exist. Error: %v", err)
+			logger.WithContext(sc.ctx).Debugf("Failed to find the item in keychain or item does not exist. Error: %v", err)
 		}
 		cred = string(i.Data)
 		if cred == "" {
-			logger.Debug("Returned credential is empty")
+			logger.WithContext(sc.ctx).Debug("Returned credential is empty")
 		} else {
-			logger.Debug("Successfully read token. Returning as string")
+			logger.WithContext(sc.ctx).Debug("Successfully read token. Returning as string")
 		}
 	} else if runtime.GOOS == "linux" {
 		createCredentialCacheDir()
 		cred = readTemporaryCredential(sc, credType)
 	} else {
-		logger.Debug("OS not supported for Local Secure Storage")
+		logger.WithContext(sc.ctx).Debug("OS not supported for Local Secure Storage")
 	}
 
 	if credType == idToken {
@@ -142,7 +142,7 @@ func getCredential(sc *snowflakeConn, credType string) {
 	} else if credType == mfaToken {
 		sc.cfg.MfaToken = cred
 	} else {
-		logger.Debugf("Unrecognized type %v for local cached credential", credType)
+		logger.WithContext(sc.ctx).Debugf("Unrecognized type %v for local cached credential", credType)
 	}
 }
 
@@ -155,7 +155,7 @@ func deleteCredential(sc *snowflakeConn, credType string) {
 		})
 		err := ring.Remove(target)
 		if err != nil {
-			logger.Debugf("Failed to delete target in Windows Credential Manager. Error: %v", err)
+			logger.WithContext(sc.ctx).Debugf("Failed to delete target in Windows Credential Manager. Error: %v", err)
 		}
 	} else if runtime.GOOS == "darwin" {
 		target = convertTarget(sc.cfg.Host, sc.cfg.User, credType)
@@ -165,7 +165,7 @@ func deleteCredential(sc *snowflakeConn, credType string) {
 		account := strings.ToUpper(sc.cfg.User)
 		err := ring.Remove(account)
 		if err != nil {
-			logger.Debugf("Failed to delete target in keychain. Error: %v", err)
+			logger.WithContext(sc.ctx).Debugf("Failed to delete target in keychain. Error: %v", err)
 		}
 	} else if runtime.GOOS == "linux" {
 		deleteTemporaryCredential(sc, credType)
@@ -180,9 +180,9 @@ func readTemporaryCredential(sc *snowflakeConn, credType string) string {
 	temporaryCredCacheLock.RUnlock()
 	cred := localCredCache[target]
 	if cred != "" {
-		logger.Debug("Successfully read token. Returning as string")
+		logger.WithContext(sc.ctx).Debug("Successfully read token. Returning as string")
 	} else {
-		logger.Debug("Returned credential is empty")
+		logger.WithContext(sc.ctx).Debug("Returned credential is empty")
 	}
 	return cred
 }
@@ -194,7 +194,7 @@ func writeTemporaryCredential(sc *snowflakeConn, credType, token string) {
 
 	j, err := json.Marshal(localCredCache)
 	if err != nil {
-		logger.Debugf("failed to convert credential to JSON.")
+		logger.WithContext(sc.ctx).Debugf("failed to convert credential to JSON.")
 	}
 	temporaryCredCacheLock.Lock()
 	writeTemporaryCacheFile(j)
@@ -203,13 +203,13 @@ func writeTemporaryCredential(sc *snowflakeConn, credType, token string) {
 
 func deleteTemporaryCredential(sc *snowflakeConn, credType string) {
 	if credCacheDir == "" {
-		logger.Debug("Cache file doesn't exist. Skipping deleting credential file.")
+		logger.WithContext(sc.ctx).Debug("Cache file doesn't exist. Skipping deleting credential file.")
 	} else {
 		target := convertTarget(sc.cfg.Host, sc.cfg.User, credType)
 		delete(localCredCache, target)
 		j, err := json.Marshal(localCredCache)
 		if err != nil {
-			logger.Debugf("failed to convert credential to JSON.")
+			logger.WithContext(sc.ctx).Debugf("failed to convert credential to JSON.")
 		}
 		temporaryCredCacheLock.Lock()
 		writeTemporaryCacheFile(j)


### PR DESCRIPTION
### Description

This will allow the user to set fields on the logs. This is needed because at the moment, the driver does not tag the requestID, so its extremely difficult to debug issues due to the fact that you cant tell which request a log is associated with. Some examples of useful data we could tag with this method includes: client side requestIDs, server side requestIDs given that `gosnowflake.WithRequestID` is used, and snowflake query ID given that we are are using the result reuse feature `gosnowflake.WithFetchResultByID`.

### Checklist
- [X] Extended the README / documentation, if necessary
