### PR TITLE
SNOW-1313927 Do not close channel twice in async handling

### DIFF
--- a/async.go
+++ b/async.go
@@ -102,7 +102,6 @@ func (sr *snowflakeRestful) getAsync(
 			if isMultiStmt(&respd.Data) {
 				if err = sc.handleMultiQuery(ctx, respd.Data, rows); err != nil {
 					rows.errChannel <- err
-					close(rows.errChannel)
 					return err
 				}
 			} else {
@@ -110,7 +109,6 @@ func (sr *snowflakeRestful) getAsync(
 			}
 			if err = rows.ChunkDownloader.start(); err != nil {
 				rows.errChannel <- err
-				close(rows.errChannel)
 				return err
 			}
 			rows.errChannel <- nil // mark query status complete


### PR DESCRIPTION
### Description

SNOW-1313927 Do not close channels that are closed by deferring closing.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
