### PR TITLE
fix panic when passing nil to time.Time.In()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -674,7 +674,7 @@ func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
 	if scd.sc != nil && scd.sc.cfg != nil {
 		return getCurrentLocation(scd.sc.cfg.Params)
 	}
-	return nil
+	return time.Now().Location()
 }
 func (scd *snowflakeArrowStreamChunkDownloader) TotalRows() int64 { return scd.Total }
 func (scd *snowflakeArrowStreamChunkDownloader) RowTypes() []execResponseRowType {

--- a/connection.go
+++ b/connection.go
@@ -674,7 +674,7 @@ func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
 	if scd.sc != nil && scd.sc.cfg != nil {
 		return getCurrentLocation(scd.sc.cfg.Params)
 	}
-	return time.UTC
+	return nil
 }
 func (scd *snowflakeArrowStreamChunkDownloader) TotalRows() int64 { return scd.Total }
 func (scd *snowflakeArrowStreamChunkDownloader) RowTypes() []execResponseRowType {

--- a/connection.go
+++ b/connection.go
@@ -671,10 +671,10 @@ type snowflakeArrowStreamChunkDownloader struct {
 }
 
 func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
-	if scd.sc != nil {
+	if scd.sc != nil && scd.sc.cfg != nil {
 		return getCurrentLocation(scd.sc.cfg.Params)
 	}
-	return nil
+	return time.UTC
 }
 func (scd *snowflakeArrowStreamChunkDownloader) TotalRows() int64 { return scd.Total }
 func (scd *snowflakeArrowStreamChunkDownloader) RowTypes() []execResponseRowType {

--- a/converter.go
+++ b/converter.go
@@ -316,6 +316,9 @@ func stringToValue(
 		}
 		loc := Location(int(offset) - 1440)
 		tt := time.Unix(sec, nsec)
+		if loc == nil {
+			loc = time.Now().Location()
+		}
 		*dest = tt.In(loc)
 		return nil
 	case "binary":
@@ -367,6 +370,9 @@ func arrowSnowflakeTimestampToTime(
 	scale int,
 	recIdx int,
 	loc *time.Location) *time.Time {
+	if loc == nil {
+		loc = time.Now().Location()
+	}
 
 	if column.IsNull(recIdx) {
 		return nil

--- a/converter.go
+++ b/converter.go
@@ -413,12 +413,18 @@ func arrowSnowflakeTimestampToTime(
 			epoch := extractEpoch(value[recIdx], scale)
 			fraction := extractFraction(value[recIdx], scale)
 			locTz := Location(int(timezone[recIdx]) - 1440)
+			if locTz == nil {
+				locTz = time.Now().Location()
+			}
 			ret = time.Unix(epoch, fraction).In(locTz)
 		} else {
 			epoch := structData.Field(0).(*array.Int64).Int64Values()
 			fraction := structData.Field(1).(*array.Int32).Int32Values()
 			timezone := structData.Field(2).(*array.Int32).Int32Values()
 			locTz := Location(int(timezone[recIdx]) - 1440)
+			if locTz == nil {
+				locTz = time.Now().Location()
+			}
 			ret = time.Unix(epoch[recIdx], int64(fraction[recIdx])).In(locTz)
 		}
 	}

--- a/converter.go
+++ b/converter.go
@@ -316,9 +316,6 @@ func stringToValue(
 		}
 		loc := Location(int(offset) - 1440)
 		tt := time.Unix(sec, nsec)
-		if loc == nil {
-			loc = time.Now().Location()
-		}
 		*dest = tt.In(loc)
 		return nil
 	case "binary":


### PR DESCRIPTION
### Description

SNOW-XXX Please explain the changes you made here.
When time.Time.In is used, if a nil is passed in it will panic. ([See docs](https://www.geeksforgeeks.org/time-time-in-function-in-golang-with-examples/#:~:text=for%20display%20uses-,.%20And%20if%20%E2%80%9Cloc%E2%80%9D%20is%20nil%20then%20panic%20is%20returned.,-Pause)) In the other functions in converter.go (see stringToValue timestamp_ltz) if the loc is nil a default will be used. 

* Bug was introduced in [this](https://github.com/snowflakedb/gosnowflake/commit/3a295547f478bda564c3943b5e1f5d61a525437b) pr

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
