### PR TITLE
SNOW-1313544 temporal credential cache map race

### DIFF
--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -190,13 +190,13 @@ func readTemporaryCredential(sc *snowflakeConn, credType string) string {
 // Writes to temporary credential file when OS is Linux.
 func writeTemporaryCredential(sc *snowflakeConn, credType, token string) {
 	target := convertTarget(sc.cfg.Host, sc.cfg.User, credType)
+	temporaryCredCacheLock.Lock()
 	localCredCache[target] = token
 
 	j, err := json.Marshal(localCredCache)
 	if err != nil {
 		logger.Debugf("failed to convert credential to JSON.")
 	}
-	temporaryCredCacheLock.Lock()
 	writeTemporaryCacheFile(j)
 	temporaryCredCacheLock.Unlock()
 }
@@ -206,12 +206,12 @@ func deleteTemporaryCredential(sc *snowflakeConn, credType string) {
 		logger.Debug("Cache file doesn't exist. Skipping deleting credential file.")
 	} else {
 		target := convertTarget(sc.cfg.Host, sc.cfg.User, credType)
+		temporaryCredCacheLock.Lock()
 		delete(localCredCache, target)
 		j, err := json.Marshal(localCredCache)
 		if err != nil {
 			logger.Debugf("failed to convert credential to JSON.")
 		}
-		temporaryCredCacheLock.Lock()
 		writeTemporaryCacheFile(j)
 		temporaryCredCacheLock.Unlock()
 	}

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -27,7 +27,7 @@ var (
 )
 
 var (
-	temporaryCredCacheLock sync.RWMutex
+	credCacheLock sync.RWMutex
 )
 
 func createCredentialCacheDir() {
@@ -175,9 +175,9 @@ func deleteCredential(sc *snowflakeConn, credType string) {
 // Reads temporary credential file when OS is Linux.
 func readTemporaryCredential(sc *snowflakeConn, credType string) string {
 	target := convertTarget(sc.cfg.Host, sc.cfg.User, credType)
-	temporaryCredCacheLock.Lock()
+	credCacheLock.Lock()
+	defer credCacheLock.Unlock()
 	localCredCache := readTemporaryCacheFile()
-	temporaryCredCacheLock.Unlock()
 	cred := localCredCache[target]
 	if cred != "" {
 		logger.Debug("Successfully read token. Returning as string")
@@ -190,7 +190,8 @@ func readTemporaryCredential(sc *snowflakeConn, credType string) string {
 // Writes to temporary credential file when OS is Linux.
 func writeTemporaryCredential(sc *snowflakeConn, credType, token string) {
 	target := convertTarget(sc.cfg.Host, sc.cfg.User, credType)
-	temporaryCredCacheLock.Lock()
+	credCacheLock.Lock()
+	defer credCacheLock.Unlock()
 	localCredCache[target] = token
 
 	j, err := json.Marshal(localCredCache)
@@ -198,14 +199,14 @@ func writeTemporaryCredential(sc *snowflakeConn, credType, token string) {
 		logger.Debugf("failed to convert credential to JSON.")
 	}
 	writeTemporaryCacheFile(j)
-	temporaryCredCacheLock.Unlock()
 }
 
 func deleteTemporaryCredential(sc *snowflakeConn, credType string) {
 	if credCacheDir == "" {
 		logger.Debug("Cache file doesn't exist. Skipping deleting credential file.")
 	} else {
-		temporaryCredCacheLock.Lock()
+		credCacheLock.Lock()
+		defer credCacheLock.Unlock()
 		target := convertTarget(sc.cfg.Host, sc.cfg.User, credType)
 		delete(localCredCache, target)
 		j, err := json.Marshal(localCredCache)
@@ -213,7 +214,6 @@ func deleteTemporaryCredential(sc *snowflakeConn, credType string) {
 			logger.Debugf("failed to convert credential to JSON.")
 		}
 		writeTemporaryCacheFile(j)
-		temporaryCredCacheLock.Unlock()
 	}
 }
 

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -196,7 +196,8 @@ func writeTemporaryCredential(sc *snowflakeConn, credType, token string) {
 
 	j, err := json.Marshal(localCredCache)
 	if err != nil {
-		logger.Debugf("failed to convert credential to JSON.")
+		logger.Warnf("failed to convert credential to JSON.")
+		return
 	}
 	writeTemporaryCacheFile(j)
 }
@@ -211,7 +212,8 @@ func deleteTemporaryCredential(sc *snowflakeConn, credType string) {
 		delete(localCredCache, target)
 		j, err := json.Marshal(localCredCache)
 		if err != nil {
-			logger.Debugf("failed to convert credential to JSON.")
+			logger.Warnf("failed to convert credential to JSON.")
+			return
 		}
 		writeTemporaryCacheFile(j)
 	}

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -27,7 +27,8 @@ var (
 )
 
 var (
-	temporaryCredCacheLock sync.RWMutex
+	temporaryCredCacheLock     sync.RWMutex
+	temporaryCredCacheFileLock sync.RWMutex
 )
 
 func createCredentialCacheDir() {
@@ -222,6 +223,9 @@ func readTemporaryCacheFile() map[string]string {
 		logger.Debug("Cache file doesn't exist. Skipping reading credential file.")
 		return nil
 	}
+	temporaryCredCacheFileLock.RLock()
+	defer temporaryCredCacheFileLock.RUnlock()
+
 	jsonData, err := os.ReadFile(credCache)
 	if err != nil {
 		logger.Debugf("Failed to read credential file: %v", err)
@@ -240,6 +244,9 @@ func writeTemporaryCacheFile(input []byte) {
 	if credCache == "" {
 		logger.Debug("Cache file doesn't exist. Skipping writing temporary credential file.")
 	} else {
+		temporaryCredCacheFileLock.Lock()
+		defer temporaryCredCacheFileLock.Unlock()
+
 		logger.Debugf("writing credential cache file. %v\n", credCache)
 		credCacheLockFileName := credCache + ".lck"
 		err := os.Mkdir(credCacheLockFileName, 0600)


### PR DESCRIPTION
SNOW-1313544 Parallel operations on different roles cause program to crash (race condition on temporal credential cache)
Discovered in a Terraform use-case, where there's a lot of resources handled by the Snowflake Terraform Provider 

* moving locks a bit ahead (delete on map happened before lock)
* write-lock instead of read-lock when reading the credentials