### PR TITLE
SNOW-1260011: mask password in the logs

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -298,7 +298,7 @@ func (sc *snowflakeConn) ExecContext(
 	query string,
 	args []driver.NamedValue) (
 	driver.Result, error) {
-	logger.WithContext(ctx).Infof("Exec: %#v, %v", query, args)
+	logger.WithContext(ctx).Infof("Exec: %#v, %v", maskSecrets(query), args)
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}
@@ -385,7 +385,7 @@ func (sc *snowflakeConn) queryContextInternal(
 	query string,
 	args []driver.NamedValue) (
 	driver.Rows, error) {
-	logger.WithContext(ctx).Infof("Query: %#v, %v", query, args)
+	logger.WithContext(ctx).Infof("Query: %#v, %v", maskSecrets(query), args)
 	if sc.rest == nil {
 		return nil, driver.ErrBadConn
 	}

--- a/log_test.go
+++ b/log_test.go
@@ -323,3 +323,20 @@ func TestLogKeysWithRegisterContextVariableToLog(t *testing.T) {
 		t.Fatalf("expected that REQUEST_ID would be in logs if logger.WithContext and RegisterContextVariableToLog was used, but got: %v", strbuf)
 	}
 }
+
+func TestLogMaskSecrets(t *testing.T) {
+	logger := CreateDefaultLogger()
+	buf := &bytes.Buffer{}
+	logger.SetOutput(buf)
+
+	ctx := context.Background()
+	query := "create user testuser password='testpassword'"
+	logger.WithContext(ctx).Infof("Query: %#v", maskSecrets(query))
+
+	// verify output
+	expected := "create user testuser password='****"
+	var strbuf = buf.String()
+	if !strings.Contains(strbuf, expected) {
+		t.Fatalf("expected that password would be masked. WithContext was used, but got: %v", strbuf)
+	}
+}


### PR DESCRIPTION
### Description

issue: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/936
SNOW-1260011: [gosnowflake] Driver exposes password in the logs

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
