### PR TITLE
doc: fixed minor typo in runbook-update-ca-certs.md

### DIFF
--- a/doc/runbook-update-ca-certs.md
+++ b/doc/runbook-update-ca-certs.md
@@ -40,8 +40,9 @@ const caRootPEM = `
 `
 ```
 
-replace the part represented by `..certs` above, with the whole content of the `cacerts.pem` which you downloaded. 
-5. Save the edited file and create a PR. 
+replace the part represented by `..certs` above, with the whole content of the `cacerts.pem` which you downloaded.
+
+6. Save the edited file and create a PR.
 
 #### Things to watch out for:
 * Make sure you retain the enclosing opening and closing backticks around the actual CA cert bundle


### PR DESCRIPTION
### Description

- Serial number for instruction to `save file and submit PR`
should be 6, instead of 5.

- Added new line before 6th instruction to improve formatting.
Previously 6th instruction didn't appear on a newline.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
