### PR TITLE
Add log to debug null pointer deference

### DIFF
--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -458,6 +458,13 @@ func decodeChunk(ctx context.Context, scd *snowflakeChunkDownloader, idx int, bu
 			return nil
 		}
 		highPrec := higherPrecisionEnabled(scd.ctx)
+		if scd.sc == nil {
+			logger.WithContext(ctx).Error("null pointer debug: null connection on chunk downloader")
+		} else {
+			if scd.sc.cfg == nil {
+				logger.WithContext(ctx).Error("null pointer debug: null config on chunk downloader's connection")
+			}
+		}
 		respd, err = arc.decodeArrowChunk(ctx, scd.RowSet.RowType, highPrec, scd.sc.cfg.Params)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description

We are seeing a decent amount of panics in the chunk downloader. The panic looks like this 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x1d0fbd3]

goroutine 149662 [running]:
github.com/snowflakedb/gosnowflake.decodeChunk({0x291d658, 0xc00235b3b0}, 0xc003c9cc00, 0xa, 0xc002540000)
	/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.9.1-0.20240419071412-c8216932b807/chunk_downloader.go:461 +0x593
github.com/snowflakedb/gosnowflake.downloadChunkHelper({0x291d658, 0xc00235b3b0}, 0xc003c9cc00, 0xa)
	/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.9.1-0.20240419071412-c8216932b807/chunk_downloader.go:392 +0x88e
github.com/snowflakedb/gosnowflake.downloadChunk({0x291d658, 0xc00235b3b0}, 0xc003c9cc00, 0xa)
	/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.9.1-0.20240419071412-c8216932b807/chunk_downloader.go:348 +0x147
created by github.com/snowflakedb/gosnowflake.(*snowflakeChunkDownloader).schedule
	/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.9.1-0.20240419071412-c8216932b807/chunk_downloader.go:151 +0x187
````
I know that something on the downloader's connection is null. Either the connection itself or the cfg. This is the only way for me to really know 