### PR TITLE
[bug fix] objectType should work w/ or wo/ ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -2087,7 +2087,7 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 		if stringCol, ok := col.(*array.String); ok {
 			newValidUtf8Array := arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
 			if newValidUtf8Array != nil {
-				newCol = *newValidUtf8Array
+				newCol = newValidUtf8Array
 			}
 		} else {
 			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake textType", col)
@@ -2114,7 +2114,7 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 		} else if stringCol, ok := col.(*array.String); ok {
 			newValidUtf8Array := arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
 			if newValidUtf8Array != nil {
-				newCol = *newValidUtf8Array
+				newCol = newValidUtf8Array
 			}
 		} else {
 			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake objectType", col)
@@ -2132,7 +2132,7 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 		} else if stringCol, ok := col.(*array.String); ok {
 			newValidUtf8Array := arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
 			if newValidUtf8Array != nil {
-				newCol = *newValidUtf8Array
+				newCol = newValidUtf8Array
 			}
 		} else {
 			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake objectType", col)
@@ -2172,7 +2172,7 @@ func arrowStringRecordToColumn(
 	mem memory.Allocator,
 	numRows int64,
 	fieldMetadata fieldMetadata,
-) *arrow.Array {
+) arrow.Array {
 	if arrowBatchesUtf8ValidationEnabled(ctx) && stringCol.DataType().ID() == arrow.STRING {
 		tb := array.NewStringBuilder(mem)
 		defer tb.Release()
@@ -2190,7 +2190,7 @@ func arrowStringRecordToColumn(
 			}
 		}
 		arr := tb.NewArray()
-		return &arr
+		return arr
 	}
 	stringCol.Retain()
 	return nil

--- a/converter.go
+++ b/converter.go
@@ -2144,6 +2144,8 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 			} else {
 				col.Retain()
 			}
+		} else {
+			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake objectType", col)
 		}
 	case arrayType:
 		if listCol, ok := col.(*array.List); ok {


### PR DESCRIPTION
### Description

If we get a snowflake object type, but we haven't set the flag `ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE`, the code will panic because we are only setting the record on the batch if the snowflake type matches the expected arrow type. This will add support for the underlying type to be either structured or string for snowflake objectType, and if its neither, we will return an error with the underlying type rather than panic so we can fix it

### Checklist
- [X] Created tests which fail without the change (if possible)
   - `TestStructuredTypeInArrowBatchesWithoutEnablingStructureTypes`: check that we can have an object type without setting structured types flag
   - `TestNullObject`: ensure that we can have a null object. (This is what was failing in my test suite; ultimately this isn't the actual trigger of the panic, but its still good to test because it could be one day)
- [NA] Extended the README / documentation, if necessary
