### PR TITLE
[bug fix] objectType should work w/ or wo/ ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE 

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -2023,8 +2023,6 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 			builder.AppendValues(floatValues, nil)
 			newCol = builder.NewArray()
 			builder.Release()
-		} else {
-			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake mapType", col)
 		}
 	case timeType:
 		newCol, err = compute.CastArray(ctx, col, compute.SafeCastOptions(arrow.FixedWidthTypes.Time64ns))
@@ -2088,8 +2086,6 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 	case textType:
 		if stringCol, ok := col.(*array.String); ok {
 			newCol = arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
-		} else {
-			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake textType", col)
 		}
 	case objectType:
 		if structCol, ok := col.(*array.Struct); ok {
@@ -2112,8 +2108,6 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 			return array.NewStructArrayWithNulls(internalCols, fieldNames, nullBitmap, numberOfNulls, 0)
 		} else if stringCol, ok := col.(*array.String); ok {
 			newCol = arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
-		} else {
-			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake objectType", col)
 		}
 	case arrayType:
 		if listCol, ok := col.(*array.List); ok {
@@ -2127,8 +2121,6 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 			return array.NewListData(newData), nil
 		} else if stringCol, ok := col.(*array.String); ok {
 			newCol = arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
-		} else {
-			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake objectType", col)
 		}
 	case mapType:
 		if mapCol, ok := col.(*array.Map); ok {
@@ -2153,8 +2145,6 @@ func arrowToRecordSingleColumn(ctx context.Context, field arrow.Field, col arrow
 			return array.NewMapData(newData), nil
 		} else if stringCol, ok := col.(*array.String); ok {
 			newCol = arrowStringRecordToColumn(ctx, stringCol, pool, numRows, fieldMetadata)
-		} else {
-			return nil, fmt.Errorf("unsupported arrow type %T when trying to convert a snowflake mapType", col)
 		}
 	default:
 		col.Retain()
@@ -2190,9 +2180,8 @@ func arrowStringRecordToColumn(
 		arr := tb.NewArray()
 		return arr
 	}
-	var asGenericArray arrow.Array = stringCol
-	asGenericArray.Retain()
-	return asGenericArray
+	stringCol.Retain()
+	return stringCol
 }
 
 func recordToSchema(sc *arrow.Schema, rowType []execResponseRowType, loc *time.Location, timestampOption snowflakeArrowBatchesTimestampOption, withHigherPrecision bool) (*arrow.Schema, error) {

--- a/structured_type_read_test.go
+++ b/structured_type_read_test.go
@@ -1621,3 +1621,157 @@ func forAllStructureTypeFormats(dbt *DBTest, f func(t *testing.T, format string)
 		})
 	}
 }
+
+func TestSelectingNullObjectsInArrowBatches(t *testing.T) {
+	testcases := []string{
+		"select null::object(v VARCHAR)",
+		"select null::object",
+	}
+	skipStructuredTypesTestsOnGHActions(t)
+	runDBTest(t, func(dbt *DBTest) {
+		for _, tc := range testcases {
+			t.Run(tc, func(t *testing.T) {
+				pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+				defer pool.AssertSize(t, 0)
+				ctx := WithArrowBatches(WithArrowAllocator(context.Background(), pool))
+
+				var err error
+				var rows driver.Rows
+				err = dbt.conn.Raw(func(sc any) error {
+					queryer, implementsQueryContext := sc.(driver.QueryerContext)
+					assertTrueF(t, implementsQueryContext, "snowflake conn does not implement QueryerContext but needs to")
+					rows, err = queryer.QueryContext(ctx, tc, nil)
+					return err
+				})
+				assertNilF(t, err, fmt.Sprintf("test failed to run the following query: %s", tc))
+				defer rows.Close()
+
+				sfRows, isSfRows := rows.(SnowflakeRows)
+				assertTrueF(t, isSfRows, "rows are not snowflakeRows")
+
+				batches, err := sfRows.GetArrowBatches()
+				assertNilF(t, err)
+				assertNotEqualF(t, len(batches), 0)
+				batch, err := batches[0].Fetch()
+				assertNilF(t, err)
+				assertNotEqualF(t, len(*batch), 0)
+				for _, record := range *batch {
+					// check number of cols/rows so we dont get index out of range
+					assertEqualF(t, record.NumRows(), int64(1), "wrong number of rows")
+					assertEqualF(t, record.NumCols(), int64(1), "wrong number of cols")
+
+					colIndex := 0
+					rowIndex := 0
+
+					srtCol, isStrCol := record.Column(colIndex).(*array.String)
+					assertTrueF(t, isStrCol, "column is not type string")
+
+					assertEqualE(t, srtCol.Value(rowIndex), "")
+					isNull := srtCol.IsNull(rowIndex)
+					assertTrueF(t, isNull)
+					record.Release()
+				}
+
+			})
+		}
+	})
+}
+
+func TestSelectingSemistructuredObjectInArrowBatches(t *testing.T) {
+	testcases := []struct {
+		name               string
+		query              string
+		expected           string
+		withUtf8Validation bool
+	}{
+		{
+			name:               "test semistructured object in arrow batch with utf8 validation, snowflakeType = objectType",
+			withUtf8Validation: true,
+			expected:           `{"s":"someString"}`,
+			query:              "SELECT {'s':'someString'}::OBJECT",
+		},
+		{
+			name:               "test semistructured object in arrow batch without utf8 validation, snowflakeType = objectType",
+			withUtf8Validation: false,
+			expected:           `{"s":"someString"}`,
+			query:              "SELECT {'s':'someString'}::OBJECT",
+		},
+		{
+			name:               "test semistructured object in arrow batch without utf8 validation, snowflakeType = arrayType",
+			withUtf8Validation: false,
+			expected:           `[1,2,3]`,
+			query:              "SELECT [1, 2, 3]::ARRAY",
+		},
+		{
+			name:               "test semistructured object in arrow batch with utf8 validation, snowflakeType = arrayType",
+			withUtf8Validation: true,
+			expected:           `[1,2,3]`,
+			query:              "SELECT [1, 2, 3]::ARRAY",
+		},
+	}
+	skipStructuredTypesTestsOnGHActions(t)
+	runDBTest(t, func(dbt *DBTest) {
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+
+				pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+				defer pool.AssertSize(t, 0)
+				ctx := WithArrowBatches(WithArrowAllocator(context.Background(), pool))
+				if tc.withUtf8Validation {
+					ctx = WithArrowBatchesUtf8Validation(ctx)
+				}
+
+				var err error
+				var rows driver.Rows
+				err = dbt.conn.Raw(func(sc any) error {
+					queryer, implementsQueryContext := sc.(driver.QueryerContext)
+					assertTrueF(t, implementsQueryContext, "snowflake conn does not implement QueryerContext but needs to")
+					rows, err = queryer.QueryContext(ctx, tc.query, nil)
+					return err
+				})
+				assertNilF(t, err)
+				defer rows.Close()
+
+				sfRows, isSfRows := rows.(SnowflakeRows)
+				assertTrueF(t, isSfRows, "rows are not snowflakeRows")
+
+				batches, err := sfRows.GetArrowBatches()
+				assertNilF(t, err)
+				assertNotEqualF(t, len(batches), 0)
+				batch, err := batches[0].Fetch()
+				assertNilF(t, err)
+				assertNotEqualF(t, len(*batch), 0)
+				for _, record := range *batch {
+					assertEqualF(t, record.NumCols(), int64(1), "unexpected number of columns")
+					assertEqualF(t, record.NumRows(), int64(1), "unexpected number of rows")
+
+					curColIndex := 0
+					rowIndex := 0
+
+					// The underlying data may be struct, or it could be string. Either way is ok but lets not fail
+					stringCol, isString := record.Column(curColIndex).(*array.String)
+					structCol, isStruct := record.Column(curColIndex).(*array.Struct)
+
+					structOrString := isString || isStruct
+					assertTrueF(t, structOrString, "wrong type for column, expected struct or string")
+
+					if isString {
+						assertEqualIgnoringWhitespaceE(t, stringCol.Value(rowIndex), tc.expected)
+					}
+
+					if isStruct {
+						fullStruct := structCol.Field(rowIndex)
+						stringCol, isString := fullStruct.(*array.String)
+						assertTrueF(t, isString, "wrong type for column, expected string")
+
+						assertEqualE(t, stringCol.Value(0), "someString")
+					}
+
+					record.Release()
+				}
+			})
+		}
+
+	})
+}
+

--- a/structured_type_read_test.go
+++ b/structured_type_read_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/apache/arrow/go/v15/arrow/array"
 	"github.com/apache/arrow/go/v15/arrow/memory"
@@ -1774,4 +1775,3 @@ func TestSelectingSemistructuredObjectInArrowBatches(t *testing.T) {
 
 	})
 }
-

--- a/structured_type_read_test.go
+++ b/structured_type_read_test.go
@@ -1678,7 +1678,7 @@ func TestSelectingNullObjectsInArrowBatches(t *testing.T) {
 	})
 }
 
-func TestSelectingSemistructuredObjectInArrowBatches(t *testing.T) {
+func TestSelectingSemistructuredTypesInArrowBatches(t *testing.T) {
 	testcases := []struct {
 		name               string
 		query              string
@@ -1751,22 +1751,9 @@ func TestSelectingSemistructuredObjectInArrowBatches(t *testing.T) {
 
 					// The underlying data may be struct, or it could be string. Either way is ok but lets not fail
 					stringCol, isString := record.Column(curColIndex).(*array.String)
-					structCol, isStruct := record.Column(curColIndex).(*array.Struct)
 
-					structOrString := isString || isStruct
-					assertTrueF(t, structOrString, "wrong type for column, expected struct or string")
-
-					if isString {
-						assertEqualIgnoringWhitespaceE(t, stringCol.Value(rowIndex), tc.expected)
-					}
-
-					if isStruct {
-						fullStruct := structCol.Field(rowIndex)
-						stringCol, isString := fullStruct.(*array.String)
-						assertTrueF(t, isString, "wrong type for column, expected string")
-
-						assertEqualE(t, stringCol.Value(0), "someString")
-					}
+					assertTrueF(t, isString, "wrong type for column, expected string")
+					assertEqualIgnoringWhitespaceE(t, stringCol.Value(rowIndex), tc.expected)
 
 					record.Release()
 				}


### PR DESCRIPTION
### Description

If we get a snowflake object type, but we haven't set the flag `ENABLE_STRUCTURED_TYPES_IN_CLIENT_RESPONSE`, the code will panic because we are only setting the record on the batch if the snowflake type matches the expected arrow type. This will add support for the underlying type to be either structured or string for snowflake objectType, and if its neither, we will return an error with the underlying type rather than panic so we can fix it

### Checklist
- [X] Created tests which fail without the change (if possible)
   - `TestStructuredTypeInArrowBatchesWithoutEnablingStructureTypes`: check that we can have an object type without setting structured types flag
   - `TestNullObject`: ensure that we can have a null object. (This is what was failing in my test suite; ultimately this isn't the actual trigger of the panic, but its still good to test because it could be one day)
- [NA] Extended the README / documentation, if necessary
