### PR TITLE
SNOW-1432112 verify / sanitize account name before creating JWT

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -480,7 +480,7 @@ func prepareJWTToken(config *Config) (string, error) {
 	}
 	hash := sha256.Sum256(pubBytes)
 
-	accountName := strings.ToUpper(config.Account)
+	accountName := getAccountForJWT(config.Account)
 	userName := strings.ToUpper(config.User)
 
 	issueAtTime := time.Now().UTC()
@@ -571,4 +571,12 @@ func fillCachedIDToken(sc *snowflakeConn) {
 
 func fillCachedMfaToken(sc *snowflakeConn) {
 	getCredential(sc, mfaToken)
+}
+
+func getAccountForJWT(accountName string) string {
+	posDot := strings.Index(accountName, ".")
+	if posDot > 0 {
+		return strings.ToUpper(accountName[:posDot])
+	}
+	return strings.ToUpper(accountName)
 }

--- a/auth.go
+++ b/auth.go
@@ -480,7 +480,7 @@ func prepareJWTToken(config *Config) (string, error) {
 	}
 	hash := sha256.Sum256(pubBytes)
 
-	accountName := getAccountForJWT(config.Account)
+	accountName := extractAccountName(config.Account)
 	userName := strings.ToUpper(config.User)
 
 	issueAtTime := time.Now().UTC()
@@ -571,12 +571,4 @@ func fillCachedIDToken(sc *snowflakeConn) {
 
 func fillCachedMfaToken(sc *snowflakeConn) {
 	getCredential(sc, mfaToken)
-}
-
-func getAccountForJWT(accountName string) string {
-	posDot := strings.Index(accountName, ".")
-	if posDot > 0 {
-		return strings.ToUpper(accountName[:posDot])
-	}
-	return strings.ToUpper(accountName)
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -927,7 +927,7 @@ func TestOktaRetryWithNewToken(t *testing.T) {
 }
 
 func TestGetAccountForJWT(t *testing.T) {
-	accounts := map[string]string{
+	testcases := map[string]string{
 		"myaccount":                          "MYACCOUNT",
 		"myaccount.eu-central-1":             "MYACCOUNT",
 		"myaccount.eu-central-1.privatelink": "MYACCOUNT",
@@ -939,7 +939,13 @@ func TestGetAccountForJWT(t *testing.T) {
 		"myorg-my_account.privatelink":       "MYORG-MY_ACCOUNT",
 	}
 
-	for account, expected := range accounts {
-		assertEqualF(t, getAccountForJWT(account), expected)
+	for account, expected := range testcases {
+		t.Run(fmt.Sprintf("Validating account part for identifier %v", account),
+			func(t *testing.T) {
+				accountPart := getAccountForJWT(account)
+				if accountPart != expected {
+					t.Fatalf("getAccountForJWT returned unexpected response (%v), should be %v", accountPart, expected)
+				}
+			})
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -925,3 +925,21 @@ func TestOktaRetryWithNewToken(t *testing.T) {
 	assertEqualF(t, authResponse.MfaToken, expectedMfaToken)
 	assertEqualF(t, authResponse.SessionInfo.DatabaseName, expectedDatabaseName)
 }
+
+func TestGetAccountForJWT(t *testing.T) {
+	accounts := map[string]string{
+		"myaccount":                          "MYACCOUNT",
+		"myaccount.eu-central-1":             "MYACCOUNT",
+		"myaccount.eu-central-1.privatelink": "MYACCOUNT",
+		"myorg-myaccount":                    "MYORG-MYACCOUNT",
+		"myorg-myaccount.privatelink":        "MYORG-MYACCOUNT",
+		"myorg-my-account":                   "MYORG-MY-ACCOUNT",
+		"myorg-my-account.privatelink":       "MYORG-MY-ACCOUNT",
+		"myorg-my_account":                   "MYORG-MY_ACCOUNT",
+		"myorg-my_account.privatelink":       "MYORG-MY_ACCOUNT",
+	}
+
+	for account, expected := range accounts {
+		assertEqualF(t, getAccountForJWT(account), expected)
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -940,7 +940,7 @@ func TestGetAccountForJWT(t *testing.T) {
 	}
 
 	for account, expected := range testcases {
-		t.Run(fmt.Sprintf("Validating account part for identifier %v", account),
+		t.Run(fmt.Sprintf("%v", account),
 			func(t *testing.T) {
 				accountPart := getAccountForJWT(account)
 				if accountPart != expected {

--- a/auth_test.go
+++ b/auth_test.go
@@ -926,7 +926,7 @@ func TestOktaRetryWithNewToken(t *testing.T) {
 	assertEqualF(t, authResponse.SessionInfo.DatabaseName, expectedDatabaseName)
 }
 
-func TestGetAccountForJWT(t *testing.T) {
+func TestExtractAccountName(t *testing.T) {
 	testcases := map[string]string{
 		"myaccount":                          "MYACCOUNT",
 		"myaccount.eu-central-1":             "MYACCOUNT",
@@ -941,9 +941,9 @@ func TestGetAccountForJWT(t *testing.T) {
 
 	for account, expected := range testcases {
 		t.Run(account, func(t *testing.T) {
-			accountPart := getAccountForJWT(account)
+			accountPart := extractAccountName(account)
 			if accountPart != expected {
-				t.Fatalf("getAccountForJWT returned unexpected response (%v), should be %v", accountPart, expected)
+				t.Fatalf("extractAccountName returned unexpected response (%v), should be %v", accountPart, expected)
 			}
 		})
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -940,12 +940,11 @@ func TestGetAccountForJWT(t *testing.T) {
 	}
 
 	for account, expected := range testcases {
-		t.Run(fmt.Sprintf("%v", account),
-			func(t *testing.T) {
-				accountPart := getAccountForJWT(account)
-				if accountPart != expected {
-					t.Fatalf("getAccountForJWT returned unexpected response (%v), should be %v", accountPart, expected)
-				}
-			})
+		t.Run(account, func(t *testing.T) {
+			accountPart := getAccountForJWT(account)
+			if accountPart != expected {
+				t.Fatalf("getAccountForJWT returned unexpected response (%v), should be %v", accountPart, expected)
+			}
+		})
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -925,26 +925,3 @@ func TestOktaRetryWithNewToken(t *testing.T) {
 	assertEqualF(t, authResponse.MfaToken, expectedMfaToken)
 	assertEqualF(t, authResponse.SessionInfo.DatabaseName, expectedDatabaseName)
 }
-
-func TestExtractAccountName(t *testing.T) {
-	testcases := map[string]string{
-		"myaccount":                          "MYACCOUNT",
-		"myaccount.eu-central-1":             "MYACCOUNT",
-		"myaccount.eu-central-1.privatelink": "MYACCOUNT",
-		"myorg-myaccount":                    "MYORG-MYACCOUNT",
-		"myorg-myaccount.privatelink":        "MYORG-MYACCOUNT",
-		"myorg-my-account":                   "MYORG-MY-ACCOUNT",
-		"myorg-my-account.privatelink":       "MYORG-MY-ACCOUNT",
-		"myorg-my_account":                   "MYORG-MY_ACCOUNT",
-		"myorg-my_account.privatelink":       "MYORG-MY_ACCOUNT",
-	}
-
-	for account, expected := range testcases {
-		t.Run(account, func(t *testing.T) {
-			accountPart := extractAccountName(account)
-			if accountPart != expected {
-				t.Fatalf("extractAccountName returned unexpected response (%v), should be %v", accountPart, expected)
-			}
-		})
-	}
-}

--- a/dsn.go
+++ b/dsn.go
@@ -907,3 +907,11 @@ func parsePrivateKeyFromFile(path string) (*rsa.PrivateKey, error) {
 	}
 	return pk, nil
 }
+
+func extractAccountName(rawAccount string) string {
+	posDot := strings.Index(rawAccount, ".")
+	if posDot > 0 {
+		return strings.ToUpper(rawAccount[:posDot])
+	}
+	return strings.ToUpper(rawAccount)
+}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1616,3 +1616,26 @@ func TestConfigValidateTmpDirPath(t *testing.T) {
 		t.Fatalf("Should fail on not existing TmpDirPath")
 	}
 }
+
+func TestExtractAccountName(t *testing.T) {
+	testcases := map[string]string{
+		"myaccount":                          "MYACCOUNT",
+		"myaccount.eu-central-1":             "MYACCOUNT",
+		"myaccount.eu-central-1.privatelink": "MYACCOUNT",
+		"myorg-myaccount":                    "MYORG-MYACCOUNT",
+		"myorg-myaccount.privatelink":        "MYORG-MYACCOUNT",
+		"myorg-my-account":                   "MYORG-MY-ACCOUNT",
+		"myorg-my-account.privatelink":       "MYORG-MY-ACCOUNT",
+		"myorg-my_account":                   "MYORG-MY_ACCOUNT",
+		"myorg-my_account.privatelink":       "MYORG-MY_ACCOUNT",
+	}
+
+	for account, expected := range testcases {
+		t.Run(account, func(t *testing.T) {
+			accountPart := extractAccountName(account)
+			if accountPart != expected {
+				t.Fatalf("extractAccountName returned unexpected response (%v), should be %v", accountPart, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Attempt to fix the issue caused by certain applications putting
* regioned (e.g. myaccount.eu-central-1)
* privatelink (e.g. myorg-myaccount.privatelink)

values in the `Account` field of the configuration, which could result in unsuccessful keypair authentication, as this value was relayed into the JWT unchanged and led to an invalid JWT

The change has been also manually tested by actually generating JWT and actually logging into live Snowflake account, whose names conform the pattern seen in the newly added part in auth_test.go