### PR TITLE
SNOW-1503458 Allow using passcode with MFA token caching enabled

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -457,8 +457,14 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 		logger.WithContext(sc.ctx).Info("Username and password MFA")
 		requestMain.LoginName = sc.cfg.User
 		requestMain.Password = sc.cfg.Password
-		if sc.cfg.MfaToken != "" {
+		switch {
+		case sc.cfg.MfaToken != "":
 			requestMain.Token = sc.cfg.MfaToken
+		case sc.cfg.PasscodeInPassword:
+			requestMain.ExtAuthnDuoMethod = "passcode"
+		case sc.cfg.Passcode != "":
+			requestMain.Passcode = sc.cfg.Passcode
+			requestMain.ExtAuthnDuoMethod = "passcode"
 		}
 	}
 

--- a/doc.go
+++ b/doc.go
@@ -96,7 +96,7 @@ The following connection parameters are supported:
 
   - authenticator: Specifies the authenticator to use for authenticating user credentials:
 
-  - To use the internal Snowflake authenticator, specify snowflake (Default).
+  - To use the internal Snowflake authenticator, specify snowflake (Default). If you want to cache your MFA logins, use AuthTypeUsernamePasswordMFA authenticator.
 
   - To authenticate through Okta, specify https://<okta_account_name>.okta.com (URL prefix for Okta).
 


### PR DESCRIPTION
### Description

SNOW-1503458 Added possibility to specify passcode while using MFA token caching

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
