### PR TITLE
SNOW-116310: Adjust BINARY col size to match assertions

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -37,7 +37,7 @@ var (
 
 const (
 	selectNumberSQL       = "SELECT %s::NUMBER(%v, %v) AS C"
-	selectVariousTypes    = "SELECT 1.0::NUMBER(30,2) as C1, 2::NUMBER(38,0) AS C2, 't3' AS C3, 4.2::DOUBLE AS C4, 'abcd'::BINARY AS C5, true AS C6"
+	selectVariousTypes    = "SELECT 1.0::NUMBER(30,2) as C1, 2::NUMBER(38,0) AS C2, 't3' AS C3, 4.2::DOUBLE AS C4, 'abcd'::BINARY(8388608) AS C5, true AS C6"
 	selectRandomGenerator = "SELECT SEQ8(), RANDSTR(1000, RANDOM()) FROM TABLE(GENERATOR(ROWCOUNT=>%v))"
 	PSTLocation           = "America/Los_Angeles"
 )

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -642,7 +642,6 @@ func TestPutLargeFile(t *testing.T) {
 
 func TestPutGetMaxLOBSize(t *testing.T) {
 	// the LOB sizes to be tested
-	// set "alter session set ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN = true", when testing for increased max LOB size
 	testCases := [5]int{smallSize, originSize, mediumSize, largeSize, maxLOBSize}
 
 	runDBTest(t, func(dbt *DBTest) {
@@ -660,6 +659,7 @@ func TestPutGetMaxLOBSize(t *testing.T) {
 			err := os.WriteFile(fname, b.Bytes(), readWriteFileMode)
 			assertNilF(t, err, "could not write to gzip file")
 
+			//dbt.mustExec("alter session set ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN = true") // when testing with increased max LOB size
 			dbt.mustExec(fmt.Sprintf("create or replace table %s (c1 varchar, c2 varchar(%v), c3 int)", tableName, tc))
 			defer dbt.mustExec("drop table " + tableName)
 			fileStream, err := os.Open(fname)

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -642,6 +642,7 @@ func TestPutLargeFile(t *testing.T) {
 
 func TestPutGetMaxLOBSize(t *testing.T) {
 	// the LOB sizes to be tested
+	// set "alter session set ALLOW_LARGE_LOBS_IN_EXTERNAL_SCAN = true", when testing for increased max LOB size
 	testCases := [5]int{smallSize, originSize, mediumSize, largeSize, maxLOBSize}
 
 	runDBTest(t, func(dbt *DBTest) {


### PR DESCRIPTION
### Description

SNOW-116310 Adjusted BINARY col size for select statement used in tests, to match assertions.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
