### PR TITLE
SNOW-1563083: snowflakeConn creates/manages its own context

### DIFF
--- a/connector_test.go
+++ b/connector_test.go
@@ -3,10 +3,13 @@
 package gosnowflake
 
 import (
+	"bytes"
 	"context"
 	"database/sql/driver"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 type noopTestDriver struct {
@@ -66,4 +69,36 @@ func TestConnectorWithMissingConfig(t *testing.T) {
 	assertTrueF(t, ok, "should be a SnowflakeError")
 	assertEqualE(t, driverErr.Number, expectedErr.Number)
 	assertEqualE(t, driverErr.Message, expectedErr.Message)
+}
+
+func TestConnectorCancelContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// restore the logger output after the test is complete.
+	logger := GetLogger().(*defaultLogger)
+	initialOutput := logger.inner.Out
+	defer logger.SetOutput(initialOutput)
+
+	// write logs to temp buffer so we can assert log output.
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+
+	// pass in our context which should only be used for establishing the initial connection; not persisted.
+	sfConn, err := buildSnowflakeConn(ctx, Config{Params: make(map[string]*string)})
+	assertNilF(t, err)
+
+	// patch close handler
+	sfConn.rest = &snowflakeRestful{
+		FuncCloseSession: func(ctx context.Context, sr *snowflakeRestful, d time.Duration) error {
+			return ctx.Err()
+		},
+	}
+
+	// cancel context BEFORE closing the connection.
+	// this may occur if the *snowflakeConn was spawned by a QueryContext(), and the query has completed.
+	cancel()
+	assertNilF(t, sfConn.Close())
+
+	// if the following log is emitted, the connection is holding onto context that it shouldn't be.
+	assertFalseF(t, strings.Contains(buf.String(), "context canceled"))
 }


### PR DESCRIPTION
### Description

SNOW-1563083 Avoid persisting query context in `snowflakeConn`, using it only for dialing purposes as described in [docs](https://pkg.go.dev/database/sql/driver#Connector).

Fixes: #1186

### Checklist
- [x] Created tests which fail without the change
- [x] Extended the README / documentation (yes, inline comments added)
