### PR TITLE
Ignore setting OCSP env if already set

### DIFF
--- a/connection_util.go
+++ b/connection_util.go
@@ -325,6 +325,12 @@ func populateChunkDownloader(
 
 func setupOCSPEnvVars(ctx context.Context, host string) error {
 	host = strings.ToLower(host)
+
+	// only set OCSP envs if not already set
+	if val, set := os.LookupEnv(cacheServerURLEnv); set {
+		logger.WithContext(ctx).Debugf("OCSP Cache Server already set by user for %v: %v\n", host, val)
+		return nil
+	}
 	if isPrivateLink(host) {
 		if err := setupOCSPPrivatelink(ctx, host); err != nil {
 			return err


### PR DESCRIPTION
### Description

Currently, if the user sets the OCSP cache server URL
```
SF_OCSP_RESPONSE_CACHE_SERVER_URL
```
it is never respected and always overwritten.

This commit only sets the OCSP env vars if they are not already set by the user.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
