### PR TITLE
SNOW-1660331 export SnowflakeFileTransferOptions.GetFileToStream

### DIFF
--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -277,7 +277,7 @@ func (util *snowflakeAzureClient) nativeDownloadFile(
 	if meta.mockAzureClient != nil {
 		blobClient = meta.mockAzureClient
 	}
-	if meta.options.getFileToStream {
+	if meta.options.GetFileToStream {
 		blobDownloadResponse, err := blobClient.DownloadStream(context.Background(), &azblob.DownloadStreamOptions{})
 		if err != nil {
 			return err

--- a/connection_util.go
+++ b/connection_util.go
@@ -115,7 +115,7 @@ func (sc *snowflakeConn) processFileTransfer(
 	if err != nil {
 		return nil, err
 	}
-	if sfa.options.getFileToStream {
+	if sfa.options.GetFileToStream {
 		if err := writeFileStream(ctx, sfa.streamBuffer); err != nil {
 			return nil, err
 		}

--- a/doc.go
+++ b/doc.go
@@ -1257,7 +1257,7 @@ an absolute path rather than a relative path. For example:
 To download a file into an in-memory stream (rather than a file) use code similar to the code below.
 
 	var streamBuf bytes.Buffer
-	ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{getFileToStream: true})
+	ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{GetFileToStream: true})
 	ctx = WithFileGetStream(ctx, &streamBuf)
 
 	sql := "get @~/data1.txt.gz file:///tmp/testData"

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -92,7 +92,7 @@ type SnowflakeFileTransferOptions struct {
 	compressSourceFromStream bool
 
 	/* streaming GET */
-	getFileToStream bool
+	GetFileToStream bool
 
 	/* PUT */
 	putCallback             *snowflakeProgressPercentage

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -322,7 +322,7 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 		return meta.lastError
 	}
 
-	if meta.options.getFileToStream {
+	if meta.options.GetFileToStream {
 		if _, err := io.Copy(meta.dstStream, resp.Body); err != nil {
 			return err
 		}

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -272,7 +272,7 @@ func TestPutGetWithAutoCompressFalse(t *testing.T) {
 
 		// GET test
 		var streamBuf bytes.Buffer
-		ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{getFileToStream: true})
+		ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{GetFileToStream: true})
 		ctx = WithFileGetStream(ctx, &streamBuf)
 		sql := fmt.Sprintf("get @~/test_put_uncompress_file/data.txt 'file://%v'", tmpDir)
 		sqlText = strings.ReplaceAll(sql, "\\", "\\\\")
@@ -468,7 +468,7 @@ func testPutGet(t *testing.T, isStream bool) {
 
 		var streamBuf bytes.Buffer
 		if isStream {
-			ctx = WithFileTransferOptions(ctx, &SnowflakeFileTransferOptions{getFileToStream: true})
+			ctx = WithFileTransferOptions(ctx, &SnowflakeFileTransferOptions{GetFileToStream: true})
 			ctx = WithFileGetStream(ctx, &streamBuf)
 		}
 		sql = fmt.Sprintf("get @%%%v 'file://%v'", tableName, tmpDir)
@@ -686,7 +686,7 @@ func TestPutGetLargeFile(t *testing.T) {
 
 		// GET test with stream
 		var streamBuf bytes.Buffer
-		ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{getFileToStream: true})
+		ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{GetFileToStream: true})
 		ctx = WithFileGetStream(ctx, &streamBuf)
 		sql := fmt.Sprintf("get @%v 'file://%v'", "~/test_put_largefile/largefile.txt.gz", t.TempDir())
 		sqlText = strings.ReplaceAll(sql, "\\", "\\\\")

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -248,7 +248,7 @@ func (util *snowflakeS3Client) nativeDownloadFile(
 		downloader = meta.mockDownloader
 	}
 
-	if meta.options.getFileToStream {
+	if meta.options.GetFileToStream {
 		buf := manager.NewWriteAtBuffer([]byte{})
 		_, err = downloader.Download(context.Background(), buf, &s3.GetObjectInput{
 			Bucket: s3Obj.Bucket,

--- a/storage_client.go
+++ b/storage_client.go
@@ -218,7 +218,7 @@ func (rsu *remoteStorageUtil) downloadOneFile(meta *fileMetadata) error {
 						return err
 					}
 				}
-				if meta.options.getFileToStream {
+				if meta.options.GetFileToStream {
 					totalFileSize, err := decryptStream(header.encryptionMetadata,
 						meta.encryptionMaterial, 0, meta.dstStream, meta.sfa.streamBuffer)
 					if err != nil {
@@ -238,7 +238,7 @@ func (rsu *remoteStorageUtil) downloadOneFile(meta *fileMetadata) error {
 				}
 
 			}
-			if !meta.options.getFileToStream {
+			if !meta.options.GetFileToStream {
 				if fi, err := os.Stat(fullDstFileName); err == nil {
 					meta.dstFileSize = fi.Size()
 				}


### PR DESCRIPTION
### Description

SNOW-1660331 // https://github.com/snowflakedb/gosnowflake/issues/1207

 attempt to fix
```
unknown field getFileToStream in struct literal of type gosnowflake.SnowflakeFileTransferOptions
```

which happens when trying to download a file into an in-memory stream (rather than a file) per docs:
```go
ctx := WithFileTransferOptions(context.Background(), &SnowflakeFileTransferOptions{getFileToStream: true})
ctx = WithFileGetStream(ctx, &streamBuf)
```

`getFileToStream` being unexported, it is not really accessible from outside of the module. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
