### PR TITLE
NO-SNOW Enable client configuration tests

### DIFF
--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -57,7 +57,7 @@ func TestTokenFilePermission(t *testing.T) {
 	}
 }
 
-func TestloadConnectionConfig_Default(t *testing.T) {
+func TestLoadConnectionConfigForStandardAuth(t *testing.T) {
 	err := os.Chmod("./test_data/connections.toml", 0600)
 	assertNilF(t, err, "The error occurred because you cannot change the file permission")
 
@@ -75,7 +75,7 @@ func TestloadConnectionConfig_Default(t *testing.T) {
 	assertEqualF(t, cfg.Port, 300)
 }
 
-func TestloadConnectionConfig_OAuth(t *testing.T) {
+func TestLoadConnectionConfigForOAuth(t *testing.T) {
 	err := os.Chmod("./test_data/connections.toml", 0600)
 	assertNilF(t, err, "The error occurred because you cannot change the file permission")
 


### PR DESCRIPTION
### Description

NO-SNOW Fixed letter case in some tests, which was not invoked at all.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
