### PR TITLE
SNOW-1569290 Make Azure headers case insensitive

### DIFF
--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -105,17 +105,17 @@ func (util *snowflakeAzureClient) getFileHeader(meta *fileMetadata, filename str
 	}
 
 	meta.resStatus = uploaded
-	metadata := resp.Metadata
+	metadata := withLowerKeys(resp.Metadata)
 	var encData encryptionData
 
-	_, ok = metadata["Encryptiondata"]
+	_, ok = metadata["encryptiondata"]
 	if ok {
-		if err = json.Unmarshal([]byte(*metadata["Encryptiondata"]), &encData); err != nil {
+		if err = json.Unmarshal([]byte(*metadata["encryptiondata"]), &encData); err != nil {
 			return nil, err
 		}
 	}
 
-	matdesc, ok := metadata["Matdesc"]
+	matdesc, ok := metadata["matdesc"]
 	if !ok {
 		// matdesc is not in response, use empty string
 		matdesc = new(string)
@@ -126,7 +126,7 @@ func (util *snowflakeAzureClient) getFileHeader(meta *fileMetadata, filename str
 		*matdesc,
 	}
 
-	digest, ok := metadata["Sfcdigest"]
+	digest, ok := metadata["sfcdigest"]
 	if !ok {
 		// sfcdigest is not in response, use empty string
 		digest = new(string)

--- a/util.go
+++ b/util.go
@@ -331,3 +331,11 @@ func contains[T comparable](s []T, e T) bool {
 func chooseRandomFromRange(min float64, max float64) float64 {
 	return rand.Float64()*(max-min) + min
 }
+
+func withLowerKeys[T any](in map[string]T) map[string]T {
+	out := make(map[string]T)
+	for k, v := range in {
+		out[strings.ToLower(k)] = v
+	}
+	return out
+}

--- a/util_test.go
+++ b/util_test.go
@@ -400,3 +400,12 @@ func randomString(n int) string {
 	}
 	return string(b)
 }
+
+func TestWithLowerKeys(t *testing.T) {
+	m := make(map[string]string)
+	m["abc"] = "def"
+	m["GHI"] = "KLM"
+	lowerM := withLowerKeys(m)
+	assertEqualE(t, lowerM["abc"], "def")
+	assertEqualE(t, lowerM["ghi"], "KLM")
+}


### PR DESCRIPTION
### Description

SNOW-1569290 Azure client treated headers as case sensitive before, which causes fails when downloading files uploaded by other drivers.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
