### PR TITLE
SNOW-1569290 Use 12 bytes for IV in gcm

### DIFF
--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 )
 
+const gcmIvLengthInBytes = 12
+
 var (
 	defaultKeyAad  = make([]byte, 0)
 	defaultDataAad = make([]byte, 0)
@@ -305,7 +307,7 @@ func initGcm(encryptionKey []byte) (cipher.AEAD, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cipher.NewGCMWithNonceSize(block, 16)
+	return cipher.NewGCM(block)
 }
 
 func encryptFileGCM(
@@ -334,13 +336,13 @@ func encryptFileGCM(
 	}
 	keySize := len(kek)
 	fileKey := getSecureRandom(keySize)
-	keyIv := getSecureRandom(keySize)
+	keyIv := getSecureRandom(gcmIvLengthInBytes)
 	encryptedFileKey, err := encryptGCM(keyIv, fileKey, kek, defaultKeyAad)
 	if err != nil {
 		return nil, "", err
 	}
 
-	dataIv := getSecureRandom(keySize)
+	dataIv := getSecureRandom(gcmIvLengthInBytes)
 	encryptedData, err := encryptGCM(dataIv, plaintext, fileKey, defaultDataAad)
 	if err != nil {
 		return nil, "", err

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -240,11 +240,11 @@ func generateKLinesOfNFiles(k int, n int, compress bool, tmpDir string) (string,
 
 func TestEncryptDecryptGCM(t *testing.T) {
 	input := []byte("abc")
-	iv := []byte("abcdef1234567890")  // pragma: allowlist secret
+	iv := []byte("ab1234567890")      // pragma: allowlist secret
 	key := []byte("1234567890abcdef") // pragma: allowlist secret
 	encrypted, err := encryptGCM(iv, input, key, nil)
 	assertNilF(t, err)
-	assertEqualE(t, base64.StdEncoding.EncodeToString(encrypted), "pgs/wjNH2TYekmN7mbhFjeHH0A==")
+	assertEqualE(t, base64.StdEncoding.EncodeToString(encrypted), "iG+lT4o27hkzj3kblYRzQikLVQ==")
 
 	decrypted, err := decryptGCM(iv, encrypted, key, nil)
 	assertNilF(t, err)


### PR DESCRIPTION
### Description

SNOW-1569290 Fixes to use 12 bytes for GCM encryption.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
