### PR TITLE
SNOW-1806123 Propagate context to snowflakeConn

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -284,7 +284,8 @@ func (sc *snowflakeConn) Close() (err error) {
 	defer sc.cleanup()
 
 	if sc.cfg != nil && !sc.cfg.KeepSessionAlive {
-		if err = sc.rest.FuncCloseSession(sc.ctx, sc.rest, sc.rest.RequestTimeout); err != nil {
+		// we have to replace context with background, otherwise we can use a one that is cancelled or timed out
+		if err = sc.rest.FuncCloseSession(context.Background(), sc.rest, sc.rest.RequestTimeout); err != nil {
 			logger.WithContext(sc.ctx).Error(err)
 		}
 	}
@@ -775,7 +776,7 @@ func (scd *snowflakeArrowStreamChunkDownloader) GetBatches() (out []ArrowStreamB
 func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, error) {
 	sc := &snowflakeConn{
 		SequenceCounter:     0,
-		ctx:                 context.Background(),
+		ctx:                 ctx,
 		cfg:                 &config,
 		queryContextCache:   (&queryContextCache{}).init(),
 		currentTimeProvider: defaultTimeProvider,


### PR DESCRIPTION
### Description

SNOW-1806123 It is a bit of reversion of https://github.com/snowflakedb/gosnowflake/pull/1196 . Firstly, the issue was that we persisted a auth context in `snowflakeConn` and reused it in closing. But if the context was cancelled or timed out, it ended up in problems with closing connection. After 1196 context was not propagated to auth calls so auth calls couldn't have been cancelled or timed out. Now the context is propagated to auth calls again, but it is not used during session closing.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
