### PR TITLE
SNOW-1855886 gracefully ignore when default region us-west-2 is used in DSN or NewConnector

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -139,11 +139,17 @@ func (c *Config) ocspMode() string {
 
 // DSN constructs a DSN for Snowflake db.
 func DSN(cfg *Config) (dsn string, err error) {
-	if cfg.Region == "us-west-2" {
+	if strings.ToLower(cfg.Region) == "us-west-2" {
 		cfg.Region = ""
+		logger.Info("Ignoring Region configuration in DSN as us-west-2 is the default one.")
 	}
 	// in case account includes region
 	region, posDot := extractRegionFromAccount(cfg.Account)
+	if strings.ToLower(region) == "us-west-2" {
+		region = ""
+		cfg.Account = cfg.Account[:posDot]
+		logger.Info("Ignoring default region .us-west-2 in DSN from Account configuration.")
+	}
 	if region != "" {
 		if cfg.Region != "" {
 			return "", errRegionConflict()
@@ -579,6 +585,11 @@ func transformAccountToHost(cfg *Config) (err error) {
 		// account name is specified instead of host:port
 		cfg.Account = cfg.Host
 		region, posDot := extractRegionFromAccount(cfg.Account)
+		if strings.ToLower(region) == "us-west-2" {
+			region = ""
+			cfg.Account = cfg.Account[:posDot]
+			logger.Info("Ignoring default region .us-west-2 from Account configuration.")
+		}
 		if region != "" {
 			cfg.Region = region
 			cfg.Account = cfg.Account[:posDot]

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1237,6 +1237,31 @@ func TestDSN(t *testing.T) {
 			cfg: &Config{
 				User:     "u",
 				Password: "p",
+				Account:  "account.us-west-2",
+			},
+			dsn: "u:p@account.snowflakecomputing.com:443?ocspFailOpen=true&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "account_us-west-2",
+			},
+			dsn: "u:p@account_us-west-2.snowflakecomputing.com:443?ocspFailOpen=true&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
+				Account:  "account",
+				Host:     "account.us-west-2.snowflakecomputing.com",
+			},
+			dsn: "u:p@account.snowflakecomputing.com:443?ocspFailOpen=true&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:     "u",
+				Password: "p",
 				Account:  "account-name",
 				Host:     "account-name.snowflakecomputing.mil",
 			},


### PR DESCRIPTION
### Description

`us-west-2` region is the default region in Snowflake, and a special one. We already had checks for the case where someone accidentally configures it in `Region`, but for `Account` we did not have any, which led to an `Account` (mis)configured as `myaccount.us-west-2` instead of omitting the region (as is the default) and using `myaccount`, not being able to connect to Snowflake and instead failing with HTTP404.

This change attempts to step over such simple misconfiguration gracefully and 
* ignores the extra `.us-west-2` from Account instead of allowing the connection to proceed, which then surely will fail on the Snowflake backend 
* logs a line about the misconfiguration on Info level, giving it a chance for the user to notice and correct it

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
