### PR TITLE
NO-SNOW log JWT claims on debug loglevel

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -481,6 +481,7 @@ func prepareJWTToken(config *Config) (string, error) {
 	if config.PrivateKey == nil {
 		return "", errors.New("trying to use keypair authentication, but PrivateKey was not provided in the driver config")
 	}
+	logger.Debug("preparing JWT for keypair authentication")
 	pubBytes, err := x509.MarshalPKIXPublicKey(config.PrivateKey.Public())
 	if err != nil {
 		return "", err
@@ -505,6 +506,7 @@ func prepareJWTToken(config *Config) (string, error) {
 		return "", err
 	}
 
+	logger.Debugf("successfully generated JWT. token: %v", tokenString)
 	return tokenString, err
 }
 

--- a/auth.go
+++ b/auth.go
@@ -492,13 +492,14 @@ func prepareJWTToken(config *Config) (string, error) {
 	userName := strings.ToUpper(config.User)
 
 	issueAtTime := time.Now().UTC()
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+	jwtClaims := jwt.MapClaims{
 		"iss": fmt.Sprintf("%s.%s.%s", accountName, userName, "SHA256:"+base64.StdEncoding.EncodeToString(hash[:])),
 		"sub": fmt.Sprintf("%s.%s", accountName, userName),
 		"iat": issueAtTime.Unix(),
 		"nbf": time.Date(2015, 10, 10, 12, 0, 0, 0, time.UTC).Unix(),
 		"exp": issueAtTime.Add(config.JWTExpireTimeout).Unix(),
-	})
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwtClaims)
 
 	tokenString, err := token.SignedString(config.PrivateKey)
 
@@ -506,7 +507,7 @@ func prepareJWTToken(config *Config) (string, error) {
 		return "", err
 	}
 
-	logger.Debugf("successfully generated JWT. token: %v", tokenString)
+	logger.Debugf("successfully generated JWT with following claims: %v", jwtClaims)
 	return tokenString, err
 }
 


### PR DESCRIPTION
### Description

Being able to see what claims are used inside JWT is immensely useful for troubleshooting issues with such authentication type, and can even one-shot certain types of issues (wrong key used, wrong login_name used, etc.). 

It would be equally useful having in gosnowflake too. Even more useful, since it would also help Snowflake Terraform Provider issues which trace back to keypair authentication.

No auth logic was changed, all the change is doing is to add two additional loglines, one of which logs out the JWT claims for the token generated.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
