### PR TITLE
MINOR: Change stray Info logs to Debug

### DIFF
--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -93,7 +93,7 @@ func newFileBasedSecureStorageManager() (*fileBasedSecureStorageManager, error) 
 		return nil, err
 	}
 	credCacheFilePath := filepath.Join(credCacheDir, credCacheFileName)
-	logger.Infof("Credentials cache path: %v", credCacheFilePath)
+	logger.Debugf("Credentials cache path: %v", credCacheFilePath)
 	ssm.credCacheFilePath = credCacheFilePath
 	return ssm, nil
 }
@@ -116,7 +116,7 @@ func (ssm *fileBasedSecureStorageManager) buildCredCacheDirPath() string {
 	}
 	home := os.Getenv("HOME")
 	if home == "" {
-		logger.Info("HOME is blank")
+		logger.Debug("HOME is blank")
 		return ""
 	}
 	credCacheDir = filepath.Join(home, ".cache", "snowflake")


### PR DESCRIPTION
### Description

We noticed in the ADBC Snowflake driver that there was some stray logging output that appeared to come from gosnowflake. I think these should be changed to Debug level as they're not useful to the user and may confuse them instead. Also, changing the logger level doesn't help with the "Credentials cache path" message since that gets triggered by a global, before any application code can run.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
