### PR TITLE
SNOW-1958566 Do fallback for OCSP GET request only when malformed response for POST is returned

### DIFF
--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -33,7 +33,7 @@ func TestOCSP(t *testing.T) {
 		"https://sfcdev2.blob.core.windows.net/",
 	}
 
-	transports := []*http.Transport{
+	transports := []http.RoundTripper{
 		snowflakeNoOcspTransport,
 		SnowflakeTransport,
 	}

--- a/test_data/wiremock/mappings/auth/password/successful_flow.json
+++ b/test_data/wiremock/mappings/auth/password/successful_flow.json
@@ -1,9 +1,6 @@
 {
   "mappings": [
     {
-      "scenarioName": "Successful PAT authentication flow",
-      "requiredScenarioState": "Started",
-      "newScenarioState": "Authenticated",
       "request": {
         "urlPathPattern": "/session/v1/login-request.*",
         "method": "POST",

--- a/test_data/wiremock/mappings/ocsp/malformed.json
+++ b/test_data/wiremock/mappings/ocsp/malformed.json
@@ -1,0 +1,13 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPathPattern": "/"
+      },
+      "response": {
+        "status": 200,
+        "base64Body": "AQID"
+      }
+    }
+  ]
+}

--- a/test_data/wiremock/mappings/ocsp/unauthorized.json
+++ b/test_data/wiremock/mappings/ocsp/unauthorized.json
@@ -1,0 +1,14 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPathPattern": "/",
+        "method": "POST"
+      },
+      "response": {
+        "status": 200,
+        "base64Body": "MAMKAQY="
+      }
+    }
+  ]
+}

--- a/wiremock_test.go
+++ b/wiremock_test.go
@@ -156,6 +156,10 @@ func (wm *wiremockClient) mappingsURL() string {
 	return fmt.Sprintf("http://%v:%v/__admin/mappings", wm.host, wm.adminPort)
 }
 
+func (wm *wiremockClient) baseURL() string {
+	return fmt.Sprintf("http://%v:%v", wm.host, wm.port)
+}
+
 func TestQueryViaHttps(t *testing.T) {
 	wiremockHTTPS.registerMappings(t,
 		wiremockMapping{filePath: "auth/password/successful_flow.json"},


### PR DESCRIPTION
### Description

SNOW-1958566 PR provides change to not fallback to GET OCSP request unless POST returns malformed response. PR provides also simple OCSP test server.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
