### PR TITLE
SNOW-1825500 Add OAUTH_TYPE to login request

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -193,6 +193,7 @@ type authRequestData struct {
 	BrowserModeRedirectPort string                       `json:"BROWSER_MODE_REDIRECT_PORT,omitempty"`
 	ProofKey                string                       `json:"PROOF_KEY,omitempty"`
 	Token                   string                       `json:"TOKEN,omitempty"`
+	OauthType               string                       `json:"OAUTH_TYPE,omitempty"`
 }
 type authRequest struct {
 	Data authRequestData `json:"data"`
@@ -518,6 +519,7 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 		}
 		requestMain.LoginName = sc.cfg.User
 		requestMain.Token = token
+		requestMain.OauthType = "OAUTH_AUTHORIZATION_CODE"
 	case AuthTypeOAuthClientCredentials:
 		logger.WithContext(sc.ctx).Debug("OAuth client credentials")
 		if !experimentalAuthEnabled() {
@@ -533,6 +535,7 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 		}
 		requestMain.LoginName = sc.cfg.User
 		requestMain.Token = token
+		requestMain.OauthType = "OAUTH_CLIENT_CREDENTIALS"
 	}
 
 	authRequest := authRequest{

--- a/auth_test.go
+++ b/auth_test.go
@@ -1083,12 +1083,10 @@ func TestWithOauthAuthorizationCodeFlowManual(t *testing.T) {
 func TestWithOAuthClientCredentialsFlowManual(t *testing.T) {
 	t.Skip("manual test")
 	cfg, err := GetConfigFromEnv([]*ConfigParam{
-		{"OAuthClientId", "SNOWFLAKE_TEST_OAUTH_CLIENT_ID", true},
-		{"OAuthClientSecret", "SNOWFLAKE_TEST_OAUTH_CLIENT_SECRET", true},
-		{"OAuthAuthorizationURL", "SNOWFLAKE_TEST_OAUTH_AUTHORIZATION_URL", true},
-		{"OAuthTokenRequestURL", "SNOWFLAKE_TEST_OAUTH_TOKEN_REQUEST_URL", true},
-		{"OAuthRedirectURI", "SNOWFLAKE_TEST_OAUTH_REDIRECT_URI", true},
-		{"Role", "SNOWFLAKE_TEST_OAUTH_ROLE", true},
+		{"OAuthClientId", "SNOWFLAKE_TEST_OAUTH_OKTA_CLIENT_ID", true},
+		{"OAuthClientSecret", "SNOWFLAKE_TEST_OAUTH_OKTA_CLIENT_SECRET", true},
+		{"OAuthTokenRequestURL", "SNOWFLAKE_TEST_OAUTH_OKTA_TOKEN_REQUEST_URL", true},
+		{"Role", "SNOWFLAKE_TEST_OAUTH_OKTA_ROLE", true},
 		{"Account", "SNOWFLAKE_TEST_ACCOUNT", true},
 	})
 	assertNilF(t, err)


### PR DESCRIPTION
### Description

SNOW-1825500 Add OAUTH_TYPE to login request

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
