### PR TITLE
SNOW-1915375: Drop copyright header in comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,6 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
+   Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,6 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/arrow_chunk.go
+++ b/arrow_chunk.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2020-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2020-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/assert_test.go
+++ b/assert_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/async.go
+++ b/async.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/async_test.go
+++ b/async_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/auth.go
+++ b/auth.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2019-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/authexternalbrowser_test.go
+++ b/authexternalbrowser_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/authokta.go
+++ b/authokta.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/authokta_test.go
+++ b/authokta_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/azure_storage_client_test.go
+++ b/azure_storage_client_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/bind_uploader.go
+++ b/bind_uploader.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/cacert.go
+++ b/cacert.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 // caRootPEM includes a snapshot of root CAs downloaded from https://curl.haxx.se/ca/cacert.pem

--- a/chunk.go
+++ b/chunk.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2018-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/client.go
+++ b/client.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/client_configuration.go
+++ b/client_configuration.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/client_configuration_test.go
+++ b/client_configuration_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/client_test.go
+++ b/client_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connection.go
+++ b/connection.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connection_configuration.go
+++ b/connection_configuration.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2019-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connection_util.go
+++ b/connection_util.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connector.go
+++ b/connector.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2020-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2020-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/converter.go
+++ b/converter.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/datatype.go
+++ b/datatype.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/datatype_test.go
+++ b/datatype_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/datetime.go
+++ b/datetime.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2024 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/debug.go
+++ b/debug.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2018-2022 Snowflake Computing Inc. All rights reserved.
-
 //go:build sfdebug
 // +build sfdebug
 

--- a/driver.go
+++ b/driver.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2019-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/dsn.go
+++ b/dsn.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/file_compression_type.go
+++ b/file_compression_type.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 //lint:file-ignore U1000 Ignore all unused code

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (
@@ -7,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
 	"net/url"
 	"os"
@@ -18,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/aws/smithy-go"
 )

--- a/file_util.go
+++ b/file_util.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2019-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/local_storage_client.go
+++ b/local_storage_client.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/local_storage_client_test.go
+++ b/local_storage_client_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/location.go
+++ b/location.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/location_test.go
+++ b/location_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/log.go
+++ b/log.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/log_test.go
+++ b/log_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/mock_util_test.go
+++ b/mock_util_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/monitoring.go
+++ b/monitoring.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/multistatement.go
+++ b/multistatement.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/multistatement_test.go
+++ b/multistatement_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2020-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/ocsp.go
+++ b/ocsp.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/old_driver_test.go
+++ b/old_driver_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/prepared_statement_test.go
+++ b/prepared_statement_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/priv_key_test.go
+++ b/priv_key_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 // For compile concern, should any newly added variables or functions here must also be added with same

--- a/priv_key_test_coding_helper.go
+++ b/priv_key_test_coding_helper.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/put_get_with_aws_test.go
+++ b/put_get_with_aws_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/query.go
+++ b/query.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/release.go
+++ b/release.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2018-2022 Snowflake Computing Inc. All rights reserved.
-
 //go:build !sfdebug
 // +build !sfdebug
 

--- a/restful.go
+++ b/restful.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/restful_test.go
+++ b/restful_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/result.go
+++ b/result.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import "errors"

--- a/retry.go
+++ b/retry.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/rows.go
+++ b/rows.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/secret_detector.go
+++ b/secret_detector.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import "regexp"

--- a/secret_detector_test.go
+++ b/secret_detector_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/sqlstate.go
+++ b/sqlstate.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 const (

--- a/statement.go
+++ b/statement.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,4 +1,3 @@
-// Copyright (c) 2020-2023 Snowflake Computing Inc. All rights reserved.
 //lint:file-ignore SA1019 Ignore deprecated methods. We should leave them as-is to keep backward compatibility.
 
 package gosnowflake

--- a/storage_client.go
+++ b/storage_client.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/transaction.go
+++ b/transaction.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/util.go
+++ b/util.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/util_test.go
+++ b/util_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2023 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/uuid.go
+++ b/uuid.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/version.go
+++ b/version.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 // SnowflakeGoDriverVersion is the version of Go Snowflake Driver.


### PR DESCRIPTION
### Description

SNOW-1915375: Drop copyright header in comments
[issue #1220](https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/1220)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
