### PR TITLE
SNOW-1825476 Remove PAT with password instead of token

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -454,9 +454,6 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 		requestMain.Authenticator = AuthTypePat.String()
 		requestMain.LoginName = sc.cfg.User
 		requestMain.Token = sc.cfg.Token
-		if sc.cfg.Password != "" && sc.cfg.Token == "" {
-			requestMain.Token = sc.cfg.Password
-		}
 	case AuthTypeSnowflake:
 		logger.WithContext(sc.ctx).Info("Username and password")
 		requestMain.LoginName = sc.cfg.User

--- a/auth_test.go
+++ b/auth_test.go
@@ -1002,14 +1002,15 @@ func TestContextPropagatedToAuthWhenUsingOpenDB(t *testing.T) {
 	cancel()
 }
 
+func enableExperimentalAuth(t *testing.T) {
+	err := os.Setenv("ENABLE_EXPERIMENTAL_AUTHENTICATION", "true")
+	assertNilF(t, err)
+}
+
 func TestPatSuccessfulFlow(t *testing.T) {
 	cfg := wiremock.connectionConfig()
 	cfg.Authenticator = AuthTypePat
 	cfg.Token = "some PAT"
-	testPatSuccessfulFlow(t, cfg)
-}
-
-func testPatSuccessfulFlow(t *testing.T, cfg *Config) {
 	enableExperimentalAuth(t)
 	wiremock.registerMappings(t,
 		wiremockMapping{filePath: "auth/pat/successful_flow.json"},
@@ -1023,18 +1024,6 @@ func testPatSuccessfulFlow(t *testing.T, cfg *Config) {
 	assertTrueE(t, rows.Next())
 	assertNilF(t, rows.Scan(&v))
 	assertEqualE(t, v, 1)
-}
-
-func enableExperimentalAuth(t *testing.T) {
-	err := os.Setenv("ENABLE_EXPERIMENTAL_AUTHENTICATION", "true")
-	assertNilF(t, err)
-}
-
-func TestPatSuccessfulFlowWithPatAsPasswordWithPatAuthenticator(t *testing.T) {
-	cfg := wiremock.connectionConfig()
-	cfg.Authenticator = AuthTypePat
-	cfg.Password = "some PAT"
-	testPatSuccessfulFlow(t, cfg)
 }
 
 func TestPatInvalidToken(t *testing.T) {


### PR DESCRIPTION
### Description

SNOW-1825476 Removed rewriting password to token field for PAT authentication.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
