### PR TITLE
SNOW-2062018 Fix smkId downcast to int

### DIFF
--- a/encrypt_util.go
+++ b/encrypt_util.go
@@ -95,7 +95,7 @@ func encryptStreamCBC(
 	}
 
 	matDesc := materialDescriptor{
-		strconv.Itoa(int(sfe.SMKID)),
+		fmt.Sprintf("%v", sfe.SMKID),
 		sfe.QueryID,
 		strconv.Itoa(keySize * 8),
 	}
@@ -378,7 +378,7 @@ func encryptFileGCM(
 	}
 
 	matDesc := materialDescriptor{
-		strconv.Itoa(int(sfe.SMKID)),
+		fmt.Sprintf("%v", sfe.SMKID),
 		sfe.QueryID,
 		strconv.Itoa(keySize * 8),
 	}

--- a/encrypt_util_test.go
+++ b/encrypt_util_test.go
@@ -27,7 +27,7 @@ func TestEncryptDecryptFileCBC(t *testing.T) {
 	encMat := snowflakeFileEncryption{
 		"ztke8tIdVt1zmlQIZm0BMA==",
 		"123873c7-3a66-40c4-ab89-e3722fbccce1",
-		3112,
+		9223372036854775807,
 	}
 	data := "test data"
 	inputFile := "test_encrypt_decrypt_file"
@@ -47,6 +47,7 @@ func TestEncryptDecryptFileCBC(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(encryptedFile)
+	assertStringContainsE(t, metadata.matdesc, "9223372036854775807")
 	decryptedFile, err := decryptFileCBC(metadata, &encMat, encryptedFile, 0, "")
 	if err != nil {
 		t.Error(err)
@@ -273,10 +274,11 @@ func TestEncryptDecryptFileGCM(t *testing.T) {
 	sfe := &snowflakeFileEncryption{
 		QueryStageMasterKey: "YWJjZGVmMTIzNDU2Nzg5MA==",
 		QueryID:             "unused",
-		SMKID:               123,
+		SMKID:               9223372036854775807,
 	}
 	meta, encryptedFileName, err := encryptFileGCM(sfe, tempFile.Name(), tmpDir)
 	assertNilF(t, err)
+	assertStringContainsE(t, meta.matdesc, "9223372036854775807")
 
 	decryptedFileName, err := decryptFileGCM(meta, sfe, encryptedFileName, tmpDir)
 	assertNilF(t, err)


### PR DESCRIPTION
### Description

SNOW-2062018 Fixed smkId that was cast to `int` type, which was system dependent.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
