### PR TITLE
SNOW-2102260 don't delete config in cleanup

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -278,7 +278,6 @@ func (sc *snowflakeConn) cleanup() {
 		sc.rest.Client.CloseIdleConnections()
 	}
 	sc.rest = nil
-	sc.cfg = nil
 }
 
 func (sc *snowflakeConn) Close() (err error) {

--- a/connection.go
+++ b/connection.go
@@ -277,7 +277,6 @@ func (sc *snowflakeConn) cleanup() {
 	if sc.rest != nil && sc.rest.Client != nil {
 		sc.rest.Client.CloseIdleConnections()
 	}
-
 	sc.rest = nil
 }
 

--- a/connection.go
+++ b/connection.go
@@ -277,6 +277,7 @@ func (sc *snowflakeConn) cleanup() {
 	if sc.rest != nil && sc.rest.Client != nil {
 		sc.rest.Client.CloseIdleConnections()
 	}
+
 	sc.rest = nil
 }
 


### PR DESCRIPTION
### Description

SNOW-2102260 ,  issue #1406 

It appears that under certain conditions, a race can be introduced between closing a connection (especially if the context has been created with timeout or cancel) and creating/using the cloud storage client e.g. for a PUT operation.
This can result in a panic due to the cloud storage client created without a Config which was previously deleted from the connection in the cleanup phase; when it was cancelled or timed out - in such a case; the cloud storage client is initialized with `nil` config and is reproducibly panicked. 

The change tries to address the situation by not removing the Config upon cleanup, so any dependent checks can proceed.

Change was manually tested on the reproduction which consistently reproduces the panic mentioned in #1406 ; with the patch, the panic doesn't happen anymore. 

I'd like to thank my colleague @sfc-gh-pfus for his valuable insights and guidance while debugging / addressing this !

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
