### PR TITLE
SNOW-2091309 Fix precision lost for NUMBER(19, 0) by returning big.Int and for non-zero scale numbers, align scan types and actual types

### DIFF
--- a/arrow_test.go
+++ b/arrow_test.go
@@ -541,15 +541,22 @@ func TestArrowVariousTypes(t *testing.T) {
 		if canNull := dbt.mustNullable(ct[1]); canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[1])
 		}
+		if v2a != 22 {
+			dbt.Errorf("failed to scan. %#v", v2a)
+		}
+		dbt.mustFailLength(ct[2])
+		if canNull := dbt.mustNullable(ct[2]); canNull {
+			dbt.Errorf("failed to get nullable. %#v", ct[2])
+		}
 		if v3 != "t3" {
 			dbt.Errorf("failed to scan. %#v", v3)
 		}
 		dbt.mustFailDecimalSize(ct[3])
 		if cLen = dbt.mustLength(ct[3]); cLen != 2 {
-			dbt.Errorf("failed to get length. %#v", ct[2])
+			dbt.Errorf("failed to get length. %#v", ct[3])
 		}
 		if canNull := dbt.mustNullable(ct[3]); canNull {
-			dbt.Errorf("failed to get nullable. %#v", ct[2])
+			dbt.Errorf("failed to get nullable. %#v", ct[3])
 		}
 		if v4 != 4.2 {
 			dbt.Errorf("failed to scan. %#v", v4)
@@ -557,7 +564,7 @@ func TestArrowVariousTypes(t *testing.T) {
 		dbt.mustFailDecimalSize(ct[4])
 		dbt.mustFailLength(ct[4])
 		if canNull := dbt.mustNullable(ct[4]); canNull {
-			dbt.Errorf("failed to get nullable. %#v", ct[3])
+			dbt.Errorf("failed to get nullable. %#v", ct[4])
 		}
 		if !bytes.Equal(v5, []byte{0xab, 0xcd}) {
 			dbt.Errorf("failed to scan. %#v", v5)

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -494,25 +494,28 @@ func TestArrowVariousTypes(t *testing.T) {
 			dbt.Errorf("column types: %v", ct)
 		}
 		var v1 *big.Float
-		var v2 int
+		var v2, v2a int
 		var v3 string
 		var v4 float64
 		var v5 []byte
 		var v6 bool
-		if err = rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6); err != nil {
+		if err = rows.Scan(&v1, &v2, &v2a, &v3, &v4, &v5, &v6); err != nil {
 			dbt.Errorf("failed to scan: %#v", err)
 		}
 		if v1.Cmp(big.NewFloat(1.0)) != 0 {
 			dbt.Errorf("failed to scan. %#v", *v1)
 		}
-		if ct[0].Name() != "C1" || ct[1].Name() != "C2" || ct[2].Name() != "C3" || ct[3].Name() != "C4" || ct[4].Name() != "C5" || ct[5].Name() != "C6" {
+		if ct[0].Name() != "C1" || ct[1].Name() != "C2" || ct[2].Name() != "C2A" || ct[3].Name() != "C3" || ct[4].Name() != "C4" || ct[5].Name() != "C5" || ct[6].Name() != "C6" {
 			dbt.Errorf("failed to get column names: %#v", ct)
 		}
 		if ct[0].ScanType() != reflect.TypeOf(&big.Float{}) {
 			dbt.Errorf("failed to get scan type. expected: %v, got: %v", reflect.TypeOf(float64(0)), ct[0].ScanType())
 		}
-		if ct[1].ScanType() != reflect.TypeOf(&big.Int{}) {
+		if ct[1].ScanType() != reflect.TypeOf(int64(0)) {
 			dbt.Errorf("failed to get scan type. expected: %v, got: %v", reflect.TypeOf(int64(0)), ct[1].ScanType())
+		}
+		if ct[2].ScanType() != reflect.TypeOf(&big.Int{}) {
+			dbt.Errorf("failed to get scan type. expected: %v, got: %v", reflect.TypeOf(&big.Int{}), ct[2].ScanType())
 		}
 		var pr, sc int64
 		var cLen int64
@@ -531,7 +534,7 @@ func TestArrowVariousTypes(t *testing.T) {
 			dbt.Errorf("failed to scan. %#v", v2)
 		}
 		pr, sc = dbt.mustDecimalSize(ct[1])
-		if pr != 38 || sc != 0 {
+		if pr != 18 || sc != 0 {
 			dbt.Errorf("failed to get precision and scale. %#v", ct[1])
 		}
 		dbt.mustFailLength(ct[1])
@@ -541,40 +544,36 @@ func TestArrowVariousTypes(t *testing.T) {
 		if v3 != "t3" {
 			dbt.Errorf("failed to scan. %#v", v3)
 		}
-		dbt.mustFailDecimalSize(ct[2])
-		if cLen = dbt.mustLength(ct[2]); cLen != 2 {
+		dbt.mustFailDecimalSize(ct[3])
+		if cLen = dbt.mustLength(ct[3]); cLen != 2 {
 			dbt.Errorf("failed to get length. %#v", ct[2])
 		}
-		if canNull := dbt.mustNullable(ct[2]); canNull {
+		if canNull := dbt.mustNullable(ct[3]); canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[2])
 		}
 		if v4 != 4.2 {
 			dbt.Errorf("failed to scan. %#v", v4)
 		}
-		dbt.mustFailDecimalSize(ct[3])
-		dbt.mustFailLength(ct[3])
-		if canNull := dbt.mustNullable(ct[3]); canNull {
+		dbt.mustFailDecimalSize(ct[4])
+		dbt.mustFailLength(ct[4])
+		if canNull := dbt.mustNullable(ct[4]); canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[3])
 		}
 		if !bytes.Equal(v5, []byte{0xab, 0xcd}) {
 			dbt.Errorf("failed to scan. %#v", v5)
 		}
-		dbt.mustFailDecimalSize(ct[4])
-		if cLen = dbt.mustLength(ct[4]); cLen != 8388608 { // BINARY
-			dbt.Errorf("failed to get length. %#v", ct[4])
+		dbt.mustFailDecimalSize(ct[5])
+		if cLen = dbt.mustLength(ct[5]); cLen != 8388608 { // BINARY
+			dbt.Errorf("failed to get length. %#v", ct[5])
 		}
-		if canNull := dbt.mustNullable(ct[4]); canNull {
-			dbt.Errorf("failed to get nullable. %#v", ct[4])
+		if canNull := dbt.mustNullable(ct[5]); canNull {
+			dbt.Errorf("failed to get nullable. %#v", ct[5])
 		}
 		if !v6 {
 			dbt.Errorf("failed to scan. %#v", v6)
 		}
-		dbt.mustFailDecimalSize(ct[5])
-		dbt.mustFailLength(ct[5])
-		/*canNull = dbt.mustNullable(ct[5])
-		if canNull {
-			dbt.Errorf("failed to get nullable. %#v", ct[5])
-		}*/
+		dbt.mustFailDecimalSize(ct[6])
+		dbt.mustFailLength(ct[6])
 	})
 }
 

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -334,14 +334,14 @@ func TestBindingInterface(t *testing.T) {
 		if !rows.Next() {
 			dbt.Error("failed to query")
 		}
-		var v1, v2, v3, v4, v5, v6 any
-		if err := rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6); err != nil {
+		var v1, v2, v2a, v3, v4, v5, v6 any
+		if err := rows.Scan(&v1, &v2, &v2a, &v3, &v4, &v5, &v6); err != nil {
 			dbt.Errorf("failed to scan: %#v", err)
 		}
 		if s1, ok := v1.(*big.Float); !ok || s1.Cmp(big.NewFloat(1.0)) != 0 {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v1)
 		}
-		if s2, ok := v2.(int64); !ok || s2 != 2 {
+		if s2, ok := v2a.(*big.Int); !ok || big.NewInt(22).Cmp(s2) != 0 {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v2)
 		}
 		if s3, ok := v3.(string); !ok || s3 != "t3" {
@@ -362,8 +362,8 @@ func TestBindingInterfaceString(t *testing.T) {
 		if !rows.Next() {
 			dbt.Error("failed to query")
 		}
-		var v1, v2, v3, v4, v5, v6 any
-		if err := rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6); err != nil {
+		var v1, v2, v2a, v3, v4, v5, v6 any
+		if err := rows.Scan(&v1, &v2, &v2a, &v3, &v4, &v5, &v6); err != nil {
 			dbt.Errorf("failed to scan: %#v", err)
 		}
 		if s, ok := v1.(string); !ok {
@@ -373,7 +373,7 @@ func TestBindingInterfaceString(t *testing.T) {
 		} else if d != 1.00 {
 			dbt.Errorf("failed to fetch. expected: 1.00, value: %v", v1)
 		}
-		if s, ok := v2.(string); !ok || s != "2" {
+		if s, ok := v2a.(string); !ok || s != "22" {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v2)
 		}
 		if s, ok := v3.(string); !ok || s != "t3" {
@@ -1457,7 +1457,7 @@ func testInsertLOBData(t *testing.T, useArrowFormat bool, isLiteral bool) {
 	}{
 		{"C1", reflect.TypeOf("")},
 		{"C2", reflect.TypeOf("")},
-		{"C3", reflect.TypeOf(int64(0))},
+		{"C3", reflect.TypeOf("")},
 	}
 	testCases := []struct {
 		testDesc string

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -341,8 +341,11 @@ func TestBindingInterface(t *testing.T) {
 		if s1, ok := v1.(*big.Float); !ok || s1.Cmp(big.NewFloat(1.0)) != 0 {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v1)
 		}
-		if s2, ok := v2a.(*big.Int); !ok || big.NewInt(22).Cmp(s2) != 0 {
+		if s2, ok := v2.(int64); !ok || s2 != 2 {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v2)
+		}
+		if s2a, ok := v2a.(*big.Int); !ok || big.NewInt(22).Cmp(s2a) != 0 {
+			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v2a)
 		}
 		if s3, ok := v3.(string); !ok || s3 != "t3" {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v3)
@@ -373,8 +376,11 @@ func TestBindingInterfaceString(t *testing.T) {
 		} else if d != 1.00 {
 			dbt.Errorf("failed to fetch. expected: 1.00, value: %v", v1)
 		}
-		if s, ok := v2a.(string); !ok || s != "22" {
+		if s, ok := v2.(string); !ok || s != "2" {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v2)
+		}
+		if s, ok := v2a.(string); !ok || s != "22" {
+			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v2a)
 		}
 		if s, ok := v3.(string); !ok || s != "t3" {
 			dbt.Fatalf("failed to fetch. ok: %v, value: %v", ok, v3)

--- a/driver_test.go
+++ b/driver_test.go
@@ -39,7 +39,7 @@ var (
 
 const (
 	selectNumberSQL       = "SELECT %s::NUMBER(%v, %v) AS C"
-	selectVariousTypes    = "SELECT 1.0::NUMBER(30,2) as C1, 2::NUMBER(38,0) AS C2, 't3' AS C3, 4.2::DOUBLE AS C4, 'abcd'::BINARY(8388608) AS C5, true AS C6"
+	selectVariousTypes    = "SELECT 1.0::NUMBER(30,2) as C1, 2::NUMBER(18,0) AS C2, 22::NUMBER(38, 0) AS C2A, 't3' AS C3, 4.2::DOUBLE AS C4, 'abcd'::BINARY(8388608) AS C5, true AS C6"
 	selectRandomGenerator = "SELECT SEQ8(), RANDSTR(1000, RANDOM()) FROM TABLE(GENERATOR(ROWCOUNT=>%v))"
 	PSTLocation           = "America/Los_Angeles"
 )
@@ -243,6 +243,7 @@ func (dbt *DBTest) mustQueryContextT(ctx context.Context, t *testing.T, query st
 	return &RowsExtended{
 		rows:      rs,
 		closeChan: &c0,
+		t:         t,
 	}
 }
 

--- a/old_driver_test.go
+++ b/old_driver_test.go
@@ -89,9 +89,12 @@ func TestJSONVariousTypes(t *testing.T) {
 		if canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[1])
 		}
+		if v2a != 22 {
+			dbt.Errorf("failed to scan. %#v", v2a)
+		}
 		pr, sc = dbt.mustDecimalSize(ct[2])
 		if pr != 38 || sc != 0 {
-			dbt.Errorf("failed to get precision and scale. %#v", ct[1])
+			dbt.Errorf("failed to get precision and scale. %#v", ct[2])
 		}
 		if v3 != "t3" {
 			dbt.Errorf("failed to scan. %#v", v3)
@@ -122,7 +125,7 @@ func TestJSONVariousTypes(t *testing.T) {
 		if cLen != 8388608 {
 			dbt.Errorf("failed to get length. %#v", ct[5])
 		}
-		canNull = dbt.mustNullable(ct[4])
+		canNull = dbt.mustNullable(ct[5])
 		if canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[5])
 		}

--- a/old_driver_test.go
+++ b/old_driver_test.go
@@ -40,19 +40,19 @@ func TestJSONVariousTypes(t *testing.T) {
 			dbt.Errorf("column types: %v", ct)
 		}
 		var v1 float32
-		var v2 int
+		var v2, v2a int
 		var v3 string
 		var v4 float64
 		var v5 []byte
 		var v6 bool
-		err = rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6)
+		err = rows.Scan(&v1, &v2, &v2a, &v3, &v4, &v5, &v6)
 		if err != nil {
 			dbt.Errorf("failed to scan: %#v", err)
 		}
 		if v1 != 1.0 {
 			dbt.Errorf("failed to scan. %#v", v1)
 		}
-		if ct[0].Name() != "C1" || ct[1].Name() != "C2" || ct[2].Name() != "C3" || ct[3].Name() != "C4" || ct[4].Name() != "C5" || ct[5].Name() != "C6" {
+		if ct[0].Name() != "C1" || ct[1].Name() != "C2" || ct[2].Name() != "C2A" || ct[3].Name() != "C3" || ct[4].Name() != "C4" || ct[5].Name() != "C5" || ct[6].Name() != "C6" {
 			dbt.Errorf("failed to get column names: %#v", ct)
 		}
 		if ct[0].ScanType() != reflect.TypeOf(float64(0)) {
@@ -61,6 +61,7 @@ func TestJSONVariousTypes(t *testing.T) {
 		if ct[1].ScanType() != reflect.TypeOf(int64(0)) {
 			dbt.Errorf("failed to get scan type. expected: %v, got: %v", reflect.TypeOf(int64(0)), ct[1].ScanType())
 		}
+		assertEqualE(t, ct[2].ScanType(), reflect.TypeOf(""))
 		var pr, sc int64
 		var cLen int64
 		var canNull bool
@@ -80,7 +81,7 @@ func TestJSONVariousTypes(t *testing.T) {
 			dbt.Errorf("failed to scan. %#v", v2)
 		}
 		pr, sc = dbt.mustDecimalSize(ct[1])
-		if pr != 38 || sc != 0 {
+		if pr != 18 || sc != 0 {
 			dbt.Errorf("failed to get precision and scale. %#v", ct[1])
 		}
 		dbt.mustFailLength(ct[1])
@@ -88,49 +89,48 @@ func TestJSONVariousTypes(t *testing.T) {
 		if canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[1])
 		}
+		pr, sc = dbt.mustDecimalSize(ct[2])
+		if pr != 38 || sc != 0 {
+			dbt.Errorf("failed to get precision and scale. %#v", ct[1])
+		}
 		if v3 != "t3" {
 			dbt.Errorf("failed to scan. %#v", v3)
 		}
-		dbt.mustFailDecimalSize(ct[2])
-		cLen = dbt.mustLength(ct[2])
-		if cLen != 2 {
-			dbt.Errorf("failed to get length. %#v", ct[2])
-		}
-		canNull = dbt.mustNullable(ct[2])
-		if canNull {
-			dbt.Errorf("failed to get nullable. %#v", ct[2])
-		}
-		if v4 != 4.2 {
-			dbt.Errorf("failed to scan. %#v", v4)
-		}
 		dbt.mustFailDecimalSize(ct[3])
-		dbt.mustFailLength(ct[3])
+		cLen = dbt.mustLength(ct[3])
+		if cLen != 2 {
+			dbt.Errorf("failed to get length. %#v", ct[3])
+		}
 		canNull = dbt.mustNullable(ct[3])
 		if canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[3])
 		}
-		if !bytes.Equal(v5, []byte{0xab, 0xcd}) {
-			dbt.Errorf("failed to scan. %#v", v5)
+		if v4 != 4.2 {
+			dbt.Errorf("failed to scan. %#v", v4)
 		}
 		dbt.mustFailDecimalSize(ct[4])
-		cLen = dbt.mustLength(ct[4]) // BINARY
-		if cLen != 8388608 {
-			dbt.Errorf("failed to get length. %#v", ct[4])
-		}
+		dbt.mustFailLength(ct[4])
 		canNull = dbt.mustNullable(ct[4])
 		if canNull {
 			dbt.Errorf("failed to get nullable. %#v", ct[4])
 		}
+		if !bytes.Equal(v5, []byte{0xab, 0xcd}) {
+			dbt.Errorf("failed to scan. %#v", v5)
+		}
+		dbt.mustFailDecimalSize(ct[5])
+		cLen = dbt.mustLength(ct[5]) // BINARY
+		if cLen != 8388608 {
+			dbt.Errorf("failed to get length. %#v", ct[5])
+		}
+		canNull = dbt.mustNullable(ct[4])
+		if canNull {
+			dbt.Errorf("failed to get nullable. %#v", ct[5])
+		}
 		if !v6 {
 			dbt.Errorf("failed to scan. %#v", v6)
 		}
-		dbt.mustFailDecimalSize(ct[5])
-		dbt.mustFailLength(ct[5])
-		/*canNull = dbt.mustNullable(ct[5])
-		if canNull {
-			dbt.Errorf("failed to get nullable. %#v", ct[5])
-		}*/
-
+		dbt.mustFailDecimalSize(ct[6])
+		dbt.mustFailLength(ct[6])
 	})
 }
 
@@ -184,8 +184,8 @@ func TestBindingJSONInterface(t *testing.T) {
 		if !rows.Next() {
 			dbt.Error("failed to query")
 		}
-		var v1, v2, v3, v4, v5, v6 interface{}
-		if err := rows.Scan(&v1, &v2, &v3, &v4, &v5, &v6); err != nil {
+		var v1, v2, v2a, v3, v4, v5, v6 interface{}
+		if err := rows.Scan(&v1, &v2, &v2a, &v3, &v4, &v5, &v6); err != nil {
 			dbt.Errorf("failed to scan: %#v", err)
 		}
 		if s, ok := v1.(string); !ok || s != "1.00" {

--- a/rows.go
+++ b/rows.go
@@ -148,7 +148,7 @@ func (rows *snowflakeRows) ColumnTypeScanType(index int) reflect.Type {
 	if err := rows.waitForAsyncQueryStatus(); err != nil {
 		return nil
 	}
-	return snowflakeTypeToGo(rows.ctx, getSnowflakeType(rows.ChunkDownloader.getRowType()[index].Type), rows.ChunkDownloader.getRowType()[index].Scale, rows.ChunkDownloader.getRowType()[index].Fields)
+	return snowflakeTypeToGo(rows.ctx, getSnowflakeType(rows.ChunkDownloader.getRowType()[index].Type), rows.ChunkDownloader.getRowType()[index].Precision, rows.ChunkDownloader.getRowType()[index].Scale, rows.ChunkDownloader.getRowType()[index].Fields)
 }
 
 func (rows *snowflakeRows) GetQueryID() string {

--- a/rows_test.go
+++ b/rows_test.go
@@ -15,6 +15,7 @@ import (
 type RowsExtended struct {
 	rows      *sql.Rows
 	closeChan *chan bool
+	t *testing.T
 }
 
 func (rs *RowsExtended) Close() error {
@@ -39,12 +40,21 @@ func (rs *RowsExtended) Next() bool {
 	return rs.rows.Next()
 }
 
+func (rs *RowsExtended) mustNext() {
+	assertTrueF(rs.t, rs.rows.Next())
+}
+
 func (rs *RowsExtended) NextResultSet() bool {
 	return rs.rows.NextResultSet()
 }
 
 func (rs *RowsExtended) Scan(dest ...interface{}) error {
 	return rs.rows.Scan(dest...)
+}
+
+func (rs *RowsExtended) mustScan(dest ...interface{}) {
+	err := rs.rows.Scan(dest...)
+	assertNilF(rs.t, err)
 }
 
 // test variables


### PR DESCRIPTION
### Description

SNOW-2091309 Before this change, when `NUMBER(19, 0)` was used as a column, there was a potential loss of precision when the value was above 9,223,372,036,854,775,807 (max int64 value). To fix this issue, `*big.Int` or string (depending on the higher precision setting) is pessimistically chosen as the return type for such a column.

Also, added higher precision support for JSON result sets.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
