### PR TITLE
SNOW-2032700 Go driver support virtual-style domains(3)

### DIFF
--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -401,11 +401,13 @@ func (util *snowflakeGcsClient) generateFileURL(stageInfo *execResponseStageInfo
 	if stageInfo.EndPoint != "" {
 		endPoint = fmt.Sprintf("https://%s", stageInfo.EndPoint)
 	} else if stageInfo.UseVirtualURL {
-		bucketName := util.extractBucketNameAndPath(stageInfo.Location).bucketName
-		endPoint = fmt.Sprintf("https://%s.storage.googleapis.com", bucketName)
-		return url.Parse(endPoint + "/" + url.QueryEscape(fullFilePath))
+		endPoint = fmt.Sprintf("https://%s.storage.googleapis.com", gcsLoc.bucketName)
 	} else if stageInfo.Region != "" && isRegionalURLEnabled {
 		endPoint = fmt.Sprintf("https://storage.%s.rep.googleapis.com", strings.ToLower(stageInfo.Region))
+	}
+
+	if stageInfo.UseVirtualURL {
+		return url.Parse(endPoint + "/" + url.QueryEscape(fullFilePath))
 	}
 
 	return url.Parse(endPoint + "/" + gcsLoc.bucketName + "/" + url.QueryEscape(fullFilePath))

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -1272,7 +1272,7 @@ func TestGetGcsCustomEndpoint(t *testing.T) {
 				Region:         "ME-CENTRAL2",
 				UseVirtualURL:  true,
 			},
-			expectedFileURL: "https://storage.specialEndPoint.rep.googleapis.com/my-travel-maps",
+			expectedFileURL: "https://storage.specialEndPoint.rep.googleapis.com",
 		},
 	}
 


### PR DESCRIPTION
### Description

SNOW-2032700 Please explain the changes you made here.
- [x] Removed one condition from the generate URL function. If the VirtualUrl is enabled, the bucket name should not be included even if the endPoint is specified. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
