### PR TITLE
Add the print statements during the timeout loop.

### DIFF
--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -282,7 +282,13 @@ func doAuthenticateByExternalBrowser(
 	}
 
 	if err = openBrowser(loginURL); err != nil {
-		return authenticateByExternalBrowserResult{nil, nil, err}
+	    msg := fmt.Sprintf("[Snowflake] Failed to launch browser automatically: %v", err)
+	    fmt.Fprintf(os.Stderr, "\n%s\n", msg)
+	    fmt.Fprintf(os.Stderr, "[Snowflake] To authenticate, please manually open the following URL in your browser:\n\n%s\n\n", loginURL)
+	    fmt.Fprintf(os.Stderr, "[Snowflake] Waiting for you to complete authentication in your browser...\n")
+
+	    logger.WithContext(ctx).Infof("%s", msg)
+	    logger.WithContext(ctx).Infof("Manual authentication URL: %s", loginURL)
 	}
 
 	encodedSamlResponseChan := make(chan string)


### PR DESCRIPTION
## Description

We need to bring the auth method behavior into compliance with the Python connector.

Gosnowflake does not print the url. It simply fails out. The Python adapter prints the URL and gives you an opportunity to paste that into a browser manually if `xdg-open` fails.


## Solution Summary

* Implements a fallback when openBrowser(loginURL) fails during external browser authentication.
* Instead of returning an error, it now:
     * Prints the login URL to stderr
     * Logs the failure and URL via the standard logger
     * Continues waiting for the browser to complete authentication via redirect

## Additional notes

#### How do I know this works?

I have some testing to do. However, this method was coded inside a clever localhost tcp listener solution. The printing does not exit the that routine (except in case of timeout or executable interrupt).

## Notes to the customer:
1. pkg/browser on Linux tries xdg-open, x-www-browser, or www-browser.
2. These often fail in WSL due to environment/path mismatches or lack of GUI.
3. Users in WSL environments may still want automatic browser launching.
4. For that, we can recommend overriding xdg-open with a wrapper that uses wslview, e.g.:
```
sudo apt install wslu
echo -e '#!/bin/sh\nwslview \"$@\"' > ~/.local/bin/xdg-open
chmod +x ~/.local/bin/xdg-open
export PATH=\"$HOME/.local/bin:$PATH\"
```

This allows gosnowflake and other tools to launch the Windows default browser correctly from within WSL. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
