### PR TITLE
SNOW-2135451 Support snake_case connection parameters

### DIFF
--- a/connection_configuration.go
+++ b/connection_configuration.go
@@ -82,7 +82,10 @@ func parseToml(cfg *Config, connectionMap map[string]interface{}) error {
 func handleSingleParam(cfg *Config, key string, value interface{}) error {
 	var err error
 	var v, tokenPath string
-	switch strings.ToLower(key) {
+
+	normalizedKey := strings.ReplaceAll(strings.ToLower(key), "_", "")
+
+	switch normalizedKey {
 	case "user", "username":
 		cfg.User, err = parseString(value)
 	case "password":
@@ -107,21 +110,21 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 		cfg.Passcode, err = parseString(value)
 	case "port":
 		cfg.Port, err = parseInt(value)
-	case "passcodeinpassword", "passcode_in_password":
+	case "passcodeinpassword":
 		cfg.PasscodeInPassword, err = parseBool(value)
-	case "clienttimeout", "client_timeout":
+	case "clienttimeout":
 		cfg.ClientTimeout, err = parseDuration(value)
-	case "jwtclienttimeout", "jwt_client_timeout":
+	case "jwtclienttimeout":
 		cfg.JWTClientTimeout, err = parseDuration(value)
-	case "logintimeout", "login_timeout":
+	case "logintimeout":
 		cfg.LoginTimeout, err = parseDuration(value)
-	case "requesttimeout", "request_timeout":
+	case "requesttimeout":
 		cfg.RequestTimeout, err = parseDuration(value)
-	case "jwttimeout", "jwt_timeout":
+	case "jwttimeout":
 		cfg.JWTExpireTimeout, err = parseDuration(value)
-	case "externalbrowsertimeout", "external_browser_timeout":
+	case "externalbrowsertimeout":
 		cfg.ExternalBrowserTimeout, err = parseDuration(value)
-	case "maxretrycount", "max_retry_count":
+	case "maxretrycount":
 		cfg.MaxRetryCount, err = parseInt(value)
 	case "application":
 		cfg.Application, err = parseString(value)
@@ -131,12 +134,12 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 			return err
 		}
 		err = determineAuthenticatorType(cfg, v)
-	case "disableocspchecks", "disable_ocsp_checks":
+	case "disableocspchecks":
 		cfg.DisableOCSPChecks, err = parseBool(value)
-	case "insecuremode", "insecure_mode":
+	case "insecuremode":
 		logInsecureModeDeprecationInfo()
 		cfg.InsecureMode, err = parseBool(value)
-	case "ocspfailopen", "ocsp_fail_open":
+	case "ocspfailopen":
 		var vv ConfigBool
 		vv, err = parseConfigBool(value)
 		if err := checkParsingError(err, key, value); err != nil {
@@ -145,7 +148,7 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 		cfg.OCSPFailOpen = OCSPFailOpenMode(vv)
 	case "token":
 		cfg.Token, err = parseString(value)
-	case "privatekey", "private_key":
+	case "privatekey":
 		v, err = parseString(value)
 		if err = checkParsingError(err, key, value); err != nil {
 			return err
@@ -158,44 +161,44 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 			}
 		}
 		cfg.PrivateKey, err = parsePKCS8PrivateKey(block)
-	case "validatedefaultparameters", "validate_default_parameters":
+	case "validatedefaultparameters":
 		cfg.ValidateDefaultParameters, err = parseConfigBool(value)
-	case "clientrequestmfatoken", "client_request_mfa_token":
+	case "clientrequestmfatoken":
 		cfg.ClientRequestMfaToken, err = parseConfigBool(value)
-	case "clientstoretemporarycredential", "client_store_temporary_credential":
+	case "clientstoretemporarycredential":
 		cfg.ClientStoreTemporaryCredential, err = parseConfigBool(value)
 	case "tracing":
 		cfg.Tracing, err = parseString(value)
-	case "tmpdirpath", "tmp_dir_path":
+	case "tmpdirpath":
 		cfg.TmpDirPath, err = parseString(value)
-	case "disablequerycontextcache", "disable_query_context_cache":
+	case "disablequerycontextcache":
 		cfg.DisableQueryContextCache, err = parseBool(value)
-	case "includeretryreason", "include_retry_reason":
+	case "includeretryreason":
 		cfg.IncludeRetryReason, err = parseConfigBool(value)
-	case "clientconfigfile", "client_config_file":
+	case "clientconfigfile":
 		cfg.ClientConfigFile, err = parseString(value)
-	case "disableconsolelogin", "disable_console_login":
+	case "disableconsolelogin":
 		cfg.DisableConsoleLogin, err = parseConfigBool(value)
-	case "disablesamlurlcheck", "disable_saml_url_check":
+	case "disablesamlurlcheck":
 		cfg.DisableSamlURLCheck, err = parseConfigBool(value)
-	case "oauth_authorization_url":
+	case "oauthauthorizationurl":
 		cfg.OauthAuthorizationURL, err = parseString(value)
-	case "oauth_client_id":
+	case "oauthclientid":
 		cfg.OauthClientID, err = parseString(value)
-	case "oauth_client_secret":
+	case "oauthclientsecret":
 		cfg.OauthClientSecret, err = parseString(value)
-	case "oauth_token_request_url":
+	case "oauthtokenrequesturl":
 		cfg.OauthTokenRequestURL, err = parseString(value)
-	case "oauth_redirect_uri":
+	case "oauthredirecturi":
 		cfg.OauthRedirectURI, err = parseString(value)
-	case "oauth_scope":
+	case "oauthscope":
 		cfg.OauthScope, err = parseString(value)
-	case "workload_identity_provider":
+	case "workloadidentityprovider":
 		cfg.WorkloadIdentityProvider, err = parseString(value)
-	case "workload_identity_entra_resource":
+	case "workloadidentityentraresource":
 		cfg.WorkloadIdentityEntraResource, err = parseString(value)
 
-	case "token_file_path":
+	case "tokenfilepath":
 		tokenPath, err = parseString(value)
 		if err = checkParsingError(err, key, value); err != nil {
 			return err

--- a/connection_configuration.go
+++ b/connection_configuration.go
@@ -107,21 +107,21 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 		cfg.Passcode, err = parseString(value)
 	case "port":
 		cfg.Port, err = parseInt(value)
-	case "passcodeinpassword":
+	case "passcodeinpassword", "passcode_in_password":
 		cfg.PasscodeInPassword, err = parseBool(value)
-	case "clienttimeout":
+	case "clienttimeout", "client_timeout":
 		cfg.ClientTimeout, err = parseDuration(value)
-	case "jwtclienttimeout":
+	case "jwtclienttimeout", "jwt_client_timeout":
 		cfg.JWTClientTimeout, err = parseDuration(value)
-	case "logintimeout":
+	case "logintimeout", "login_timeout":
 		cfg.LoginTimeout, err = parseDuration(value)
-	case "requesttimeout":
+	case "requesttimeout", "request_timeout":
 		cfg.RequestTimeout, err = parseDuration(value)
-	case "jwttimeout":
+	case "jwttimeout", "jwt_timeout":
 		cfg.JWTExpireTimeout, err = parseDuration(value)
-	case "externalbrowsertimeout":
+	case "externalbrowsertimeout", "external_browser_timeout":
 		cfg.ExternalBrowserTimeout, err = parseDuration(value)
-	case "maxretrycount":
+	case "maxretrycount", "max_retry_count":
 		cfg.MaxRetryCount, err = parseInt(value)
 	case "application":
 		cfg.Application, err = parseString(value)
@@ -131,12 +131,12 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 			return err
 		}
 		err = determineAuthenticatorType(cfg, v)
-	case "disableocspchecks":
+	case "disableocspchecks", "disable_ocsp_checks":
 		cfg.DisableOCSPChecks, err = parseBool(value)
-	case "insecuremode":
+	case "insecuremode", "insecure_mode":
 		logInsecureModeDeprecationInfo()
 		cfg.InsecureMode, err = parseBool(value)
-	case "ocspfailopen":
+	case "ocspfailopen", "ocsp_fail_open":
 		var vv ConfigBool
 		vv, err = parseConfigBool(value)
 		if err := checkParsingError(err, key, value); err != nil {
@@ -145,7 +145,7 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 		cfg.OCSPFailOpen = OCSPFailOpenMode(vv)
 	case "token":
 		cfg.Token, err = parseString(value)
-	case "privatekey":
+	case "privatekey", "private_key":
 		v, err = parseString(value)
 		if err = checkParsingError(err, key, value); err != nil {
 			return err
@@ -158,25 +158,25 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 			}
 		}
 		cfg.PrivateKey, err = parsePKCS8PrivateKey(block)
-	case "validatedefaultparameters":
+	case "validatedefaultparameters", "validate_default_parameters":
 		cfg.ValidateDefaultParameters, err = parseConfigBool(value)
-	case "clientrequestmfatoken":
+	case "clientrequestmfatoken", "client_request_mfa_token":
 		cfg.ClientRequestMfaToken, err = parseConfigBool(value)
-	case "clientstoretemporarycredential":
+	case "clientstoretemporarycredential", "client_store_temporary_credential":
 		cfg.ClientStoreTemporaryCredential, err = parseConfigBool(value)
 	case "tracing":
 		cfg.Tracing, err = parseString(value)
-	case "tmpdirpath":
+	case "tmpdirpath", "tmp_dir_path":
 		cfg.TmpDirPath, err = parseString(value)
-	case "disablequerycontextcache":
+	case "disablequerycontextcache", "disable_query_context_cache":
 		cfg.DisableQueryContextCache, err = parseBool(value)
-	case "includeretryreason":
+	case "includeretryreason", "include_retry_reason":
 		cfg.IncludeRetryReason, err = parseConfigBool(value)
-	case "clientconfigfile":
+	case "clientconfigfile", "client_config_file":
 		cfg.ClientConfigFile, err = parseString(value)
-	case "disableconsolelogin":
+	case "disableconsolelogin", "disable_console_login":
 		cfg.DisableConsoleLogin, err = parseConfigBool(value)
-	case "disablesamlurlcheck":
+	case "disablesamlurlcheck", "disable_saml_url_check":
 		cfg.DisableSamlURLCheck, err = parseConfigBool(value)
 	case "oauth_authorization_url":
 		cfg.OauthAuthorizationURL, err = parseString(value)

--- a/connection_configuration.go
+++ b/connection_configuration.go
@@ -83,8 +83,10 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 	var err error
 	var v, tokenPath string
 
+	// We normalize the key to handle both snake_case and camelCase.
 	normalizedKey := strings.ReplaceAll(strings.ToLower(key), "_", "")
 
+	// the cases in switch statement should be in lower case and no _
 	switch normalizedKey {
 	case "user", "username":
 		cfg.User, err = parseString(value)

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -205,23 +205,24 @@ func TestParseToml(t *testing.T) {
 		{
 			testParams: []string{"user", "password", "host", "account", "warehouse", "database",
 				"schema", "role", "region", "protocol", "passcode", "application", "token",
-				"tracing", "tmpDirPath", "clientConfigFile", "oauth_authorization_url", "oauth_client_id",
+				"tracing", "tmpDirPath", "tmp_dir_path", "clientConfigFile", "client_config_file", "oauth_authorization_url", "oauth_client_id",
 				"oauth_client_secret", "oauth_token_request_url", "oauth_redirect_uri", "oauth_scope",
 				"workload_identity_provider", "workload_identity_entra_resource"},
 			values: []interface{}{"value"},
 		},
 		{
-			testParams: []string{"privatekey"},
+			testParams: []string{"privatekey", "private_key"},
 			values:     []interface{}{generatePKCS8StringSupress(testPrivKey)},
 		},
 		{
-			testParams: []string{"port", "maxRetryCount", "clientTimeout", "jwtClientTimeout", "loginTimeout",
-				"requestTimeout", "jwtTimeout", "externalBrowserTimeout"},
+			testParams: []string{"port", "maxRetryCount", "max_retry_count", "clientTimeout", "client_timeout", "jwtClientTimeout", "jwt_client_timeout", "loginTimeout",
+				"login_timeout", "requestTimeout", "request_timeout", "jwtTimeout", "jwt_timeout", "externalBrowserTimeout", "external_browser_timeout"},
 			values: []interface{}{"300", 500},
 		},
 		{
-			testParams: []string{"ocspFailOpen", "insecureMode", "PasscodeInPassword", "validateDEFAULTParameters", "clientRequestMFAtoken",
-				"clientStoreTemporaryCredential", "disableQueryContextCache", "includeRetryReason", "disableConsoleLogin", "disableSamlUrlCheck"},
+			testParams: []string{"ocspFailOpen", "ocsp_fail_open", "insecureMode", "insecure_mode", "PasscodeInPassword", "passcode_in_password", "validateDEFAULTParameters", "validate_default_parameters",
+				"clientRequestMFAtoken", "client_request_mfa_token", "clientStoreTemporaryCredential", "client_store_temporary_credential", "disableQueryContextCache", "disable_query_context_cache", "disable_ocsp_checks",
+				"includeRetryReason", "include_retry_reason", "disableConsoleLogin", "disable_console_login", "disableSamlUrlCheck", "disable_saml_url_check"},
 			values: []interface{}{true, "true", false, "false"},
 		},
 	}

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -95,6 +95,18 @@ func TestLoadConnectionConfigForOAuth(t *testing.T) {
 	assertEqualE(t, cfg.DisableOCSPChecks, true)
 }
 
+func TestLoadConnectionConfigForSnakeCaseConfiguration(t *testing.T) {
+	err := os.Chmod("./test_data/connections.toml", 0600)
+	assertNilF(t, err, "The error occurred because you cannot change the file permission")
+
+	os.Setenv(snowflakeHome, "./test_data")
+	os.Setenv(snowflakeConnectionName, "snake-case")
+
+	cfg, err := loadConnectionConfig()
+	assertNilF(t, err, "The error should not occur")
+	assertEqualE(t, cfg.OCSPFailOpen, OCSPFailOpenTrue)
+}
+
 func TestReadTokenValueWithTokenFilePath(t *testing.T) {
 	err := os.Chmod("./test_data/connections.toml", 0600)
 	assertNilF(t, err, "The error occurred because you cannot change the file permission")

--- a/test_data/connections.toml
+++ b/test_data/connections.toml
@@ -46,3 +46,14 @@ protocol = 'https'
 authenticator = 'oauth'
 token_file_path = './test_data/snowflake/session/token'
 insecureMode = true
+
+[snake-case]
+account = 'snowdriverswarsaw.us-west-2.aws'
+user = 'test_default_user'
+password = 'test_default_pass'
+warehouse = 'testw_default'
+database = 'test_default_db'
+schema = 'test_default_go'
+protocol = 'https'
+port = '300'
+ocsp_fail_open=true


### PR DESCRIPTION
# Support snake_case connection parameters

## Problem
The Go driver currently doesn't support reading snake_case parameters from connection configuration files (e.g., connections.toml). This is problematic in Snowpark Container Services (SPCS) where connection parameters are automatically generated in snake_case format, preventing the use of auto-configuration features.

## Solution
Modified the connection parameter parsing logic to handle both camelCase and snake_case parameter names. This change maintains backward compatibility with camelCase while adding support for snake_case variants, enabling seamless auto-configuration in SPCS environments.

For example:
- `client_timeout` and `clientTimeout`
- `login_timeout` and `loginTimeout`
- `disable_ocsp_checks` and `disableOcspChecks`

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
