### PR TITLE
Fix unprotected concurrent access to slice

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -53,8 +53,9 @@ func (st *snowflakeTelemetry) addLog(data *telemetryData) error {
 	}
 	st.mutex.Lock()
 	st.logs = append(st.logs, data)
+	shouldFlush := len(st.logs) >= st.flushSize
 	st.mutex.Unlock()
-	if len(st.logs) >= st.flushSize {
+	if shouldFlush {
 		if err := st.sendBatch(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Access to the slices length must be protected by the mutex, but isn't. Running a test with the race detector would show the problem clearly.

Background: We are facing a large amount of memory usage that stems from the error telemetry framework of gosnowflake. It could be a leak, but it is unclear what it exactly is. While digging through the code, we found this potential issue. Most likely not
the cause of the memory growth, but good to fix in any case.