### PR TITLE
[SNOW-2159160] Add mechanism to allow skipping permission validation for configuration file

### DIFF
--- a/connection_configuration.go
+++ b/connection_configuration.go
@@ -332,7 +332,17 @@ func getConnectionDSN(dsn string) string {
 	return "default"
 }
 
+// In certain environments, the configuration file and the token file are injected and the permissions
+// are neither set to 0600 nor can be changed. In such cases, we need a way to skip the file permission validation.
+func skipFilePermissionValidation() bool {
+	return os.Getenv("GOSNOWFLAKE_SKIP_CONFIGURATION_FILE_PERMISSION_VALIDATION") != ""
+}
+
 func validateFilePermission(filePath string) error {
+	if skipFilePermissionValidation() {
+		return nil
+	}
+
 	if isWindows {
 		return nil
 	}

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -52,6 +52,26 @@ func TestTokenFilePermission(t *testing.T) {
 
 		_, err = readToken("./test_data/snowflake/session/token")
 		assertNilF(t, err, "The error occurred because the permission is not 0600")
+
+		func(t *testing.T) {
+			os.Setenv("GOSNOWFLAKE_SKIP_CONFIGURATION_FILE_PERMISSION_VALIDATION", "true")
+			defer func() {
+				os.Setenv("GOSNOWFLAKE_SKIP_CONFIGURATION_FILE_PERMISSION_VALIDATION", "")
+			}()
+
+			err = os.Chmod("./test_data/connections.toml", 0644)
+			assertNilF(t, err, "The error occurred because you cannot change the file permission")
+
+			err = os.Chmod("./test_data/snowflake/session/token", 0644)
+			assertNilF(t, err, "The error occurred because you cannot change the file permission")
+
+			_, err = loadConnectionConfig()
+			assertNilF(t, err, "The error occurred because the permission check is not skipped")
+
+			_, err = readToken("./test_data/snowflake/session/token")
+			assertNilF(t, err, "The error occurred because the permission check is not skipped")
+		}(t)
+
 	}
 }
 


### PR DESCRIPTION
### Description

SNOW-2159160 Please explain the changes you made here.

### PR Description

#### Problem
- In certain environments, the configuration and token files are injected with permissions that are not set to `0600`, and these permissions cannot be modified. This causes file permission validation to fail, blocking functionality.

#### Solution
- Introduced a mechanism to skip file permission validation by checking the environment variable `GOSNOWFLAKE_SKIP_CONFIGURATION_FILE_PERMISSION_VALIDATION`.

#### Impact
- Ensures compatibility with environments where file permissions cannot be controlled, while maintaining the ability to validate permissions in standard setups.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
