### PR TITLE
SNOW-2163233 fixing credential_cache_v1.json gets created with 0 bytes on Linux and connection caching doesnt work

### DIFF
--- a/ocsp.go
+++ b/ocsp.go
@@ -1091,7 +1091,7 @@ func createOCSPCacheDir() {
 	}
 
 	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+		if err = os.MkdirAll(cacheDir, 0700); err != nil {
 			logger.Debugf("failed to create cache directory. %v, err: %v. ignored\n", cacheDir, err)
 		}
 	}

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -560,7 +560,7 @@ func TestInitOCSPCacheFileCreation(t *testing.T) {
 	var src *os.File
 	if _, err = os.Stat(srcFileName); errors.Is(err, os.ErrNotExist) {
 		// file does not exist
-		if err = os.MkdirAll(dirName+"/.cache/snowflake/", os.ModePerm); err != nil {
+		if err = os.MkdirAll(dirName+"/.cache/snowflake/", 0700); err != nil {
 			t.Error(err)
 		}
 		if _, err = os.Create(srcFileName); err != nil {

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -273,9 +273,11 @@ func (ssm *fileBasedSecureStorageManager) lockFile() error {
 		return fmt.Errorf("failed to open %v. err: %v", lockPath, err)
 	}
 	defer func() {
-		err = lockFile.Close()
-		if err != nil {
-			logger.Debugf("error while closing lock file. %v", err)
+		if lockFile != nil {
+			err = lockFile.Close()
+			if err != nil {
+				logger.Debugf("error while closing lock file. %v", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
### Description

This is an attempt to address https://github.com/snowflakedb/gosnowflake/issues/1447. 
This is a Linux-only error, as we use different (system) keystores on MacOS and Windows; Linux is the one where we use a .json stored on the filesystem.

After further testing, this issue is maybe only triggered when upgrading from <=1.13.1 . The newer version seemed to create the cache dir with 700. 

Reproduced the issue manually on an Ubuntu 24.04 LTS just by using local SSO + MFA credentials caching. Got errors in the log:
```
time="2025-06-20T10:12:05+02:00" level=warning msg="failed to ensure permission for temporary cache dir. incorrect permissions(drwxrwxr-x, expected drwx------) for credential file" func="gosnowflake.(*defaultLogger).Warnf" file="log.go:204"
time="2025-06-20T10:12:05+02:00" level=debug msg="error while closing lock file. invalid argument" func="gosnowflake.(*defaultLogger).Debugf" file="log.go:186"
```
and we never seemed to reach the code which is actually manipulating the cache file. 

Error seems to point to: 
* temporal credential cache file is stored in the same directory (`$HOME/.cache/snowflake`) as the OCSP cache file
* and (at least on 1.131.1) OCSP creates this dir with `os.ModePerm` (effectively ending up with 775 due to umask) on my repro
* however temp.cred.cache requires 700 ! (understandably, this is a sensitive file)
* this leads to verification for temp.cred.cache determining the dir permissions are [non-700](https://github.com/snowflakedb/gosnowflake/blob/v1.14.1/secure_storage_manager.go#L231-233) and due to this permission error we return before write the token to the local cache

Fix attempts to:
* create cache dir (OCSP + temp.cred.cache) with the same exact permissions, against which we do validation later.
* also only try to close the lockfile when we managed to create it to avoid the lock-related error (should not come anyways, with proper dir permissions)

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
