### PR TITLE
fix: do not panic when `asb.scd` is nil

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -590,6 +590,13 @@ func (w *wrapReader) Close() error {
 }
 
 func (asb *ArrowStreamBatch) downloadChunkStreamHelper(ctx context.Context) error {
+	if asb == nil || asb.scd == nil {
+		return &SnowflakeError{
+			Number:   ErrNilArrowStreamBatch,
+			SQLState: SQLStateConnectionFailure,
+			Message:  errMsgNilArrowStreamBatch,
+		}
+	}
 	headers := make(map[string]string)
 	if len(asb.scd.ChunkHeader) > 0 {
 		logger.WithContext(ctx).Debug("chunk header is provided")

--- a/connection.go
+++ b/connection.go
@@ -597,6 +597,14 @@ func (asb *ArrowStreamBatch) downloadChunkStreamHelper(ctx context.Context) erro
 			Message:  errMsgNilArrowStreamBatch,
 		}
 	}
+	if asb.scd.ChunkMetas == nil || asb.idx >= len(asb.scd.ChunkMetas) {
+		return &SnowflakeError{
+			Number:      ErrFailedToGetChunk,
+			SQLState:    SQLStateConnectionFailure,
+			Message:     errMsgFailedToGetChunk,
+			MessageArgs: []interface{}{asb.idx},
+		}
+	}
 	headers := make(map[string]string)
 	if len(asb.scd.ChunkHeader) > 0 {
 		logger.WithContext(ctx).Debug("chunk header is provided")

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -60,7 +60,7 @@ func TestTokenFilePermission(t *testing.T) {
 		defer func() {
 			os.Unsetenv(skipWarningForReadPermissionsEnv)
 		}()
-		
+
 		var originalLogger = logger
 		logger = CreateDefaultLogger()
 		buf := &bytes.Buffer{}

--- a/errors.go
+++ b/errors.go
@@ -180,6 +180,8 @@ const (
 	ErrFailedToGetChunk = 262000
 	// ErrNonArrowResponseInArrowBatches is an error code for case where ArrowBatches mode is enabled, but response is not Arrow-based
 	ErrNonArrowResponseInArrowBatches = 262001
+	// ErrNilArrowStreamBatch is an error code for when ArrowStreamBatch or its scd field is nil
+	ErrNilArrowStreamBatch = 262002
 
 	/* transaction*/
 
@@ -289,6 +291,7 @@ const (
 	errMsgIdpConnectionError                 = "failed to verify URLs. authenticator: %v, token URL:%v, SSO URL:%v"
 	errMsgSSOURLNotMatch                     = "SSO URL didn't match. expected: %v, got: %v"
 	errMsgFailedToGetChunk                   = "failed to get a chunk of result sets. idx: %v"
+	errMsgNilArrowStreamBatch                = "ArrowStreamBatch or scd is nil"
 	errMsgFailedToPostQuery                  = "failed to POST. HTTP: %v, URL: %v"
 	errMsgFailedToRenew                      = "failed to renew session. HTTP: %v, URL: %v"
 	errMsgFailedToCancelQuery                = "failed to cancel query. HTTP: %v, URL: %v"

--- a/rows_test.go
+++ b/rows_test.go
@@ -15,7 +15,7 @@ import (
 type RowsExtended struct {
 	rows      *sql.Rows
 	closeChan *chan bool
-	t *testing.T
+	t         *testing.T
 }
 
 func (rs *RowsExtended) Close() error {


### PR DESCRIPTION
### Description
This is an attempt to fix the panic in the below case: 
I wouldn't say with full confidence that this is the source of the issue but it happened upon a single select query execution.
```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x3f2dca8]

goroutine 593403 [running]:
github.com/snowflakedb/gosnowflake.(*ArrowStreamBatch).downloadChunkStreamHelper(0xc002bceed0, {0x6168b88, 0xc001572ff0})
	/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.14.0/connection.go:600 +0x228
github.com/snowflakedb/gosnowflake.(*ArrowStreamBatch).GetStream(...)
	/go/pkg/mod/github.com/snowflakedb/gosnowflake@v1.14.0/connection.go:655
github.com/apache/arrow-adbc/go/adbc/driver/snowflake.newRecordReader.func3.1()
	/go/pkg/mod/github.com/apache/arrow-adbc/go/adbc@v1.6.0/driver/snowflake/record_reader.go:655 +0x106
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 593359
	/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:78 +0x93
```


### Checklist
- [ ] Created tests which fail without the change (if possible) (not exactly sure ho
- [ ] Extended the README / documentation, if necessary
