### PR TITLE
NO-SNOW Fix aws config for WIF

### DIFF
--- a/auth_wif.go
+++ b/auth_wif.go
@@ -8,15 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/golang-jwt/jwt/v5"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -153,7 +154,7 @@ type defaultAwsAttestationMetadataProvider struct {
 }
 
 func createDefaultAwsAttestationMetadataProvider(ctx context.Context) *defaultAwsAttestationMetadataProvider {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithEC2IMDSRegion())
 	if err != nil {
 		logger.Debugf("Unable to load AWS config: %v", err)
 		return nil


### PR DESCRIPTION
### Description
`LoadWithConfig` resolves region using 3 resolvers:
```
resolveRegion,                
resolveEC2IMDSRegion,
resolveDefaultRegion, 
```

When running auth on EC2 with no region in config, we should fetch it from the metadata service (resolveEC2IMDSRegion), but it returns "" unless the config option is set:
```
if o.UseEC2IMDSRegion == nil {
  return "", false, nil
}
```

PR doesn't contain any unit test changes, as they used a mocked AWS provider and can't catch such issues. Future e2e tests will catch such issues.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
