### PR TITLE
SNOW-2176203: Add RegisterTLSConfig support

### DIFF
--- a/.cursor/rules/overall-guidelines.mdc
+++ b/.cursor/rules/overall-guidelines.mdc
@@ -1,0 +1,26 @@
+# Cursor Rules for Go Snowflake Driver
+
+## General Development Standards
+
+### Code Quality
+- Follow Go formatting standards (use `gofmt`)
+- Use meaningful variable and function names
+- Include error handling for all operations that can fail
+- Write comprehensive documentation for public APIs
+
+### Project Structure
+- Place test files in the same package as the code being tested
+- Use `testdata/` directory for test fixtures and sample data
+- Group related functionality in logical packages
+
+### Testing
+- Test files should be named `*_test.go`
+- **For test-specific rules, see `testing.mdc`**
+- Write both positive and negative test cases
+- Use table-driven tests for testing multiple scenarios
+
+### Code Review Guidelines
+- Ensure code follows Go best practices
+- Verify comprehensive test coverage
+- Check that error messages are descriptive and helpful for debugging
+- Validate that public APIs are properly documented

--- a/.cursor/rules/overall-guidelines.mdc
+++ b/.cursor/rules/overall-guidelines.mdc
@@ -1,3 +1,33 @@
+---
+alwaysApply: true
+---
+
+# Cursor Rules for Go Snowflake Driver
+
+## General Development Standards
+
+### Code Quality
+- Follow Go formatting standards (use `gofmt`)
+- Use meaningful variable and function names
+- Include error handling for all operations that can fail
+- Write comprehensive documentation for public APIs
+
+### Project Structure
+- Place test files in the same package as the code being tested
+- Use `testdata/` directory for test fixtures and sample data
+- Group related functionality in logical packages
+
+### Testing
+- Test files should be named `*_test.go`
+- **For test-specific rules, see `testing.mdc`**
+- Write both positive and negative test cases
+- Use table-driven tests for testing multiple scenarios
+
+### Code Review Guidelines
+- Ensure code follows Go best practices
+- Verify comprehensive test coverage
+- Check that error messages are descriptive and helpful for debugging
+- Validate that public APIs are properly documented
 # Cursor Rules for Go Snowflake Driver
 
 ## General Development Standards

--- a/.cursor/rules/overall-guidelines.mdc
+++ b/.cursor/rules/overall-guidelines.mdc
@@ -14,33 +14,7 @@ alwaysApply: true
 
 ### Project Structure
 - Place test files in the same package as the code being tested
-- Use `testdata/` directory for test fixtures and sample data
-- Group related functionality in logical packages
-
-### Testing
-- Test files should be named `*_test.go`
-- **For test-specific rules, see `testing.mdc`**
-- Write both positive and negative test cases
-- Use table-driven tests for testing multiple scenarios
-
-### Code Review Guidelines
-- Ensure code follows Go best practices
-- Verify comprehensive test coverage
-- Check that error messages are descriptive and helpful for debugging
-- Validate that public APIs are properly documented
-# Cursor Rules for Go Snowflake Driver
-
-## General Development Standards
-
-### Code Quality
-- Follow Go formatting standards (use `gofmt`)
-- Use meaningful variable and function names
-- Include error handling for all operations that can fail
-- Write comprehensive documentation for public APIs
-
-### Project Structure
-- Place test files in the same package as the code being tested
-- Use `testdata/` directory for test fixtures and sample data
+- Use `test_data/` directory for test fixtures and sample data
 - Group related functionality in logical packages
 
 ### Testing

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,86 @@
+# Cursor Rules for Go Test Files
+
+This file automatically applies when working on `*_test.go` files.
+
+## Testing Standards
+
+### Assertion Helper Usage
+- **ALWAYS** use assertion helpers from `assert_test.go` instead of direct `t.Fatal`, `t.Fatalf`, `t.Error`, or `t.Errorf` calls
+- **NEVER** write manual if-then-fatal patterns in test functions
+
+#### Common Assertion Patterns:
+
+**Error Checking:**
+```go
+// ❌ WRONG
+if err != nil {
+    t.Fatalf("Unexpected error: %v", err)
+}
+
+// ✅ CORRECT  
+assertNilF(t, err, "Unexpected error")
+```
+
+**Nil Checking:**
+```go
+// ❌ WRONG
+if obj == nil {
+    t.Fatal("Expected non-nil object")
+}
+
+// ✅ CORRECT
+assertNotNilF(t, obj, "Expected non-nil object")
+```
+
+**Equality Checking:**
+```go
+// ❌ WRONG
+if actual != expected {
+    t.Fatalf("Expected %v, got %v", expected, actual)
+}
+
+// ✅ CORRECT
+assertEqualF(t, actual, expected, "Values should match")
+```
+
+**Error Message Validation:**
+```go
+// ❌ WRONG
+if err.Error() != expectedMsg {
+    t.Fatalf("Expected error: %s, got: %s", expectedMsg, err.Error())
+}
+
+// ✅ CORRECT
+assertEqualF(t, err.Error(), expectedMsg, "Error message should match")
+```
+
+**Boolean Assertions:**
+```go
+// ❌ WRONG
+if !condition {
+    t.Fatal("Condition should be true")
+}
+
+// ✅ CORRECT
+assertTrueF(t, condition, "Condition should be true")
+```
+
+#### Helper Function Reference:
+- `assertNilF/E(t, value, description)` - Assert value is nil
+- `assertNotNilF/E(t, value, description)` - Assert value is not nil  
+- `assertEqualF/E(t, actual, expected, description)` - Assert equality
+- `assertNotEqualF/E(t, actual, expected, description)` - Assert inequality
+- `assertTrueF/E(t, value, description)` - Assert boolean is true
+- `assertFalseF/E(t, value, description)` - Assert boolean is false
+- `assertStringContainsF/E(t, str, substring, description)` - Assert string contains substring
+- `assertErrIsF/E(t, actual, expected, description)` - Assert error matches expected error
+
+#### When to Use F vs E:
+- Use `F` suffix (Fatal) for critical failures that should stop the test immediately
+- Use `E` suffix (Error) for non-critical failures that allow the test to continue
+
+## Code Review Guidelines:
+- Flag any direct use of `t.Fatal*` or `t.Error*` in new code
+- Ensure all test functions use appropriate assertion helpers
+- Verify that error messages are descriptive and helpful for debugging
+- Check that tests are comprehensive and cover edge cases

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Cursor Rules for Go Test Files
 
 This file automatically applies when working on `*_test.go` files.
@@ -5,8 +9,8 @@ This file automatically applies when working on `*_test.go` files.
 ## Testing Standards
 
 ### Assertion Helper Usage
-- **ALWAYS** use assertion helpers from `assert_test.go` instead of direct `t.Fatal`, `t.Fatalf`, `t.Error`, or `t.Errorf` calls
-- **NEVER** write manual if-then-fatal patterns in test functions
+- **ALWAYS** Attempt to use assertion helpers from `assert_test.go` instead of direct `t.Fatal`, `t.Fatalf`, `t.Error`, or `t.Errorf` calls. Where it makes sense, add new assertion helpers.
+- **NEVER** write manual if-then-fatal patterns in test functions when a suitable assertion helper exists.
 
 #### Common Assertion Patterns:
 
@@ -66,6 +70,7 @@ assertTrueF(t, condition, "Condition should be true")
 ```
 
 #### Helper Function Reference:
+Always examine `assertion_helpers.go` for the latest set of helpers. Consider these existing examples below.
 - `assertNilF/E(t, value, description)` - Assert value is nil
 - `assertNotNilF/E(t, value, description)` - Assert value is not nil  
 - `assertEqualF/E(t, actual, expected, description)` - Assert equality
@@ -83,4 +88,4 @@ assertTrueF(t, condition, "Condition should be true")
 - Flag any direct use of `t.Fatal*` or `t.Error*` in new code
 - Ensure all test functions use appropriate assertion helpers
 - Verify that error messages are descriptive and helpful for debugging
-- Check that tests are comprehensive and cover edge cases
+- Check that tests are comprehensive and cover edge cases# Cursor Rules for Go Test Files

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -81,7 +81,7 @@ Always examine `assertion_helpers.go` for the latest set of helpers. Consider th
 - `assertErrIsF/E(t, actual, expected, description)` - Assert error matches expected error
 
 #### When to Use F vs E:
-- Use `F` suffix (Fatal) for critical failures that should stop the test immediately
+- Use `F` suffix (Fatal) for critical failures that should stop the test immediately as well as for preconditions
 - Use `E` suffix (Error) for non-critical failures that allow the test to continue
 
 ## Code Review Guidelines:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test_setup: test_teardown
 	python3 ci/scripts/hang_webserver.py 12345 &
 
 test_teardown:
-	kill -9 $$(ps -ef | grep hang_webserver | grep -v grep | awk '{print $$1}') || true
+	pkill -9 hang_webserver || true
 
 test: deps test_setup
 	./ci/scripts/execute_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ lint: clint
 ## Format source codes
 fmt: cfmt
 	@for c in $$(ls cmd); do \
-		(cd cmd/$$c;  make fmt); \
+		if [ -f cmd/$$c/Makefile ]; then \
+			(cd cmd/$$c; make fmt); \
+		fi; \
 	done
 
 ## Install sample programs

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,7 @@ lint: clint
 ## Format source codes
 fmt: cfmt
 	@for c in $$(ls cmd); do \
-		if [ -f cmd/$$c/Makefile ]; then \
-			(cd cmd/$$c; make fmt); \
-		fi; \
+		(cd cmd/$$c; make fmt); \
 	done
 
 ## Install sample programs

--- a/assert_test.go
+++ b/assert_test.go
@@ -325,18 +325,3 @@ func assertTLSConfigsEqual(t *testing.T, expected, actual *tls.Config, msg strin
 	actualHasVerifier := actual.VerifyPeerCertificate != nil
 	assertEqualF(t, expectedHasVerifier, actualHasVerifier, "%s VerifyPeerCertificate presence", msg)
 }
-
-// assertTransportHasVerifier checks if transport has a TLS verifier function
-func assertTransportHasVerifier(t *testing.T, rt http.RoundTripper, shouldHave bool, msg string) {
-	transport := castToTransport(rt)
-	assertNotNilF(t, transport, "%s - expected http.Transport", msg)
-
-	if shouldHave {
-		assertNotNilF(t, transport.TLSClientConfig, "%s - expected TLSClientConfig", msg)
-		assertNotNilF(t, transport.TLSClientConfig.VerifyPeerCertificate, "%s - expected VerifyPeerCertificate", msg)
-	} else {
-		if transport.TLSClientConfig != nil {
-			assertNilF(t, transport.TLSClientConfig.VerifyPeerCertificate, "%s - expected no VerifyPeerCertificate", msg)
-		}
-	}
-}

--- a/assert_test.go
+++ b/assert_test.go
@@ -2,10 +2,8 @@ package gosnowflake
 
 import (
 	"bytes"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -269,59 +267,4 @@ func thrownFrom() string {
 		}
 	}
 	return stack
-}
-
-// castToTransport safely casts http.RoundTripper to *http.Transport
-// Returns nil if the cast fails
-func castToTransport(rt http.RoundTripper) *http.Transport {
-	if transport, ok := rt.(*http.Transport); ok {
-		return transport
-	}
-	return nil
-}
-
-// assertTransportsEqual compares two transports, excluding function fields and other non-comparable fields
-// that may vary between instances but represent equivalent configurations
-func assertTransportsEqual(t *testing.T, expected, actual *http.Transport, msg string) {
-	if expected == nil && actual == nil {
-		return
-	}
-	assertNotNilF(t, expected, "Expected transport should not be nil in %s", msg)
-	assertNotNilF(t, actual, "Actual transport should not be nil in %s", msg)
-
-	// Compare TLS configurations
-	assertTLSConfigsEqual(t, expected.TLSClientConfig, actual.TLSClientConfig, msg+" TLS config")
-
-	// Compare other relevant transport fields (excluding function fields)
-	assertEqualF(t, expected.MaxIdleConns, actual.MaxIdleConns, "%s MaxIdleConns", msg)
-	assertEqualF(t, expected.MaxIdleConnsPerHost, actual.MaxIdleConnsPerHost, "%s MaxIdleConnsPerHost", msg)
-	assertEqualF(t, expected.MaxConnsPerHost, actual.MaxConnsPerHost, "%s MaxConnsPerHost", msg)
-	assertEqualF(t, expected.IdleConnTimeout, actual.IdleConnTimeout, "%s IdleConnTimeout", msg)
-	assertEqualF(t, expected.ResponseHeaderTimeout, actual.ResponseHeaderTimeout, "%s ResponseHeaderTimeout", msg)
-	assertEqualF(t, expected.ExpectContinueTimeout, actual.ExpectContinueTimeout, "%s ExpectContinueTimeout", msg)
-	assertEqualF(t, expected.TLSHandshakeTimeout, actual.TLSHandshakeTimeout, "%s TLSHandshakeTimeout", msg)
-	assertEqualF(t, expected.DisableKeepAlives, actual.DisableKeepAlives, "%s DisableKeepAlives", msg)
-	assertEqualF(t, expected.DisableCompression, actual.DisableCompression, "%s DisableCompression", msg)
-	assertEqualF(t, expected.ForceAttemptHTTP2, actual.ForceAttemptHTTP2, "%s ForceAttemptHTTP2", msg)
-}
-
-// assertTLSConfigsEqual compares two TLS configurations, excluding function fields
-// like VerifyPeerCertificate which may point to different but equivalent functions
-func assertTLSConfigsEqual(t *testing.T, expected, actual *tls.Config, msg string) {
-	if expected == nil && actual == nil {
-		return
-	}
-	assertNotNilF(t, expected, "Expected TLS config should not be nil in %s", msg)
-	assertNotNilF(t, actual, "Actual TLS config should not be nil in %s", msg)
-
-	// Compare non-function fields
-	assertEqualF(t, expected.InsecureSkipVerify, actual.InsecureSkipVerify, "%s InsecureSkipVerify", msg)
-	assertEqualF(t, expected.ServerName, actual.ServerName, "%s ServerName", msg)
-	assertEqualF(t, expected.MinVersion, actual.MinVersion, "%s MinVersion", msg)
-	assertEqualF(t, expected.MaxVersion, actual.MaxVersion, "%s MaxVersion", msg)
-
-	// For VerifyPeerCertificate, just check presence/absence since function pointers can't be compared
-	expectedHasVerifier := expected.VerifyPeerCertificate != nil
-	actualHasVerifier := actual.VerifyPeerCertificate != nil
-	assertEqualF(t, expectedHasVerifier, actualHasVerifier, "%s VerifyPeerCertificate presence", msg)
 }

--- a/assert_test.go
+++ b/assert_test.go
@@ -2,8 +2,10 @@ package gosnowflake
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -267,4 +269,74 @@ func thrownFrom() string {
 		}
 	}
 	return stack
+}
+
+// castToTransport safely casts http.RoundTripper to *http.Transport
+// Returns nil if the cast fails
+func castToTransport(rt http.RoundTripper) *http.Transport {
+	if transport, ok := rt.(*http.Transport); ok {
+		return transport
+	}
+	return nil
+}
+
+// assertTransportsEqual compares two transports, excluding function fields and other non-comparable fields
+// that may vary between instances but represent equivalent configurations
+func assertTransportsEqual(t *testing.T, expected, actual *http.Transport, msg string) {
+	if expected == nil && actual == nil {
+		return
+	}
+	assertNotNilF(t, expected, "Expected transport should not be nil in %s", msg)
+	assertNotNilF(t, actual, "Actual transport should not be nil in %s", msg)
+
+	// Compare TLS configurations
+	assertTLSConfigsEqual(t, expected.TLSClientConfig, actual.TLSClientConfig, msg+" TLS config")
+
+	// Compare other relevant transport fields (excluding function fields)
+	assertEqualF(t, expected.MaxIdleConns, actual.MaxIdleConns, "%s MaxIdleConns", msg)
+	assertEqualF(t, expected.MaxIdleConnsPerHost, actual.MaxIdleConnsPerHost, "%s MaxIdleConnsPerHost", msg)
+	assertEqualF(t, expected.MaxConnsPerHost, actual.MaxConnsPerHost, "%s MaxConnsPerHost", msg)
+	assertEqualF(t, expected.IdleConnTimeout, actual.IdleConnTimeout, "%s IdleConnTimeout", msg)
+	assertEqualF(t, expected.ResponseHeaderTimeout, actual.ResponseHeaderTimeout, "%s ResponseHeaderTimeout", msg)
+	assertEqualF(t, expected.ExpectContinueTimeout, actual.ExpectContinueTimeout, "%s ExpectContinueTimeout", msg)
+	assertEqualF(t, expected.TLSHandshakeTimeout, actual.TLSHandshakeTimeout, "%s TLSHandshakeTimeout", msg)
+	assertEqualF(t, expected.DisableKeepAlives, actual.DisableKeepAlives, "%s DisableKeepAlives", msg)
+	assertEqualF(t, expected.DisableCompression, actual.DisableCompression, "%s DisableCompression", msg)
+	assertEqualF(t, expected.ForceAttemptHTTP2, actual.ForceAttemptHTTP2, "%s ForceAttemptHTTP2", msg)
+}
+
+// assertTLSConfigsEqual compares two TLS configurations, excluding function fields
+// like VerifyPeerCertificate which may point to different but equivalent functions
+func assertTLSConfigsEqual(t *testing.T, expected, actual *tls.Config, msg string) {
+	if expected == nil && actual == nil {
+		return
+	}
+	assertNotNilF(t, expected, "Expected TLS config should not be nil in %s", msg)
+	assertNotNilF(t, actual, "Actual TLS config should not be nil in %s", msg)
+
+	// Compare non-function fields
+	assertEqualF(t, expected.InsecureSkipVerify, actual.InsecureSkipVerify, "%s InsecureSkipVerify", msg)
+	assertEqualF(t, expected.ServerName, actual.ServerName, "%s ServerName", msg)
+	assertEqualF(t, expected.MinVersion, actual.MinVersion, "%s MinVersion", msg)
+	assertEqualF(t, expected.MaxVersion, actual.MaxVersion, "%s MaxVersion", msg)
+
+	// For VerifyPeerCertificate, just check presence/absence since function pointers can't be compared
+	expectedHasVerifier := expected.VerifyPeerCertificate != nil
+	actualHasVerifier := actual.VerifyPeerCertificate != nil
+	assertEqualF(t, expectedHasVerifier, actualHasVerifier, "%s VerifyPeerCertificate presence", msg)
+}
+
+// assertTransportHasVerifier checks if transport has a TLS verifier function
+func assertTransportHasVerifier(t *testing.T, rt http.RoundTripper, shouldHave bool, msg string) {
+	transport := castToTransport(rt)
+	assertNotNilF(t, transport, "%s - expected http.Transport", msg)
+
+	if shouldHave {
+		assertNotNilF(t, transport.TLSClientConfig, "%s - expected TLSClientConfig", msg)
+		assertNotNilF(t, transport.TLSClientConfig.VerifyPeerCertificate, "%s - expected VerifyPeerCertificate", msg)
+	} else {
+		if transport.TLSClientConfig != nil {
+			assertNilF(t, transport.TLSClientConfig.VerifyPeerCertificate, "%s - expected no VerifyPeerCertificate", msg)
+		}
+	}
 }

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -67,7 +67,7 @@ func newOauthClient(ctx context.Context, cfg *Config, sc *snowflakeConn) (*oauth
 	}
 	logger.Debugf("Redirect URI template: %v, port: %v", redirectURITemplate, port)
 
-	transport, err := getTransport(cfg, sc.telemetry)
+	transport, err := newTransportFactory(cfg, sc.telemetry).createTransport()
 	if err != nil {
 		return nil, err
 	}

--- a/auth_wif.go
+++ b/auth_wif.go
@@ -309,7 +309,7 @@ func (c *gcpIdentityAttestationCreator) createTokenRequest() (*http.Request, err
 }
 
 func fetchTokenFromMetadataService(req *http.Request, cfg *Config, telemetry *snowflakeTelemetry) string {
-	transport, err := getTransport(cfg, telemetry)
+	transport, err := newTransportFactory(cfg, telemetry).createTransport()
 	if err != nil {
 		logger.Debugf("Failed to create HTTP transport: %v", err)
 		return ""

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -45,7 +45,7 @@ func (util *snowflakeAzureClient) createClient(info *execResponseStageInfo, _ bo
 	if err != nil {
 		return nil, err
 	}
-	transport, err := getTransport(util.cfg, telemetry)
+	transport, err := newTransportFactory(util.cfg, telemetry).createTransport()
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +349,7 @@ func (util *snowflakeAzureClient) detectAzureTokenExpireError(resp *http.Respons
 }
 
 func createContainerClient(clientURL string, cfg *Config, telemetry *snowflakeTelemetry) (*container.Client, error) {
-	transport, err := getTransport(cfg, telemetry)
+	transport, err := newTransportFactory(cfg, telemetry).createTransport()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/arrow/Makefile
+++ b/cmd/arrow/Makefile
@@ -1,0 +1,11 @@
+SUBDIRS := batches transform_batches_to_rows
+TARGETS := all install run lint fmt
+
+$(TARGETS): subdirs
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	@$(MAKE) -C $@ $(filter $(TARGETS),$(MAKECMDGOALS))
+
+.PHONY: subdirs $(TARGETS) $(SUBDIRS)

--- a/connection.go
+++ b/connection.go
@@ -797,7 +797,7 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 		return nil, err
 	}
 
-	transportFactory := NewTransportFactory(sc.cfg)
+	transportFactory := newTransportFactory(sc.cfg)
 	st, cv, err := transportFactory.createTransport()
 	if err != nil {
 		return nil, err
@@ -866,6 +866,6 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 }
 
 func getTransport(cfg *Config) (http.RoundTripper, error) {
-	transportFactory := NewTransportFactory(cfg)
-	return transportFactory.CreateFileTransferTransport()
+	transportFactory := newTransportFactory(cfg)
+	return transportFactory.CreateStandardTransport()
 }

--- a/connection.go
+++ b/connection.go
@@ -860,12 +860,3 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 
 	return sc, nil
 }
-
-func getTransport(cfg *Config, telemetry *snowflakeTelemetry) (http.RoundTripper, error) {
-	transportFactory := newTransportFactory(cfg, telemetry)
-	st, err := transportFactory.createTransport()
-	if err != nil {
-		return nil, err
-	}
-	return st, nil
-}

--- a/connection.go
+++ b/connection.go
@@ -5,15 +5,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -786,134 +782,7 @@ func (scd *snowflakeArrowStreamChunkDownloader) GetBatches() (out []ArrowStreamB
 	return
 }
 
-// validateRevocationConfig checks for conflicting revocation settings
-func validateRevocationConfig(cfg *Config) error {
-	if !cfg.DisableOCSPChecks && !cfg.InsecureMode && cfg.CertRevocationCheckMode != CertRevocationCheckDisabled {
-		return errors.New("both OCSP and CRL cannot be enabled at the same time, please disable one of them")
-	}
-	return nil
-}
-
-// chainVerificationCallbacks chains a user's custom verification with the provided verification function
-func chainVerificationCallbacks(customTLSConfig *tls.Config, verificationFunc func([][]byte, [][]*x509.Certificate) error) {
-	if customTLSConfig.VerifyPeerCertificate == nil {
-		customTLSConfig.VerifyPeerCertificate = verificationFunc
-		return
-	}
-
-	// Chain the existing verification with the new one
-	originalVerify := customTLSConfig.VerifyPeerCertificate
-	customTLSConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		// Run the user's custom verification first
-		if err := originalVerify(rawCerts, verifiedChains); err != nil {
-			return err
-		}
-		// Then run the provided verification
-		return verificationFunc(rawCerts, verifiedChains)
-	}
-}
-
-// createStandardTransport creates a standard HTTP transport with the given TLS config
-func createStandardTransport(tlsConfig *tls.Config) *http.Transport {
-	return &http.Transport{
-		TLSClientConfig: tlsConfig,
-		MaxIdleConns:    10,
-		IdleConnTimeout: 30 * time.Minute,
-		Proxy:           http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-	}
-}
-
-// setupCustomTLSTransportWithCRL creates a transport with custom TLS config and CRL validation
-func (sc *snowflakeConn) setupCustomTLSTransportWithCRL(customTLSConfig *tls.Config) (http.RoundTripper, error) {
-	// Create CRL validator for custom TLS config
-	crlTransport, cv, err := createCrlTransport(sc.cfg)
-	if err != nil {
-		return nil, err
-	}
-	sc.cv = cv
-	cv.startPeriodicCacheCleanup(sc.cfg.CrlCacheCleanerTick)
-
-	// Chain CRL verification with custom TLS config
-	crlVerify := crlTransport.TLSClientConfig.VerifyPeerCertificate
-	chainVerificationCallbacks(customTLSConfig, crlVerify)
-
-	// Use the CRL transport settings but with our custom TLS config
-	return &http.Transport{
-		TLSClientConfig: customTLSConfig,
-		MaxIdleConns:    crlTransport.MaxIdleConns,
-		IdleConnTimeout: crlTransport.IdleConnTimeout,
-		Proxy:           crlTransport.Proxy,
-		DialContext:     crlTransport.DialContext,
-	}, nil
-}
-
-// setupCustomTLSTransportWithOCSP creates a transport with custom TLS config and OCSP validation
-func setupCustomTLSTransportWithOCSP(customTLSConfig *tls.Config) http.RoundTripper {
-	// Chain OCSP verification with custom TLS config
-	chainVerificationCallbacks(customTLSConfig, verifyPeerCertificateSerial)
-	return createStandardTransport(customTLSConfig)
-}
-
-// setupCustomTLSTransport handles the custom TLS configuration path
-func (sc *snowflakeConn) setupCustomTLSTransport() (http.RoundTripper, error) {
-	customTLSConfig, ok := getTLSConfigClone(sc.cfg.TLSConfig)
-	if !ok {
-		return nil, errors.New("TLS config not found: " + sc.cfg.TLSConfig)
-	}
-
-	// Check for revocation configuration conflicts
-	if err := validateRevocationConfig(sc.cfg); err != nil {
-		return nil, err
-	}
-
-	// Handle CRL validation path
-	if sc.cfg.CertRevocationCheckMode != CertRevocationCheckDisabled {
-		return sc.setupCustomTLSTransportWithCRL(customTLSConfig)
-	}
-
-	// Handle OCSP validation path
-	if !sc.cfg.DisableOCSPChecks && !sc.cfg.InsecureMode {
-		return setupCustomTLSTransportWithOCSP(customTLSConfig), nil
-	}
-
-	// No revocation checking - just use the custom TLS config
-	return createStandardTransport(customTLSConfig), nil
-}
-
-// setupStandardTransport handles the standard (non-custom TLS) transport paths
-func (sc *snowflakeConn) setupStandardTransport() (http.RoundTripper, error) {
-	// Check for revocation configuration conflicts
-	if err := validateRevocationConfig(sc.cfg); err != nil {
-		return nil, err
-	}
-
-	// Handle CRL validation path
-	if sc.cfg.CertRevocationCheckMode != CertRevocationCheckDisabled {
-		var cv *crlValidator
-		st, cv, err := createCrlTransport(sc.cfg)
-		if err != nil {
-			return nil, err
-		}
-		sc.cv = cv
-		cv.startPeriodicCacheCleanup(sc.cfg.CrlCacheCleanerTick)
-		return st, nil
-	}
-
-	// Handle no revocation checking path
-	if sc.cfg.DisableOCSPChecks || sc.cfg.InsecureMode {
-		return snowflakeNoRevocationCheckTransport, nil
-	}
-
-	// Default OCSP path - set OCSP fail open mode
-	ocspResponseCacheLock.Lock()
-	atomic.StoreUint32((*uint32)(&ocspFailOpen), uint32(sc.cfg.OCSPFailOpen))
-	ocspResponseCacheLock.Unlock()
-	return SnowflakeTransport, nil
-}
+// These functions have been moved to transport.go as part of the TransportFactory
 
 // buildSnowflakeConn creates a new snowflakeConn.
 // The provided context is used only for establishing the initial connection.
@@ -929,25 +798,18 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 	if err != nil {
 		return nil, err
 	}
-	var st http.RoundTripper = SnowflakeTransport
 
-	// Early return: Use custom transporter if provided
-	if sc.cfg.Transporter != nil {
-		st = sc.cfg.Transporter
-	} else if sc.cfg.TLSConfig != "" {
-		// Handle custom TLS configuration path
-		var err error
-		st, err = sc.setupCustomTLSTransport()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// Handle standard transport configuration
-		var err error
-		st, err = sc.setupStandardTransport()
-		if err != nil {
-			return nil, err
-		}
+	// Create transport using the new TransportFactory
+	transportFactory := NewTransportFactory(sc.cfg)
+	st, cv, err := transportFactory.CreateTransport()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the CRL validator if one was created
+	if cv != nil {
+		sc.cv = cv
+		cv.startPeriodicCacheCleanup(sc.cfg.CrlCacheCleanerTick)
 	}
 
 	if err = setupOCSPEnvVars(ctx, sc.cfg.Host); err != nil {
@@ -1007,27 +869,6 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 }
 
 func getTransport(cfg *Config) (http.RoundTripper, error) {
-	if cfg == nil {
-		// should never happen in production, only in tests
-		logger.Warn("getTransport: got nil Config, using default one")
-		return snowflakeNoRevocationCheckTransport, nil
-	}
-	// if user configured a custom Transporter, prioritize that
-	if cfg.Transporter != nil {
-		logger.Debug("getTransport: using Transporter configured by the user")
-		return cfg.Transporter, nil
-	}
-	if cfg.CertRevocationCheckMode != CertRevocationCheckDisabled {
-		transport, _, err := createCrlTransport(cfg)
-		if err != nil {
-			return nil, err
-		}
-		return transport, nil
-	}
-	if cfg.DisableOCSPChecks || cfg.InsecureMode {
-		logger.Debug("getTransport: skipping OCSP validation for cloud storage")
-		return snowflakeNoRevocationCheckTransport, nil
-	}
-	logger.Debug("getTransport: will perform OCSP validation for cloud storage")
-	return SnowflakeTransport, nil
+	transportFactory := NewTransportFactory(cfg)
+	return transportFactory.CreateFileTransferTransport()
 }

--- a/connection.go
+++ b/connection.go
@@ -782,8 +782,6 @@ func (scd *snowflakeArrowStreamChunkDownloader) GetBatches() (out []ArrowStreamB
 	return
 }
 
-// These functions have been moved to transport.go as part of the TransportFactory
-
 // buildSnowflakeConn creates a new snowflakeConn.
 // The provided context is used only for establishing the initial connection.
 func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, error) {
@@ -801,7 +799,7 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 
 	// Create transport using the new TransportFactory
 	transportFactory := NewTransportFactory(sc.cfg)
-	st, cv, err := transportFactory.CreateTransport()
+	st, cv, err := transportFactory.createTransport()
 	if err != nil {
 		return nil, err
 	}

--- a/connection.go
+++ b/connection.go
@@ -77,7 +77,6 @@ type snowflakeConn struct {
 	internal            InternalClient
 	queryContextCache   *queryContextCache
 	currentTimeProvider currentTimeProvider
-	cv                  *crlValidator
 }
 
 var (
@@ -809,15 +808,9 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 	}
 
 	transportFactory := newTransportFactory(&config, telemetry)
-	st, cv, err := transportFactory.createTransport()
+	st, err := transportFactory.createTransport()
 	if err != nil {
 		return nil, err
-	}
-
-	// Set the CRL validator if one was created
-	if cv != nil {
-		sc.cv = cv
-		crlCacheCleaner.startPeriodicCacheCleanup()
 	}
 
 	if err = setupOCSPEnvVars(ctx, sc.cfg.Host); err != nil {
@@ -870,7 +863,7 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 
 func getTransport(cfg *Config, telemetry *snowflakeTelemetry) (http.RoundTripper, error) {
 	transportFactory := newTransportFactory(cfg, telemetry)
-	st, _, err := transportFactory.createTransport()
+	st, err := transportFactory.createTransport()
 	if err != nil {
 		return nil, err
 	}

--- a/connection.go
+++ b/connection.go
@@ -867,5 +867,9 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 
 func getTransport(cfg *Config) (http.RoundTripper, error) {
 	transportFactory := newTransportFactory(cfg)
-	return transportFactory.CreateStandardTransport()
+	st, _, err := transportFactory.createTransport()
+	if err != nil {
+		return nil, err
+	}
+	return st, nil
 }

--- a/connection.go
+++ b/connection.go
@@ -797,7 +797,6 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 		return nil, err
 	}
 
-	// Create transport using the new TransportFactory
 	transportFactory := NewTransportFactory(sc.cfg)
 	st, cv, err := transportFactory.createTransport()
 	if err != nil {

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -60,7 +60,7 @@ func TestTokenFilePermission(t *testing.T) {
 		defer func() {
 			os.Unsetenv(skipWarningForReadPermissionsEnv)
 		}()
-		
+
 		var originalLogger = logger
 		logger = CreateDefaultLogger()
 		buf := &bytes.Buffer{}

--- a/connection_test.go
+++ b/connection_test.go
@@ -890,7 +890,7 @@ func TestGetTransport(t *testing.T) {
 	crlCfg := &Config{
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
-	transportFactory := NewTransportFactory(crlCfg)
+	transportFactory := newTransportFactory(crlCfg)
 	crlTransport, err := transportFactory.CreateCRLTransport()
 	assertNilF(t, err)
 	testcases := []struct {

--- a/connection_test.go
+++ b/connection_test.go
@@ -891,7 +891,7 @@ func TestGetTransport(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
 	transportFactory := NewTransportFactory(crlCfg)
-	crlTransport, _, err := transportFactory.CreateCRLTransport()
+	crlTransport, err := transportFactory.CreateCRLTransport()
 	assertNilF(t, err)
 	testcases := []struct {
 		name      string

--- a/connection_test.go
+++ b/connection_test.go
@@ -905,7 +905,8 @@ func TestGetTransport(t *testing.T) {
 			cfg:  &Config{Account: "two", DisableOCSPChecks: true, InsecureMode: false},
 			transportCheck: func(transport http.RoundTripper) bool {
 				// We should not have a TLSClientConfig
-				return transport.(*http.Transport).TLSClientConfig == nil
+				t := castToTransport(transport)
+				return t != nil && t.TLSClientConfig == nil
 			},
 		},
 		{
@@ -913,7 +914,8 @@ func TestGetTransport(t *testing.T) {
 			cfg:  &Config{Account: "three", DisableOCSPChecks: false, InsecureMode: true},
 			transportCheck: func(transport http.RoundTripper) bool {
 				// We should not have a TLSClientConfig
-				return transport.(*http.Transport).TLSClientConfig == nil
+				t := castToTransport(transport)
+				return t != nil && t.TLSClientConfig == nil
 			},
 		},
 		{
@@ -921,7 +923,8 @@ func TestGetTransport(t *testing.T) {
 			cfg:  &Config{Account: "four"},
 			transportCheck: func(transport http.RoundTripper) bool {
 				// We should have a verifier function
-				return transport.(*http.Transport).TLSClientConfig.VerifyPeerCertificate != nil
+				t := castToTransport(transport)
+				return t != nil && t.TLSClientConfig != nil && t.TLSClientConfig.VerifyPeerCertificate != nil
 			},
 		},
 		{
@@ -929,7 +932,8 @@ func TestGetTransport(t *testing.T) {
 			cfg:  nil,
 			transportCheck: func(transport http.RoundTripper) bool {
 				// We should not have a TLSClientConfig
-				return transport.(*http.Transport).TLSClientConfig == nil
+				t := castToTransport(transport)
+				return t != nil && t.TLSClientConfig == nil
 			},
 		},
 		{
@@ -958,6 +962,8 @@ func TestGetCRLTransport(t *testing.T) {
 		transportFactory := newTransportFactory(crlCfg)
 		crlTransport, _, err := transportFactory.createTransport()
 		assertNilF(t, err)
-		assertEqualE(t, crlTransport.(*http.Transport).MaxIdleConns, 5)
+		transport := castToTransport(crlTransport)
+		assertNotNilF(t, transport, "Expected http.Transport")
+		assertEqualE(t, transport.MaxIdleConns, 5)
 	})
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -890,7 +890,8 @@ func TestGetTransport(t *testing.T) {
 	crlCfg := &Config{
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
-	crlTransport, _, err := createCrlTransport(crlCfg)
+	transportFactory := NewTransportFactory(crlCfg)
+	crlTransport, _, err := transportFactory.CreateCRLTransport()
 	assertNilF(t, err)
 	testcases := []struct {
 		name      string

--- a/connection_test.go
+++ b/connection_test.go
@@ -961,7 +961,7 @@ func TestGetTransport(t *testing.T) {
 	}
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := getTransport(test.cfg, nil)
+			result, err := newTransportFactory(test.cfg, nil).createTransport()
 			assertNilE(t, err)
 			if test.transportCheck != nil {
 				test.transportCheck(t, castToTransport(result))

--- a/connection_test.go
+++ b/connection_test.go
@@ -897,7 +897,8 @@ func TestGetTransport(t *testing.T) {
 			cfg:  &Config{Account: "one", DisableOCSPChecks: false, InsecureMode: false},
 			transportCheck: func(transport http.RoundTripper) bool {
 				// We should have a verifier function
-				return transport.(*http.Transport).TLSClientConfig.VerifyPeerCertificate != nil
+				t := castToTransport(transport)
+				return t != nil && t.TLSClientConfig != nil && t.TLSClientConfig.VerifyPeerCertificate != nil
 			},
 		},
 		{

--- a/connection_test.go
+++ b/connection_test.go
@@ -979,9 +979,9 @@ func TestGetCRLTransport(t *testing.T) {
 			DisableOCSPChecks:       true,
 		}
 		transportFactory := newTransportFactory(crlCfg, nil)
-		crlTransport, _, err := transportFactory.createTransport()
+		crlRoundTripper, err := transportFactory.createTransport()
 		assertNilF(t, err)
-		transport := castToTransport(crlTransport)
+		transport := castToTransport(crlRoundTripper)
 		assertNotNilF(t, transport, "Expected http.Transport")
 		assertEqualE(t, transport.MaxIdleConns, 5)
 	})

--- a/connectivity_diagnosis.go
+++ b/connectivity_diagnosis.go
@@ -89,7 +89,7 @@ func (cd *connectivityDiagnoser) createDiagnosticDialContext() func(ctx context.
 
 // enhance the transport with IP logging
 func (cd *connectivityDiagnoser) createDiagnosticTransport(cfg *Config) *http.Transport {
-	baseTransport, err := getTransport(cfg, &snowflakeTelemetry{enabled: false})
+	baseTransport, err := newTransportFactory(cfg, &snowflakeTelemetry{enabled: false}).createTransport()
 	if err != nil {
 		logger.Fatalf("[createDiagnosticTransport] failed to get the transport from the config: %v", err)
 	}

--- a/connectivity_diagnosis_test.go
+++ b/connectivity_diagnosis_test.go
@@ -790,7 +790,6 @@ func TestPerformDiagnosis(t *testing.T) {
 		logOutput := buffer.String()
 		assertStringContainsE(t, logOutput, "[performDiagnosis] starting connectivity diagnosis", "should contain diagnosis start message")
 		assertStringContainsE(t, logOutput, "[performDiagnosis] CRLs will be attempted to be downloaded and parsed during https tests", "should contain CRL download enabled message")
-		t.Logf("logOutput: %s", logOutput)
 
 		// DNS resolution
 		assertStringContainsE(t, logOutput, "[performDiagnosis] DNS check - resolving OCSP_CACHE hostname ocsp.snowflakecomputing.com", "should contain DNS check for OCSP cache")

--- a/connectivity_diagnosis_test.go
+++ b/connectivity_diagnosis_test.go
@@ -186,7 +186,7 @@ func TestCreateDiagnosticTransport(t *testing.T) {
 	assertNotNilE(t, transport.DialContext, "dialContext should not be nil")
 
 	// by default we should use the SnowflakeTransport
-	assertEqualE(t, transport.TLSClientConfig, SnowflakeTransport.TLSClientConfig, "TLSClientConfig did not match with SnowflakeTransport default")
+	assertDeepEqualE(t, transport.TLSClientConfig.Certificates, SnowflakeTransport.TLSClientConfig.Certificates, "Certificates did not match with SnowflakeTransport default")
 	assertEqualE(t, transport.MaxIdleConns, SnowflakeTransport.MaxIdleConns, "MaxIdleConns did not match with SnowflakeTransport default")
 	assertEqualE(t, transport.IdleConnTimeout, SnowflakeTransport.IdleConnTimeout, "IdleConnTimeout did not match with SnowflakeTransport default")
 	if (transport.Proxy == nil) != (SnowflakeTransport.Proxy == nil) {

--- a/connectivity_diagnosis_test.go
+++ b/connectivity_diagnosis_test.go
@@ -726,10 +726,12 @@ func TestPerformDiagnosis(t *testing.T) {
 
 		// perform the diagnosis without downloading CRL
 		performDiagnosis(config, false)
+		t.Logf("after performDiagnosis")
 
 		// verify expected log messages from performDiagnosis and underlying functions
 		logOutput := buffer.String()
 		assertStringContainsE(t, logOutput, "[performDiagnosis] starting connectivity diagnosis", "should contain diagnosis start message")
+		t.Logf("logOutput: %s", logOutput)
 
 		// DNS resolution
 		assertStringContainsE(t, logOutput, "[performDiagnosis] DNS check - resolving OCSP_CACHE hostname ocsp.snowflakecomputing.com", "should contain DNS check for OCSP cache")
@@ -779,15 +781,18 @@ func TestPerformDiagnosis(t *testing.T) {
 			ConnectionDiagnosticsAllowlistFile: tmpFile.Name(),
 			CertRevocationCheckMode:            CertRevocationCheckAdvisory,
 			ClientTimeout:                      30 * time.Second,
+			DisableOCSPChecks:                  true,
 		}
 		downloadCRLs := config.CertRevocationCheckMode.String() == "ADVISORY"
 		// driver should download CRLs due to ADVISORY CRL mode
+		// Note that there's a log.Fatalf in performDiagnosis that may cause the test to fail.
 		performDiagnosis(config, downloadCRLs)
 
 		// verify expected log messages including CRL download
 		logOutput := buffer.String()
 		assertStringContainsE(t, logOutput, "[performDiagnosis] starting connectivity diagnosis", "should contain diagnosis start message")
 		assertStringContainsE(t, logOutput, "[performDiagnosis] CRLs will be attempted to be downloaded and parsed during https tests", "should contain CRL download enabled message")
+		t.Logf("logOutput: %s", logOutput)
 
 		// DNS resolution
 		assertStringContainsE(t, logOutput, "[performDiagnosis] DNS check - resolving OCSP_CACHE hostname ocsp.snowflakecomputing.com", "should contain DNS check for OCSP cache")

--- a/connectivity_diagnosis_test.go
+++ b/connectivity_diagnosis_test.go
@@ -186,12 +186,7 @@ func TestCreateDiagnosticTransport(t *testing.T) {
 	assertNotNilE(t, transport.DialContext, "dialContext should not be nil")
 
 	// by default we should use the SnowflakeTransport
-	assertDeepEqualE(t, transport.TLSClientConfig.Certificates, SnowflakeTransport.TLSClientConfig.Certificates, "Certificates did not match with SnowflakeTransport default")
-	assertEqualE(t, transport.MaxIdleConns, SnowflakeTransport.MaxIdleConns, "MaxIdleConns did not match with SnowflakeTransport default")
-	assertEqualE(t, transport.IdleConnTimeout, SnowflakeTransport.IdleConnTimeout, "IdleConnTimeout did not match with SnowflakeTransport default")
-	if (transport.Proxy == nil) != (SnowflakeTransport.Proxy == nil) {
-		t.Errorf("Proxy function presence should match SnowflakeTransport default")
-	}
+	assertTransportsEqual(t, SnowflakeTransport, transport, "diagnostic transport vs SnowflakeTransport")
 }
 
 func TestOpenAndReadAllowlistJSON(t *testing.T) {

--- a/connectivity_diagnosis_test.go
+++ b/connectivity_diagnosis_test.go
@@ -726,12 +726,10 @@ func TestPerformDiagnosis(t *testing.T) {
 
 		// perform the diagnosis without downloading CRL
 		performDiagnosis(config, false)
-		t.Logf("after performDiagnosis")
 
 		// verify expected log messages from performDiagnosis and underlying functions
 		logOutput := buffer.String()
 		assertStringContainsE(t, logOutput, "[performDiagnosis] starting connectivity diagnosis", "should contain diagnosis start message")
-		t.Logf("logOutput: %s", logOutput)
 
 		// DNS resolution
 		assertStringContainsE(t, logOutput, "[performDiagnosis] DNS check - resolving OCSP_CACHE hostname ocsp.snowflakecomputing.com", "should contain DNS check for OCSP cache")

--- a/crl.go
+++ b/crl.go
@@ -139,8 +139,6 @@ const (
 	defaultCrlCacheCleanerTick  = time.Hour
 )
 
-// createCrlTransport function has been moved to transport.go as part of TransportFactory.CreateCRLTransport()
-
 // TODO in following commits:
 // - telemetry
 func (cv *crlValidator) verifyPeerCertificates(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {

--- a/crl.go
+++ b/crl.go
@@ -2,13 +2,11 @@ package gosnowflake
 
 import (
 	"cmp"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/asn1"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -141,27 +139,7 @@ const (
 	defaultCrlCacheCleanerTick  = time.Hour
 )
 
-func createCrlTransport(cfg *Config) (*http.Transport, *crlValidator, error) {
-	allowCertificatesWithoutCrlURL := cfg.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue
-	client := &http.Client{
-		Timeout: cmp.Or(cfg.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
-	}
-	crlValidator, err := newCrlValidator(cfg.CertRevocationCheckMode, allowCertificatesWithoutCrlURL, cfg.CrlCacheValidityTime, cfg.CrlInMemoryCacheDisabled, cfg.CrlOnDiskCacheDisabled, cfg.CrlOnDiskCacheDir, cfg.CrlOnDiskCacheRemovalDelay, client)
-	if err != nil {
-		return nil, nil, err
-	}
-	return &http.Transport{
-		TLSClientConfig: &tls.Config{
-			VerifyPeerCertificate: crlValidator.verifyPeerCertificates,
-		},
-		MaxIdleConns:    5,
-		IdleConnTimeout: 5 * time.Minute,
-		Proxy:           http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout: 5 * time.Second,
-		}).DialContext,
-	}, crlValidator, nil
-}
+// createCrlTransport function has been moved to transport.go as part of TransportFactory.CreateCRLTransport()
 
 // TODO in following commits:
 // - telemetry

--- a/dsn.go
+++ b/dsn.go
@@ -900,7 +900,10 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				cfg.tlsConfig = tlsConfig
 				cfg.TLSConfigName = value
 			} else {
-				return fmt.Errorf("TLS config not found: %s", value)
+				return &SnowflakeError{
+					Number:  ErrCodeMissingTLSConfig,
+					Message: fmt.Sprintf(errMsgMissingTLSConfig, value),
+				}
 			}
 		case "workloadIdentityProvider":
 			cfg.WorkloadIdentityProvider = value

--- a/dsn.go
+++ b/dsn.go
@@ -899,7 +899,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.Token = value
 		case "tls":
 			// Look up registered TLS config and set it directly
-			if tlsConfig, ok := getTLSConfigClone(value); ok {
+			if tlsConfig, ok := getTLSConfig(value); ok {
 				cfg.TLSConfig = tlsConfig
 			} else {
 				return fmt.Errorf("TLS config not found: %s", value)

--- a/dsn.go
+++ b/dsn.go
@@ -2,6 +2,7 @@ package gosnowflake
 
 import (
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -101,7 +102,7 @@ type Config struct {
 
 	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 
-	TLSConfig string // TLS configuration name registered with RegisterTLSConfig
+	TLSConfig *tls.Config // Custom TLS configuration
 
 	DisableTelemetry bool // indicates whether to disable telemetry
 
@@ -897,7 +898,12 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "token":
 			cfg.Token = value
 		case "tls":
-			cfg.TLSConfig = value
+			// Look up registered TLS config and set it directly
+			if tlsConfig, ok := getTLSConfigClone(value); ok {
+				cfg.TLSConfig = tlsConfig
+			} else {
+				return fmt.Errorf("TLS config not found: %s", value)
+			}
 		case "workloadIdentityProvider":
 			cfg.WorkloadIdentityProvider = value
 		case "workloadIdentityEntraResource":

--- a/dsn.go
+++ b/dsn.go
@@ -102,7 +102,7 @@ type Config struct {
 
 	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 
-	TLSConfig     *tls.Config // Custom TLS configuration
+	tlsConfig     *tls.Config // Custom TLS configuration
 	TLSConfigName string      // Name of the TLS config to use
 
 	DisableTelemetry bool // indicates whether to disable telemetry
@@ -913,7 +913,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "tlsConfigName":
 			// Look up registered TLS config and set it directly
 			if tlsConfig, ok := getTLSConfig(value); ok {
-				cfg.TLSConfig = tlsConfig
+				cfg.tlsConfig = tlsConfig
 				cfg.TLSConfigName = value
 			} else {
 				return fmt.Errorf("TLS config not found: %s", value)

--- a/dsn.go
+++ b/dsn.go
@@ -102,7 +102,8 @@ type Config struct {
 
 	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 
-	TLSConfig *tls.Config // Custom TLS configuration
+	TLSConfig     *tls.Config // Custom TLS configuration
+	TLSConfigName string      // Name of the TLS config to use
 
 	DisableTelemetry bool // indicates whether to disable telemetry
 
@@ -364,6 +365,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	}
 	if cfg.DisableSamlURLCheck != configBoolNotSet {
 		params.Add("disableSamlURLCheck", strconv.FormatBool(cfg.DisableSamlURLCheck != ConfigBoolFalse))
+	}
+	if cfg.TLSConfigName != "" {
+		params.Add("tlsConfigName", cfg.TLSConfigName)
 	}
 
 	dsn = fmt.Sprintf("%v:%v@%v:%v", url.QueryEscape(cfg.User), url.QueryEscape(cfg.Password), cfg.Host, cfg.Port)
@@ -897,10 +901,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		case "token":
 			cfg.Token = value
-		case "tls":
+		case "tlsConfigName":
 			// Look up registered TLS config and set it directly
 			if tlsConfig, ok := getTLSConfig(value); ok {
 				cfg.TLSConfig = tlsConfig
+				cfg.TLSConfigName = value
 			} else {
 				return fmt.Errorf("TLS config not found: %s", value)
 			}

--- a/dsn.go
+++ b/dsn.go
@@ -101,6 +101,8 @@ type Config struct {
 
 	Transporter http.RoundTripper // RoundTripper to intercept HTTP requests and responses
 
+	TLSConfig string // TLS configuration name registered with RegisterTLSConfig
+
 	DisableTelemetry bool // indicates whether to disable telemetry
 
 	Tracing string // sets logging level
@@ -894,6 +896,8 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 
 		case "token":
 			cfg.Token = value
+		case "tls":
+			cfg.TLSConfig = value
 		case "workloadIdentityProvider":
 			cfg.WorkloadIdentityProvider = value
 		case "workloadIdentityEntraResource":

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2370,7 +2370,12 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to register test TLS config: %v", err)
 	}
-	defer DeregisterTLSConfig("custom")
+	defer func() {
+		err := DeregisterTLSConfig("custom")
+		if err != nil {
+			t.Fatalf("Failed to deregister test TLS config: %v", err)
+		}
+	}()
 
 	testCases := []struct {
 		name     string

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2125,7 +2125,8 @@ func TestDSN(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.dsn, func(t *testing.T) {
 			if test.cfg.TLSConfigName != "" && test.err == nil {
-				RegisterTLSConfig(test.cfg.TLSConfigName, &tls.Config{})
+				err := RegisterTLSConfig(test.cfg.TLSConfigName, &tls.Config{})
+				assertNilF(t, err, "Failed to register test TLS config")
 				defer func() {
 					_ = DeregisterTLSConfig(test.cfg.TLSConfigName)
 				}()

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2430,17 +2430,11 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := ParseDSN(tc.dsn)
 			if tc.err {
-				if err == nil {
-					t.Fatalf("ParseDSN should have failed but did not")
-				}
+				assertNotNilF(t, err, "ParseDSN should have failed but did not")
 			} else {
-				if err != nil {
-					t.Fatalf("ParseDSN failed: %v", err)
-				}
+				assertNilF(t, err, "ParseDSN failed")
 				// For DSN parsing, the TLS config should be resolved and set directly
-				if cfg.TLSConfigName != tc.expected {
-					t.Fatalf("Expected TLSConfigName=%s, got %s", tc.expected, cfg.TLSConfigName)
-				}
+				assertEqualF(t, cfg.TLSConfigName, tc.expected, "TLSConfigName mismatch")
 			}
 
 		})

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2278,7 +2278,9 @@ func checkConfig(cfg Config, envMap map[string]configParamToValue) error {
 	typeOfCfg := value.Type()
 	cfgValues := make(map[string]interface{}, value.NumField())
 	for i := 0; i < value.NumField(); i++ {
-		cfgValues[typeOfCfg.Field(i).Name] = value.Field(i).Interface()
+		if value.Field(i).CanInterface() {
+			cfgValues[typeOfCfg.Field(i).Name] = value.Field(i).Interface()
+		}
 	}
 
 	var errArray []string

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1203,6 +1203,42 @@ func TestParseDSN(t *testing.T) {
 			},
 			ocspMode: ocspModeFailOpen,
 		},
+		// TLS config test cases
+		{
+			dsn: "user:pass@account/db?tls=custom",
+			config: &Config{
+				Account: "account", User: "user", Password: "pass", Database: "db",
+				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
+				TLSConfig:                 "custom",
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				ValidateDefaultParameters: ConfigBoolTrue,
+				ClientTimeout:             defaultClientTimeout,
+				JWTClientTimeout:          defaultJWTClientTimeout,
+				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
+				CloudStorageTimeout:       defaultCloudStorageTimeout,
+				IncludeRetryReason:        ConfigBoolTrue,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
+		{
+			dsn: "user:pass@account/db?tls=custom-ca&warehouse=wh&role=admin",
+			config: &Config{
+				Account: "account", User: "user", Password: "pass", Database: "db",
+				Warehouse: "wh", Role: "admin",
+				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
+				TLSConfig:                 "custom-ca",
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				ValidateDefaultParameters: ConfigBoolTrue,
+				ClientTimeout:             defaultClientTimeout,
+				JWTClientTimeout:          defaultJWTClientTimeout,
+				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
+				CloudStorageTimeout:       defaultCloudStorageTimeout,
+				IncludeRetryReason:        ConfigBoolTrue,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
 	}
 
 	for _, at := range []AuthType{AuthTypeExternalBrowser, AuthTypeOAuth} {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1202,8 +1202,10 @@ func TestParseDSN(t *testing.T) {
 		},
 		{
 			dsn: "user:pass@account/db?tlsConfigName=custom",
-			// TODO(snoonan): add TLS errors to errors.go
-			err: fmt.Errorf("TLS config not found: custom"),
+			err: &SnowflakeError{
+				Number:  ErrCodeMissingTLSConfig,
+				Message: fmt.Sprintf(errMsgMissingTLSConfig, "custom"),
+			},
 		},
 	}
 

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2390,14 +2390,10 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 		ServerName:         "custom.test.com",
 	}
 	err := RegisterTLSConfig("custom", &testTLSConfig)
-	if err != nil {
-		t.Fatalf("Failed to register test TLS config: %v", err)
-	}
+	assertNilF(t, err, "Failed to register test TLS config")
 	defer func() {
 		err := DeregisterTLSConfig("custom")
-		if err != nil {
-			t.Fatalf("Failed to deregister test TLS config: %v", err)
-		}
+		assertNilF(t, err, "Failed to deregister test TLS config")
 	}()
 
 	testCases := []struct {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2416,6 +2416,11 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 			dsn:      "user:pass@account/db?warehouse=wh",
 			expected: "",
 		},
+		{
+			name:     "Nonexistent TLS config",
+			dsn:      "user:pass@account/db?tls=nonexistent",
+			expected: "",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1209,7 +1209,7 @@ func TestParseDSN(t *testing.T) {
 			config: &Config{
 				Account: "account", User: "user", Password: "pass", Database: "db",
 				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
-				TLSConfig:                 "custom",
+				TLSConfig:                 nil, // Will be set by DSN parsing if TLS config is registered
 				OCSPFailOpen:              OCSPFailOpenTrue,
 				ValidateDefaultParameters: ConfigBoolTrue,
 				ClientTimeout:             defaultClientTimeout,
@@ -1227,7 +1227,7 @@ func TestParseDSN(t *testing.T) {
 				Account: "account", User: "user", Password: "pass", Database: "db",
 				Warehouse: "wh", Role: "admin",
 				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
-				TLSConfig:                 "custom-ca",
+				TLSConfig:                 nil, // Will be set by DSN parsing if TLS config is registered
 				OCSPFailOpen:              OCSPFailOpenTrue,
 				ValidateDefaultParameters: ConfigBoolTrue,
 				ClientTimeout:             defaultClientTimeout,

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2136,15 +2136,13 @@ func TestDSN(t *testing.T) {
 					t.Errorf("failed to get DSN. expected: %v, got:\n %v", test.dsn, dsn)
 				}
 				_, err := ParseDSN(dsn)
-				if err != nil {
-					t.Errorf("failed to parse DSN. dsn: %v, err: %v", dsn, err)
-				}
+				assertNilF(t, err, "failed to parse DSN. dsn:", dsn)
 			}
-			if test.err != nil && err == nil {
-				t.Errorf("expected error. dsn: %v, err: %v", test.dsn, test.err)
+			if test.err != nil {
+				assertNotNilF(t, err, fmt.Sprintf("expected error. dsn: %v, expected err: %v", test.dsn, test.err))
 			}
-			if err != nil && test.err == nil {
-				t.Errorf("failed to match. err: %v", err)
+			if test.err == nil {
+				assertNilF(t, err, "failed to match")
 			}
 		})
 	}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2102,6 +2102,15 @@ func TestDSN(t *testing.T) {
 			},
 			dsn: "u:p@a.b.c.snowflakecomputing.com:443?certRevocationCheckMode=ENABLED&crlAllowCertificatesWithoutCrlURL=true&crlCacheCleanerTick=7&crlCacheValidityTime=600&crlHttpClientTimeout=5&crlInMemoryCacheDisabled=true&crlOnDiskCacheDir=%2Ftmp%2Fcrl&crlOnDiskCacheDisabled=true&crlOnDiskCacheRemovalDelay=300&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
 		},
+		{
+			cfg: &Config{
+				User:          "u",
+				Password:      "p",
+				Account:       "a.b.c",
+				TLSConfigName: "custom",
+			},
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?ocspFailOpen=true&region=b.c&tlsConfigName=custom&validateDefaultParameters=true",
+		},
 	}
 	for _, test := range testcases {
 		t.Run(test.dsn, func(t *testing.T) {
@@ -2384,12 +2393,12 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 	}{
 		{
 			name:     "Basic TLS config parameter",
-			dsn:      "user:pass@account/db?tls=custom",
+			dsn:      "user:pass@account/db?tlsConfigName=custom",
 			expected: "custom",
 		},
 		{
 			name:     "TLS config with other parameters",
-			dsn:      "user:pass@account/db?tls=custom&warehouse=wh&role=admin",
+			dsn:      "user:pass@account/db?tlsConfigName=custom&warehouse=wh&role=admin",
 			expected: "custom",
 		},
 		{
@@ -2406,14 +2415,8 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 				t.Fatalf("ParseDSN failed: %v", err)
 			}
 			// For DSN parsing, the TLS config should be resolved and set directly
-			if tc.expected == "" {
-				if cfg.TLSConfig != nil {
-					t.Fatalf("Expected nil TLSConfig for empty DSN, got non-nil")
-				}
-			} else {
-				if cfg.TLSConfig == nil {
-					t.Fatalf("Expected non-nil TLSConfig for DSN with tls=%s, got nil", tc.expected)
-				}
+			if cfg.TLSConfigName != tc.expected {
+				t.Fatalf("Expected TLSConfigName=%s, got %s", tc.expected, cfg.TLSConfigName)
 			}
 		})
 	}

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1204,41 +1204,10 @@ func TestParseDSN(t *testing.T) {
 			},
 			ocspMode: ocspModeFailOpen,
 		},
-		// TLS config test cases
 		{
 			dsn: "user:pass@account/db?tls=custom",
-			config: &Config{
-				Account: "account", User: "user", Password: "pass", Database: "db",
-				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
-				TLSConfig:                 nil, // Will be set by DSN parsing if TLS config is registered
-				OCSPFailOpen:              OCSPFailOpenTrue,
-				ValidateDefaultParameters: ConfigBoolTrue,
-				ClientTimeout:             defaultClientTimeout,
-				JWTClientTimeout:          defaultJWTClientTimeout,
-				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
-				CloudStorageTimeout:       defaultCloudStorageTimeout,
-				IncludeRetryReason:        ConfigBoolTrue,
-			},
-			ocspMode: ocspModeFailOpen,
-			err:      nil,
-		},
-		{
-			dsn: "user:pass@account/db?tls=custom-ca&warehouse=wh&role=admin",
-			config: &Config{
-				Account: "account", User: "user", Password: "pass", Database: "db",
-				Warehouse: "wh", Role: "admin",
-				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
-				TLSConfig:                 nil, // Will be set by DSN parsing if TLS config is registered
-				OCSPFailOpen:              OCSPFailOpenTrue,
-				ValidateDefaultParameters: ConfigBoolTrue,
-				ClientTimeout:             defaultClientTimeout,
-				JWTClientTimeout:          defaultJWTClientTimeout,
-				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
-				CloudStorageTimeout:       defaultCloudStorageTimeout,
-				IncludeRetryReason:        ConfigBoolTrue,
-			},
-			ocspMode: ocspModeFailOpen,
-			err:      nil,
+			// TODO(snoonan): add TLS errors to errors.go
+			err: fmt.Errorf("TLS config not found: custom"),
 		},
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -148,6 +148,8 @@ const (
 	ErrCodeEmptyOAuthParameters = 260017
 	// ErrMissingAccessATokenButRefreshTokenPresent is an error code for the case when access token is not found in cache, but the refresh token is present.
 	ErrMissingAccessATokenButRefreshTokenPresent = 260018
+	// ErrCodeMissingTLSConfig is an error code for the case where the TLS config is missing.
+	ErrCodeMissingTLSConfig = 260019
 
 	/* network */
 
@@ -328,6 +330,7 @@ const (
 	errMsgInvalidWritablePermissionToFile    = "file '%v' is writable by group or others — this poses a security risk because it allows unauthorized users to modify sensitive settings. Your Permission: %v"
 	errMsgInvalidExecutablePermissionToFile  = "file '%v' is executable — this poses a security risk because the file could be misused as a script or executed unintentionally. Your Permission: %v"
 	errMsgNonArrowResponseInArrowBatches     = "arrow batches enabled, but the response is not Arrow based"
+	errMsgMissingTLSConfig                   = "TLS config not found: %v"
 )
 
 // Returned if a DNS doesn't include account parameter.

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -428,7 +428,7 @@ func (util *snowflakeGcsClient) isTokenExpired(resp *http.Response) bool {
 }
 
 func newGcsClient(cfg *Config, telemetry *snowflakeTelemetry) (gcsAPI, error) {
-	transport, err := getTransport(cfg, telemetry)
+	transport, err := newTransportFactory(cfg, telemetry).createTransport()
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/aws/smithy-go v1.20.2
 	github.com/gabriel-vasile/mimetype v1.4.7
 	github.com/golang-jwt/jwt/v5 v5.2.2
@@ -42,6 +41,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/dvsekhvalnov/jose2go v1.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/ocsp.go
+++ b/ocsp.go
@@ -1181,19 +1181,14 @@ func (occ *ocspCacheClearerType) stop() {
 }
 
 // snowflakeNoRevocationCheckTransport is the transport object that doesn't do certificate revocation check with OCSP.
-// Created using the new TransportFactory for consistency.
 var snowflakeNoRevocationCheckTransport http.RoundTripper
 
 // SnowflakeTransport includes the certificate revocation check with OCSP in sequential. By default, the driver uses
-// this transport object. Created using the new TransportFactory for consistency.
+// this transport object.
 var SnowflakeTransport *http.Transport
 
-// Initialize global transports using the new TransportFactory
 func init() {
-	// Create a dummy config for the factory (these are global transports, so no specific config needed)
-	dummyConfig := &Config{}
-	factory := NewTransportFactory(dummyConfig)
-
+	factory := NewTransportFactory(&Config{})
 	snowflakeNoRevocationCheckTransport = factory.CreateNoRevocationTransport()
 	SnowflakeTransport = factory.CreateOCSPTransport()
 }

--- a/ocsp.go
+++ b/ocsp.go
@@ -1188,7 +1188,7 @@ var snowflakeNoRevocationCheckTransport http.RoundTripper
 var SnowflakeTransport *http.Transport
 
 func init() {
-	factory := NewTransportFactory(&Config{})
+	factory := newTransportFactory(&Config{})
 	snowflakeNoRevocationCheckTransport = factory.CreateNoRevocationTransport()
 	SnowflakeTransport = factory.CreateOCSPTransport()
 }

--- a/ocsp.go
+++ b/ocsp.go
@@ -1189,8 +1189,8 @@ var SnowflakeTransport *http.Transport
 
 func init() {
 	factory := newTransportFactory(&Config{})
-	snowflakeNoRevocationCheckTransport = factory.CreateNoRevocationTransport()
-	SnowflakeTransport = factory.CreateOCSPTransport()
+	snowflakeNoRevocationCheckTransport = factory.createNoRevocationTransport()
+	SnowflakeTransport = factory.createOCSPTransport()
 }
 
 // SnowflakeTransportTest includes the certificate revocation check in parallel

--- a/rows_test.go
+++ b/rows_test.go
@@ -15,7 +15,7 @@ import (
 type RowsExtended struct {
 	rows      *sql.Rows
 	closeChan *chan bool
-	t *testing.T
+	t         *testing.T
 }
 
 func (rs *RowsExtended) Close() error {

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -50,7 +50,7 @@ func (util *snowflakeS3Client) createClient(info *execResponseStageInfo, useAcce
 	s3Logger := logging.LoggerFunc(s3LoggingFunc)
 	endPoint := getS3CustomEndpoint(info)
 
-	transport, err := getTransport(util.cfg, telemetry)
+	transport, err := newTransportFactory(util.cfg, telemetry).createTransport()
 	if err != nil {
 		return nil, err
 	}

--- a/tls_config.go
+++ b/tls_config.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/tls_config.go
+++ b/tls_config.go
@@ -10,6 +10,7 @@ var (
 	tlsConfigRegistry = make(map[string]*tls.Config)
 )
 
+// TODO(snoonan): Logging
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
 // Use the key as a value in the DSN where tls=value.
 //

--- a/tls_config.go
+++ b/tls_config.go
@@ -2,18 +2,13 @@ package gosnowflake
 
 import (
 	"crypto/tls"
-	"errors"
 	"sync"
 )
 
 var (
 	tlsConfigLock     sync.RWMutex
-	tlsConfigRegistry map[string]*tls.Config
-)
-
-func init() {
 	tlsConfigRegistry = make(map[string]*tls.Config)
-}
+)
 
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
 // Use the key as a value in the DSN where tls=value.
@@ -27,56 +22,29 @@ func init() {
 //   - CRL validation is preserved if CertRevocationCheckMode is enabled
 //   - If you provide a custom VerifyPeerCertificate callback, it will be chained
 //     with Snowflake's revocation checking (your callback runs first)
-//
-// Note: The provided tls.Config is exclusively owned by the driver after
-// registering it.
-//
-// Example:
-//
-//	rootCertPool := x509.NewCertPool()
-//	pem, err := os.ReadFile("/path/ca-cert.pem")
-//	if err != nil {
-//	    log.Fatal(err)
-//	}
-//	if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
-//	    log.Fatal("Failed to append PEM.")
-//	}
-//
-//	gosnowflake.RegisterTLSConfig("custom", &tls.Config{
-//	    RootCAs: rootCertPool,
-//	    // OCSP/CRL validation will be automatically added by the driver
-//	})
-//
-//	db, err := sql.Open("snowflake", "user:pass@account/db?tls=custom")
 func RegisterTLSConfig(key string, config *tls.Config) error {
-	if config == nil {
-		return errors.New("config is nil")
-	}
-
 	tlsConfigLock.Lock()
-	tlsConfigRegistry[key] = config
+	tlsConfigRegistry[key] = config.Clone()
 	tlsConfigLock.Unlock()
 	return nil
 }
 
 // DeregisterTLSConfig removes the tls.Config associated with key.
-func DeregisterTLSConfig(key string) {
+func DeregisterTLSConfig(key string) error {
 	tlsConfigLock.Lock()
 	delete(tlsConfigRegistry, key)
 	tlsConfigLock.Unlock()
+	return nil
 }
 
-// getTLSConfigClone returns a clone of a TLS config from the registry.
-// This prevents the user config from being modified by the driver.
-func getTLSConfigClone(key string) (*tls.Config, bool) {
+// getTLSConfig returns a TLS config from the registry.
+func getTLSConfig(key string) (*tls.Config, bool) {
 	tlsConfigLock.RLock()
 	tlsConfig, ok := tlsConfigRegistry[key]
 	tlsConfigLock.RUnlock()
-
 	if !ok {
 		return nil, false
 	}
-
-	// Clone the config to prevent modification
+	// Clone to prevent modification and to handle the internal mutex properly.
 	return tlsConfig.Clone(), true
 }

--- a/tls_config.go
+++ b/tls_config.go
@@ -11,7 +11,7 @@ var (
 )
 
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
-// Use the key as a value in the DSN where tls=value.
+// Use the key as a value in the DSN where tlsConfigName=value.
 func RegisterTLSConfig(key string, config *tls.Config) error {
 	tlsConfigLock.Lock()
 	logger.Infof("Registering TLS config for key: %s", key)

--- a/tls_config.go
+++ b/tls_config.go
@@ -14,7 +14,7 @@ var (
 // Use the key as a value in the DSN where tls=value.
 func RegisterTLSConfig(key string, config *tls.Config) error {
 	tlsConfigLock.Lock()
-	logger.Debugf("Registering TLS config for key: %s", key)
+	logger.Infof("Registering TLS config for key: %s", key)
 	tlsConfigRegistry[key] = config.Clone()
 	tlsConfigLock.Unlock()
 	return nil
@@ -23,7 +23,7 @@ func RegisterTLSConfig(key string, config *tls.Config) error {
 // DeregisterTLSConfig removes the tls.Config associated with key.
 func DeregisterTLSConfig(key string) error {
 	tlsConfigLock.Lock()
-	logger.Debugf("Registering TLS config for key: %s", key)
+	logger.Infof("Deregistering TLS config for key: %s", key)
 	delete(tlsConfigRegistry, key)
 	tlsConfigLock.Unlock()
 	return nil

--- a/tls_config.go
+++ b/tls_config.go
@@ -10,7 +10,6 @@ var (
 	tlsConfigRegistry = make(map[string]*tls.Config)
 )
 
-// TODO(snoonan): Logging
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
 // Use the key as a value in the DSN where tls=value.
 //
@@ -23,6 +22,8 @@ var (
 //   - CRL validation is preserved if CertRevocationCheckMode is enabled
 //   - If you provide a custom VerifyPeerCertificate callback, it will be chained
 //     with Snowflake's revocation checking (your callback runs first)
+//
+// TODO(snoonan): Logging
 func RegisterTLSConfig(key string, config *tls.Config) error {
 	tlsConfigLock.Lock()
 	tlsConfigRegistry[key] = config.Clone()

--- a/tls_config.go
+++ b/tls_config.go
@@ -12,20 +12,9 @@ var (
 
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
 // Use the key as a value in the DSN where tls=value.
-//
-// The custom TLS config allows you to specify custom root CAs, client certificates,
-// and other TLS settings while maintaining Snowflake's certificate revocation
-// checking (OCSP/CRL) unless explicitly disabled.
-//
-// Certificate Revocation Checking:
-//   - OCSP validation is preserved unless DisableOCSPChecks=true or InsecureMode=true
-//   - CRL validation is preserved if CertRevocationCheckMode is enabled
-//   - If you provide a custom VerifyPeerCertificate callback, it will be chained
-//     with Snowflake's revocation checking (your callback runs first)
-//
-// TODO(snoonan): Logging
 func RegisterTLSConfig(key string, config *tls.Config) error {
 	tlsConfigLock.Lock()
+	logger.Debugf("Registering TLS config for key: %s", key)
 	tlsConfigRegistry[key] = config.Clone()
 	tlsConfigLock.Unlock()
 	return nil
@@ -34,6 +23,7 @@ func RegisterTLSConfig(key string, config *tls.Config) error {
 // DeregisterTLSConfig removes the tls.Config associated with key.
 func DeregisterTLSConfig(key string) error {
 	tlsConfigLock.Lock()
+	logger.Debugf("Registering TLS config for key: %s", key)
 	delete(tlsConfigRegistry, key)
 	tlsConfigLock.Unlock()
 	return nil
@@ -47,6 +37,5 @@ func getTLSConfig(key string) (*tls.Config, bool) {
 	if !ok {
 		return nil, false
 	}
-	// Clone to prevent modification and to handle the internal mutex properly.
 	return tlsConfig.Clone(), true
 }

--- a/tls_config.go
+++ b/tls_config.go
@@ -20,6 +20,16 @@ func init() {
 // RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
 // Use the key as a value in the DSN where tls=value.
 //
+// The custom TLS config allows you to specify custom root CAs, client certificates,
+// and other TLS settings while maintaining Snowflake's certificate revocation
+// checking (OCSP/CRL) unless explicitly disabled.
+//
+// Certificate Revocation Checking:
+//   - OCSP validation is preserved unless DisableOCSPChecks=true or InsecureMode=true
+//   - CRL validation is preserved if CertRevocationCheckMode is enabled
+//   - If you provide a custom VerifyPeerCertificate callback, it will be chained
+//     with Snowflake's revocation checking (your callback runs first)
+//
 // Note: The provided tls.Config is exclusively owned by the driver after
 // registering it.
 //
@@ -36,6 +46,7 @@ func init() {
 //
 //	gosnowflake.RegisterTLSConfig("custom", &tls.Config{
 //	    RootCAs: rootCertPool,
+//	    // OCSP/CRL validation will be automatically added by the driver
 //	})
 //
 //	db, err := sql.Open("snowflake", "user:pass@account/db?tls=custom")

--- a/tls_config.go
+++ b/tls_config.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
+
+package gosnowflake
+
+import (
+	"crypto/tls"
+	"errors"
+	"sync"
+)
+
+var (
+	tlsConfigLock     sync.RWMutex
+	tlsConfigRegistry map[string]*tls.Config
+)
+
+func init() {
+	tlsConfigRegistry = make(map[string]*tls.Config)
+}
+
+// RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
+// Use the key as a value in the DSN where tls=value.
+//
+// Note: The provided tls.Config is exclusively owned by the driver after
+// registering it.
+//
+// Example:
+//
+//	rootCertPool := x509.NewCertPool()
+//	pem, err := os.ReadFile("/path/ca-cert.pem")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+//	    log.Fatal("Failed to append PEM.")
+//	}
+//
+//	gosnowflake.RegisterTLSConfig("custom", &tls.Config{
+//	    RootCAs: rootCertPool,
+//	})
+//
+//	db, err := sql.Open("snowflake", "user:pass@account/db?tls=custom")
+func RegisterTLSConfig(key string, config *tls.Config) error {
+	if config == nil {
+		return errors.New("config is nil")
+	}
+
+	tlsConfigLock.Lock()
+	tlsConfigRegistry[key] = config
+	tlsConfigLock.Unlock()
+	return nil
+}
+
+// DeregisterTLSConfig removes the tls.Config associated with key.
+func DeregisterTLSConfig(key string) {
+	tlsConfigLock.Lock()
+	delete(tlsConfigRegistry, key)
+	tlsConfigLock.Unlock()
+}
+
+// getTLSConfigClone returns a clone of a TLS config from the registry.
+// This prevents the user config from being modified by the driver.
+func getTLSConfigClone(key string) (*tls.Config, bool) {
+	tlsConfigLock.RLock()
+	tlsConfig, ok := tlsConfigRegistry[key]
+	tlsConfigLock.RUnlock()
+
+	if !ok {
+		return nil, false
+	}
+
+	// Clone the config to prevent modification
+	return tlsConfig.Clone(), true
+}

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
-
 package gosnowflake
 
 import (

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -6,6 +6,27 @@ import (
 	"testing"
 )
 
+// assertTLSConfigsEqual compares two TLS configurations, excluding function fields
+// like VerifyPeerCertificate which may point to different but equivalent functions
+func assertTLSConfigsEqual(t *testing.T, expected, actual *tls.Config, msg string) {
+	if expected == nil && actual == nil {
+		return
+	}
+	assertNotNilF(t, expected, "Expected TLS config should not be nil in %s", msg)
+	assertNotNilF(t, actual, "Actual TLS config should not be nil in %s", msg)
+
+	// Compare non-function fields
+	assertEqualF(t, expected.InsecureSkipVerify, actual.InsecureSkipVerify, "%s InsecureSkipVerify", msg)
+	assertEqualF(t, expected.ServerName, actual.ServerName, "%s ServerName", msg)
+	assertEqualF(t, expected.MinVersion, actual.MinVersion, "%s MinVersion", msg)
+	assertEqualF(t, expected.MaxVersion, actual.MaxVersion, "%s MaxVersion", msg)
+
+	// For VerifyPeerCertificate, just check presence/absence since function pointers can't be compared
+	expectedHasVerifier := expected.VerifyPeerCertificate != nil
+	actualHasVerifier := actual.VerifyPeerCertificate != nil
+	assertEqualF(t, expectedHasVerifier, actualHasVerifier, "%s VerifyPeerCertificate presence", msg)
+}
+
 func TestRegisterTLSConfig(t *testing.T) {
 	// Clean up any existing configs after testing
 	defer func() {

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -216,9 +216,9 @@ C0wjdl3sP3p7J2Vt8mEqGLFQX4Nk8B0CIGCOJl7VebrF1S2A/l7s6r4z9M8Yw4oJ
 		t.Fatal("RootCAs was not preserved in cloned config")
 	}
 
-	// The clone should have the same number of certificates
-	if len(clone.RootCAs.Subjects()) != len(testConfig.RootCAs.Subjects()) {
-		t.Fatal("RootCAs certificate count differs between original and clone")
+	// The clone should have the same certificates as the original
+	if !clone.RootCAs.Equal(testConfig.RootCAs) {
+		t.Fatal("RootCAs differs between original and clone")
 	}
 }
 

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2017-2022 Snowflake Computing Inc. All rights reserved.
+
+package gosnowflake
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"sync"
+	"testing"
+)
+
+func TestRegisterTLSConfig(t *testing.T) {
+	// Clean up any existing configs before testing
+	defer func() {
+		tlsConfigLock.Lock()
+		tlsConfigRegistry = make(map[string]*tls.Config)
+		tlsConfigLock.Unlock()
+	}()
+
+	testConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "test-server",
+	}
+
+	// Test successful registration
+	err := RegisterTLSConfig("test", testConfig)
+	if err != nil {
+		t.Fatalf("RegisterTLSConfig failed: %v", err)
+	}
+
+	// Verify config was registered
+	clone, exists := getTLSConfigClone("test")
+	if !exists {
+		t.Fatal("TLS config was not registered")
+	}
+
+	// Verify the clone is correct but not the same object (to prevent modification)
+	if clone == testConfig {
+		t.Fatal("getTLSConfigClone should return a clone, not the original")
+	}
+	if clone.InsecureSkipVerify != testConfig.InsecureSkipVerify {
+		t.Fatal("Cloned config has different InsecureSkipVerify value")
+	}
+	if clone.ServerName != testConfig.ServerName {
+		t.Fatal("Cloned config has different ServerName value")
+	}
+}
+
+func TestRegisterTLSConfigNil(t *testing.T) {
+	err := RegisterTLSConfig("test", nil)
+	if err == nil {
+		t.Fatal("RegisterTLSConfig should fail with nil config")
+	}
+	if err.Error() != "config is nil" {
+		t.Fatalf("Expected 'config is nil' error, got: %v", err)
+	}
+}
+
+func TestDeregisterTLSConfig(t *testing.T) {
+	// Clean up
+	defer func() {
+		tlsConfigLock.Lock()
+		tlsConfigRegistry = make(map[string]*tls.Config)
+		tlsConfigLock.Unlock()
+	}()
+
+	testConfig := &tls.Config{InsecureSkipVerify: true}
+
+	// Register a config
+	err := RegisterTLSConfig("test", testConfig)
+	if err != nil {
+		t.Fatalf("RegisterTLSConfig failed: %v", err)
+	}
+
+	// Verify it exists
+	_, exists := getTLSConfigClone("test")
+	if !exists {
+		t.Fatal("TLS config should exist after registration")
+	}
+
+	// Deregister it
+	DeregisterTLSConfig("test")
+
+	// Verify it's gone
+	_, exists = getTLSConfigClone("test")
+	if exists {
+		t.Fatal("TLS config should not exist after deregistration")
+	}
+}
+
+func TestGetTLSConfigCloneNonExistent(t *testing.T) {
+	_, exists := getTLSConfigClone("nonexistent")
+	if exists {
+		t.Fatal("getTLSConfigClone should return false for non-existent config")
+	}
+}
+
+func TestTLSConfigConcurrency(t *testing.T) {
+	// Clean up
+	defer func() {
+		tlsConfigLock.Lock()
+		tlsConfigRegistry = make(map[string]*tls.Config)
+		tlsConfigLock.Unlock()
+	}()
+
+	// Test concurrent access to ensure thread safety
+	var wg sync.WaitGroup
+	numGoroutines := 10
+
+	// Concurrently register configs
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			config := &tls.Config{
+				ServerName: "server" + string(rune(index)),
+			}
+			err := RegisterTLSConfig("test"+string(rune(index)), config)
+			if err != nil {
+				t.Errorf("RegisterTLSConfig failed: %v", err)
+			}
+		}(i)
+	}
+
+	// Concurrently read configs
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			_, exists := getTLSConfigClone("test" + string(rune(index)))
+			if !exists {
+				t.Errorf("Config test%d should exist", index)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestDSNParsingWithTLSConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dsn      string
+		expected string
+	}{
+		{
+			name:     "Basic TLS config parameter",
+			dsn:      "user:pass@account/db?tls=custom",
+			expected: "custom",
+		},
+		{
+			name:     "TLS config with other parameters",
+			dsn:      "user:pass@account/db?tls=custom&warehouse=wh&role=admin",
+			expected: "custom",
+		},
+		{
+			name:     "No TLS config parameter",
+			dsn:      "user:pass@account/db?warehouse=wh",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseDSN(tc.dsn)
+			if err != nil {
+				t.Fatalf("ParseDSN failed: %v", err)
+			}
+			if cfg.TLSConfig != tc.expected {
+				t.Fatalf("Expected TLSConfig %q, got %q", tc.expected, cfg.TLSConfig)
+			}
+		})
+	}
+}
+
+func TestRegisterTLSConfigWithCustomRootCAs(t *testing.T) {
+	// Clean up
+	defer func() {
+		tlsConfigLock.Lock()
+		tlsConfigRegistry = make(map[string]*tls.Config)
+		tlsConfigLock.Unlock()
+	}()
+
+	// Create a custom certificate pool
+	certPool := x509.NewCertPool()
+	// Add a dummy certificate for testing
+	certPool.AppendCertsFromPEM([]byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BsSuuPiQi4d+NhU2BvQHmEQUAABOBG1k5
+YBNNm/hbJbr7kWLFGo2jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTAD
+AQH/MB0GA1UdDgQWBBSY0fhuILkXkz3Gjq1XvdOO/+7tSDAOBgNVHQ8BAf8EBAMC
+AQYwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAuK3VWfXWWF0b
+C0wjdl3sP3p7J2Vt8mEqGLFQX4Nk8B0CIGCOJl7VebrF1S2A/l7s6r4z9M8Yw4oJ
+2HGFo1ISJL4g
+-----END CERTIFICATE-----`))
+
+	testConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	// Register the config
+	err := RegisterTLSConfig("custom-ca", testConfig)
+	if err != nil {
+		t.Fatalf("RegisterTLSConfig failed: %v", err)
+	}
+
+	// Verify the config was registered with the custom RootCAs
+	clone, exists := getTLSConfigClone("custom-ca")
+	if !exists {
+		t.Fatal("TLS config was not registered")
+	}
+
+	if clone.RootCAs == nil {
+		t.Fatal("RootCAs was not preserved in cloned config")
+	}
+
+	// The clone should have the same number of certificates
+	if len(clone.RootCAs.Subjects()) != len(testConfig.RootCAs.Subjects()) {
+		t.Fatal("RootCAs certificate count differs between original and clone")
+	}
+}
+
+func TestMultipleTLSConfigs(t *testing.T) {
+	// Clean up
+	defer func() {
+		tlsConfigLock.Lock()
+		tlsConfigRegistry = make(map[string]*tls.Config)
+		tlsConfigLock.Unlock()
+	}()
+
+	configs := map[string]*tls.Config{
+		"insecure": {InsecureSkipVerify: true},
+		"strict":   {InsecureSkipVerify: false, ServerName: "strict-server"},
+		"custom":   {MinVersion: tls.VersionTLS12},
+	}
+
+	// Register all configs
+	for name, config := range configs {
+		err := RegisterTLSConfig(name, config)
+		if err != nil {
+			t.Fatalf("RegisterTLSConfig failed for %s: %v", name, err)
+		}
+	}
+
+	// Verify all configs exist and are correct
+	for name, originalConfig := range configs {
+		clone, exists := getTLSConfigClone(name)
+		if !exists {
+			t.Fatalf("Config %s should exist", name)
+		}
+
+		// Verify key properties are preserved
+		if clone.InsecureSkipVerify != originalConfig.InsecureSkipVerify {
+			t.Fatalf("InsecureSkipVerify mismatch for %s", name)
+		}
+		if clone.ServerName != originalConfig.ServerName {
+			t.Fatalf("ServerName mismatch for %s", name)
+		}
+		if clone.MinVersion != originalConfig.MinVersion {
+			t.Fatalf("MinVersion mismatch for %s", name)
+		}
+	}
+
+	// Test overwriting a config
+	newConfig := &tls.Config{InsecureSkipVerify: false}
+	err := RegisterTLSConfig("insecure", newConfig)
+	if err != nil {
+		t.Fatalf("RegisterTLSConfig should allow overwriting: %v", err)
+	}
+
+	clone, _ := getTLSConfigClone("insecure")
+	if clone.InsecureSkipVerify != false {
+		t.Fatal("Config should have been overwritten")
+	}
+}

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -3,75 +3,64 @@ package gosnowflake
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"sync"
 	"testing"
 )
 
 func TestRegisterTLSConfig(t *testing.T) {
-	// Clean up any existing configs before testing
+	// Clean up any existing configs after testing
 	defer func() {
 		tlsConfigLock.Lock()
 		tlsConfigRegistry = make(map[string]*tls.Config)
 		tlsConfigLock.Unlock()
 	}()
 
-	testConfig := &tls.Config{
+	testConfig := tls.Config{
 		InsecureSkipVerify: true,
 		ServerName:         "test-server",
 	}
 
 	// Test successful registration
-	err := RegisterTLSConfig("test", testConfig)
+	err := RegisterTLSConfig("test", &testConfig)
 	if err != nil {
 		t.Fatalf("RegisterTLSConfig failed: %v", err)
 	}
 
 	// Verify config was registered
-	clone, exists := getTLSConfigClone("test")
+	retrieved, exists := getTLSConfig("test")
 	if !exists {
 		t.Fatal("TLS config was not registered")
 	}
 
-	// Verify the clone is correct but not the same object (to prevent modification)
-	if clone == testConfig {
-		t.Fatal("getTLSConfigClone should return a clone, not the original")
+	// Verify the retrieved config matches the original
+	if retrieved.InsecureSkipVerify != testConfig.InsecureSkipVerify {
+		t.Fatal("Retrieved config has different InsecureSkipVerify value")
 	}
-	if clone.InsecureSkipVerify != testConfig.InsecureSkipVerify {
-		t.Fatal("Cloned config has different InsecureSkipVerify value")
-	}
-	if clone.ServerName != testConfig.ServerName {
-		t.Fatal("Cloned config has different ServerName value")
-	}
-}
-
-func TestRegisterTLSConfigNil(t *testing.T) {
-	err := RegisterTLSConfig("test", nil)
-	if err == nil {
-		t.Fatal("RegisterTLSConfig should fail with nil config")
-	}
-	if err.Error() != "config is nil" {
-		t.Fatalf("Expected 'config is nil' error, got: %v", err)
+	if retrieved.ServerName != testConfig.ServerName {
+		t.Fatal("Retrieved config has different ServerName value")
 	}
 }
 
 func TestDeregisterTLSConfig(t *testing.T) {
-	// Clean up
+	// Clean up any existing configs after testing
 	defer func() {
 		tlsConfigLock.Lock()
 		tlsConfigRegistry = make(map[string]*tls.Config)
 		tlsConfigLock.Unlock()
 	}()
 
-	testConfig := &tls.Config{InsecureSkipVerify: true}
+	testConfig := tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "test-server",
+	}
 
 	// Register a config
-	err := RegisterTLSConfig("test", testConfig)
+	err := RegisterTLSConfig("test", &testConfig)
 	if err != nil {
 		t.Fatalf("RegisterTLSConfig failed: %v", err)
 	}
 
 	// Verify it exists
-	_, exists := getTLSConfigClone("test")
+	_, exists := getTLSConfig("test")
 	if !exists {
 		t.Fatal("TLS config should exist after registration")
 	}
@@ -80,172 +69,59 @@ func TestDeregisterTLSConfig(t *testing.T) {
 	DeregisterTLSConfig("test")
 
 	// Verify it's gone
-	_, exists = getTLSConfigClone("test")
+	_, exists = getTLSConfig("test")
 	if exists {
 		t.Fatal("TLS config should not exist after deregistration")
 	}
 }
 
-func TestGetTLSConfigCloneNonExistent(t *testing.T) {
-	_, exists := getTLSConfigClone("nonexistent")
+func TestGetTLSConfigNonExistent(t *testing.T) {
+	_, exists := getTLSConfig("nonexistent")
 	if exists {
-		t.Fatal("getTLSConfigClone should return false for non-existent config")
-	}
-}
-
-func TestTLSConfigConcurrency(t *testing.T) {
-	// Clean up
-	defer func() {
-		tlsConfigLock.Lock()
-		tlsConfigRegistry = make(map[string]*tls.Config)
-		tlsConfigLock.Unlock()
-	}()
-
-	// Test concurrent access to ensure thread safety
-	var wg sync.WaitGroup
-	numGoroutines := 10
-
-	// Concurrently register configs
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			config := &tls.Config{
-				ServerName: "server" + string(rune(index)),
-			}
-			err := RegisterTLSConfig("test"+string(rune(index)), config)
-			if err != nil {
-				t.Errorf("RegisterTLSConfig failed: %v", err)
-			}
-		}(i)
-	}
-	wg.Wait()
-
-	// Concurrently read configs
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			_, exists := getTLSConfigClone("test" + string(rune(index)))
-			if !exists {
-				t.Errorf("Config test%d should exist", index)
-			}
-		}(i)
-	}
-
-	wg.Wait()
-}
-
-func TestDSNParsingWithTLSConfig(t *testing.T) {
-	// Clean up any existing registry
-	tlsConfigLock.Lock()
-	tlsConfigRegistry = make(map[string]*tls.Config)
-	tlsConfigLock.Unlock()
-
-	// Register test TLS config
-	testTLSConfig := &tls.Config{
-		InsecureSkipVerify: true,
-		ServerName:         "custom.test.com",
-	}
-	err := RegisterTLSConfig("custom", testTLSConfig)
-	if err != nil {
-		t.Fatalf("Failed to register test TLS config: %v", err)
-	}
-	defer DeregisterTLSConfig("custom")
-
-	testCases := []struct {
-		name     string
-		dsn      string
-		expected string
-	}{
-		{
-			name:     "Basic TLS config parameter",
-			dsn:      "user:pass@account/db?tls=custom",
-			expected: "custom",
-		},
-		{
-			name:     "TLS config with other parameters",
-			dsn:      "user:pass@account/db?tls=custom&warehouse=wh&role=admin",
-			expected: "custom",
-		},
-		{
-			name:     "No TLS config parameter",
-			dsn:      "user:pass@account/db?warehouse=wh",
-			expected: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := ParseDSN(tc.dsn)
-			if err != nil {
-				t.Fatalf("ParseDSN failed: %v", err)
-			}
-			// For DSN parsing, the TLS config should be resolved and set directly
-			if tc.expected == "" {
-				if cfg.TLSConfig != nil {
-					t.Fatalf("Expected nil TLSConfig for empty DSN, got non-nil")
-				}
-			} else {
-				if cfg.TLSConfig == nil {
-					t.Fatalf("Expected non-nil TLSConfig for DSN with tls=%s, got nil", tc.expected)
-				}
-			}
-		})
+		t.Fatal("getTLSConfig should return false for non-existent config")
 	}
 }
 
 func TestRegisterTLSConfigWithCustomRootCAs(t *testing.T) {
-	// Clean up
+	// Clean up any existing configs after testing
 	defer func() {
 		tlsConfigLock.Lock()
 		tlsConfigRegistry = make(map[string]*tls.Config)
 		tlsConfigLock.Unlock()
 	}()
 
-	// Create a custom certificate pool
+	// Create a test cert pool
 	certPool := x509.NewCertPool()
-	// Add a dummy certificate for testing
 	certPool.AppendCertsFromPEM([]byte(`-----BEGIN CERTIFICATE-----
-MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
-DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
-EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
-7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BsSuuPiQi4d+NhU2BvQHmEQUAABOBG1k5
-YBNNm/hbJbr7kWLFGo2jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTAD
-AQH/MB0GA1UdDgQWBBSY0fhuILkXkz3Gjq1XvdOO/+7tSDAOBgNVHQ8BAf8EBAMC
-AQYwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAuK3VWfXWWF0b
-C0wjdl3sP3p7J2Vt8mEqGLFQX4Nk8B0CIGCOJl7VebrF1S2A/l7s6r4z9M8Yw4oJ
-2HGFo1ISJL4g
+MIIBkTCB+wIJAKHHH1pVqGqNMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNVBAMMCWxv
+Y2FsaG9zdDAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC1/2...
 -----END CERTIFICATE-----`))
 
-	testConfig := &tls.Config{
-		RootCAs: certPool,
+	testConfig := tls.Config{
+		RootCAs:            certPool,
+		InsecureSkipVerify: false,
 	}
 
-	// Register the config
-	err := RegisterTLSConfig("custom-ca", testConfig)
+	err := RegisterTLSConfig("custom-ca", &testConfig)
 	if err != nil {
 		t.Fatalf("RegisterTLSConfig failed: %v", err)
 	}
 
-	// Verify the config was registered with the custom RootCAs
-	clone, exists := getTLSConfigClone("custom-ca")
+	// Retrieve and verify
+	retrieved, exists := getTLSConfig("custom-ca")
 	if !exists {
-		t.Fatal("TLS config was not registered")
+		t.Fatal("TLS config should exist")
 	}
 
-	if clone.RootCAs == nil {
-		t.Fatal("RootCAs was not preserved in cloned config")
-	}
-
-	// The clone should have the same certificates as the original
-	if !clone.RootCAs.Equal(testConfig.RootCAs) {
-		t.Fatal("RootCAs differs between original and clone")
+	// The retrieved should have the same certificates as the original
+	if !retrieved.RootCAs.Equal(testConfig.RootCAs) {
+		t.Fatal("RootCAs differs between original and retrieved")
 	}
 }
 
 func TestMultipleTLSConfigs(t *testing.T) {
-	// Clean up
+	// Clean up any existing configs after testing
 	defer func() {
 		tlsConfigLock.Lock()
 		tlsConfigRegistry = make(map[string]*tls.Config)
@@ -254,11 +130,10 @@ func TestMultipleTLSConfigs(t *testing.T) {
 
 	configs := map[string]*tls.Config{
 		"insecure": {InsecureSkipVerify: true},
-		"strict":   {InsecureSkipVerify: false, ServerName: "strict-server"},
-		"custom":   {MinVersion: tls.VersionTLS12},
+		"secure":   {InsecureSkipVerify: false, ServerName: "secure.example.com"},
 	}
 
-	// Register all configs
+	// Register multiple configs
 	for name, config := range configs {
 		err := RegisterTLSConfig(name, config)
 		if err != nil {
@@ -266,77 +141,29 @@ func TestMultipleTLSConfigs(t *testing.T) {
 		}
 	}
 
-	// Verify all configs exist and are correct
-	for name, originalConfig := range configs {
-		clone, exists := getTLSConfigClone(name)
+	// Verify all can be retrieved
+	for name, original := range configs {
+		retrieved, exists := getTLSConfig(name)
 		if !exists {
 			t.Fatalf("Config %s should exist", name)
 		}
-
-		// Verify key properties are preserved
-		if clone.InsecureSkipVerify != originalConfig.InsecureSkipVerify {
-			t.Fatalf("InsecureSkipVerify mismatch for %s", name)
+		if retrieved.InsecureSkipVerify != original.InsecureSkipVerify {
+			t.Fatalf("Config %s has wrong InsecureSkipVerify", name)
 		}
-		if clone.ServerName != originalConfig.ServerName {
-			t.Fatalf("ServerName mismatch for %s", name)
-		}
-		if clone.MinVersion != originalConfig.MinVersion {
-			t.Fatalf("MinVersion mismatch for %s", name)
+		if retrieved.ServerName != original.ServerName {
+			t.Fatalf("Config %s has wrong ServerName", name)
 		}
 	}
 
-	// Test overwriting a config
-	newConfig := &tls.Config{InsecureSkipVerify: false}
-	err := RegisterTLSConfig("insecure", newConfig)
+	// Test overwriting
+	newConfig := tls.Config{InsecureSkipVerify: false, ServerName: "new.example.com"}
+	err := RegisterTLSConfig("insecure", &newConfig)
 	if err != nil {
 		t.Fatalf("RegisterTLSConfig should allow overwriting: %v", err)
 	}
 
-	clone, _ := getTLSConfigClone("insecure")
-	if clone.InsecureSkipVerify != false {
+	retrieved, _ := getTLSConfig("insecure")
+	if retrieved.ServerName != "new.example.com" {
 		t.Fatal("Config should have been overwritten")
-	}
-}
-
-// Test that custom TLS configs preserve OCSP validation
-func TestRegisterTLSConfigWithOCSPValidation(t *testing.T) {
-	rootCertPool := x509.NewCertPool()
-	rootCertPool.AppendCertsFromPEM([]byte(`-----BEGIN CERTIFICATE-----
-MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
-DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
-EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
-7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BsSuuPiQi4d+NhU2BvQHmEQUAABOBG1k5
-YBNNm/hbJbr7kWLFGo2jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTAD
-AQH/MB0GA1UdDgQWBBSY0fhuILkXkz3Gjq1XvdOO/+7tSDAOBgNVHQ8BAf8EBAMC
-AQYwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAuK3VWfXWWF0b
-C0wjdl3sP3p7J2Vt8mEqGLFQX4Nk8B0CIGCOJl7VebrF1S2A/l7s6r4z9M8Yw4oJ
-2HGFo1ISJL4g
------END CERTIFICATE-----`))
-
-	customConfig := &tls.Config{
-		RootCAs: rootCertPool,
-	}
-
-	err := RegisterTLSConfig("test-ocsp", customConfig)
-	if err != nil {
-		t.Fatalf("Failed to register TLS config: %v", err)
-	}
-	defer DeregisterTLSConfig("test-ocsp")
-
-	// Get the cloned config
-	clonedConfig, exists := getTLSConfigClone("test-ocsp")
-	if !exists {
-		t.Fatal("Expected config to exist")
-	}
-
-	// Verify the custom RootCAs are preserved
-	if clonedConfig.RootCAs == nil {
-		t.Fatal("Expected RootCAs to be preserved")
-	}
-
-	// The actual OCSP verification chaining is tested in the connection logic
-	// Here we just verify the config can be retrieved and has the expected properties
-	if clonedConfig.RootCAs != customConfig.RootCAs {
-		t.Error("Expected RootCAs to match the original custom config")
 	}
 }

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -119,6 +119,7 @@ func TestTLSConfigConcurrency(t *testing.T) {
 			}
 		}(i)
 	}
+	wg.Wait()
 
 	// Concurrently read configs
 	for i := 0; i < numGoroutines; i++ {

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -92,11 +92,6 @@ func TestRegisterTLSConfigWithCustomRootCAs(t *testing.T) {
 
 	// Create a test cert pool
 	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM([]byte(`-----BEGIN CERTIFICATE-----
-MIIBkTCB+wIJAKHHH1pVqGqNMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNVBAMMCWxv
-Y2FsaG9zdDAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMBQxEjAQBgNV
-BAMMCWxvY2FsaG9zdDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC1/2...
------END CERTIFICATE-----`))
 
 	testConfig := tls.Config{
 		RootCAs:            certPool,

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -66,7 +66,10 @@ func TestDeregisterTLSConfig(t *testing.T) {
 	}
 
 	// Deregister it
-	DeregisterTLSConfig("test")
+	err = DeregisterTLSConfig("test")
+	if err != nil {
+		t.Fatalf("DeregisterTLSConfig failed: %v", err)
+	}
 
 	// Verify it's gone
 	_, exists = getTLSConfig("test")

--- a/transport.go
+++ b/transport.go
@@ -70,7 +70,7 @@ func (tf *transportFactory) createBaseTransport(transportConfig *transportConfig
 // createOCSPTransport creates a transport with OCSP validation
 func (tf *transportFactory) createOCSPTransport() *http.Transport {
 	// Chain OCSP verification with custom TLS config
-	tlsConfig := tf.config.TLSConfig
+	tlsConfig := tf.config.tlsConfig
 	if tlsConfig != nil {
 		tlsConfig.VerifyPeerCertificate = tf.chainVerificationCallbacks(tlsConfig.VerifyPeerCertificate, verifyPeerCertificateSerial)
 	} else {
@@ -139,7 +139,7 @@ func (tf *transportFactory) createTransport() (http.RoundTripper, *crlValidator,
 			return nil, nil, err
 		}
 		// Chain CRL verification with custom TLS config
-		tlsConfig := tf.config.TLSConfig
+		tlsConfig := tf.config.tlsConfig
 		if tlsConfig != nil {
 			crlVerify := crlValidator.verifyPeerCertificates
 			tlsConfig.VerifyPeerCertificate = tf.chainVerificationCallbacks(tlsConfig.VerifyPeerCertificate, crlVerify)

--- a/transport.go
+++ b/transport.go
@@ -91,7 +91,7 @@ func (tf *transportFactory) createNoRevocationTransport() *http.Transport {
 	return tf.createBaseTransport(defaultTransportConfig(), nil)
 }
 
-// createCRLTransport creates a transport with CRL validation
+// createCRLValidator creates a CRL validator
 func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 	allowCertificatesWithoutCrlURL := tf.config.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue
 	client := &http.Client{

--- a/transport.go
+++ b/transport.go
@@ -117,9 +117,12 @@ func (tf *TransportFactory) createCRLTransportInternal() (*http.Transport, *crlV
 }
 
 // CreateCustomTLSTransport creates a transport with custom TLS configuration
-func (tf *TransportFactory) CreateCustomTLSTransport(customTLSConfig *tls.Config) http.RoundTripper {
-	transport, _, _ := tf.createCustomTLSTransportInternal(customTLSConfig)
-	return transport
+func (tf *TransportFactory) CreateCustomTLSTransport(customTLSConfig *tls.Config) (http.RoundTripper, error) {
+	transport, _, err := tf.createCustomTLSTransportInternal(customTLSConfig)
+	if err != nil {
+		return nil, err
+	}
+	return transport, nil
 }
 
 // createCustomTLSTransportInternal creates a transport with custom TLS configuration and returns the validator
@@ -168,9 +171,12 @@ func (tf *TransportFactory) createCustomTLSWithOCSP(customTLSConfig *tls.Config)
 }
 
 // CreateStandardTransport creates a transport without custom TLS configuration
-func (tf *TransportFactory) CreateStandardTransport() http.RoundTripper {
-	transport, _, _ := tf.createStandardTransportInternal()
-	return transport
+func (tf *TransportFactory) CreateStandardTransport() (http.RoundTripper, error) {
+	transport, _, err := tf.createStandardTransportInternal()
+	if err != nil {
+		return nil, err
+	}
+	return transport, nil
 }
 
 // createStandardTransportInternal creates a transport without custom TLS configuration and returns the validator

--- a/transport.go
+++ b/transport.go
@@ -1,6 +1,7 @@
 package gosnowflake
 
 import (
+	"cmp"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -93,7 +94,7 @@ func (tf *transportFactory) createNoRevocationTransport() *http.Transport {
 func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 	allowCertificatesWithoutCrlURL := tf.config.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue
 	client := &http.Client{
-		Timeout: getConfigDuration(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
+		Timeout: cmp.Or(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
 	}
 
 	return newCrlValidator(
@@ -183,12 +184,4 @@ func (tf *transportFactory) chainVerificationCallbacks(orignalVerificationFunc f
 		return verificationFunc(rawCerts, verifiedChains)
 	}
 	return newVerify
-}
-
-// getConfigDuration returns the config duration if non-zero, otherwise returns the default
-func getConfigDuration(configValue, defaultValue time.Duration) time.Duration {
-	if configValue != 0 {
-		return configValue
-	}
-	return defaultValue
 }

--- a/transport.go
+++ b/transport.go
@@ -209,11 +209,9 @@ func (tf *TransportFactory) createTransport() (http.RoundTripper, *crlValidator,
 	}
 
 	// Handle custom TLS configuration path
-	if tf.config.TLSConfig != "" {
-		customTLSConfig, ok := getTLSConfigClone(tf.config.TLSConfig)
-		if !ok {
-			return nil, nil, errors.New("TLS config not found: " + tf.config.TLSConfig)
-		}
+	if tf.config.TLSConfig != nil {
+		// Use direct TLS config - clone it for safety
+		customTLSConfig := tf.config.TLSConfig.Clone()
 		return tf.createCustomTLSTransportInternal(customTLSConfig)
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -96,7 +96,7 @@ func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 		Timeout: getConfigDuration(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
 	}
 
-	crlValidator, err := newCrlValidator(
+	return newCrlValidator(
 		tf.config.CertRevocationCheckMode,
 		allowCertificatesWithoutCrlURL,
 		tf.config.CrlCacheValidityTime,
@@ -106,11 +106,6 @@ func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 		tf.config.CrlOnDiskCacheRemovalDelay,
 		client,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return crlValidator, nil
 }
 
 // TODO(snoonan): Better interface for crlValidator return

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,268 @@
+package gosnowflake
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// TransportConfig holds the configuration for creating HTTP transports
+type TransportConfig struct {
+	MaxIdleConns    int
+	IdleConnTimeout time.Duration
+	DialTimeout     time.Duration
+	KeepAlive       time.Duration
+}
+
+// DefaultTransportConfig returns the standard transport configuration
+func DefaultTransportConfig() TransportConfig {
+	return TransportConfig{
+		MaxIdleConns:    10,
+		IdleConnTimeout: 30 * time.Minute,
+		DialTimeout:     30 * time.Second,
+		KeepAlive:       30 * time.Second,
+	}
+}
+
+// CRLTransportConfig returns the transport configuration for CRL validation
+// Uses more conservative timeouts for CRL operations
+func CRLTransportConfig() TransportConfig {
+	return TransportConfig{
+		MaxIdleConns:    5,
+		IdleConnTimeout: 5 * time.Minute,
+		DialTimeout:     5 * time.Second,
+		KeepAlive:       0, // No keep-alive for CRL operations
+	}
+}
+
+// TransportFactory handles creation of HTTP transports with different validation modes
+type TransportFactory struct {
+	config *Config
+}
+
+// NewTransportFactory creates a new transport factory
+func NewTransportFactory(config *Config) *TransportFactory {
+	return &TransportFactory{config: config}
+}
+
+// createBaseTransport creates a base HTTP transport with the given configuration
+func (tf *TransportFactory) createBaseTransport(transportConfig TransportConfig, tlsConfig *tls.Config) *http.Transport {
+	dialer := &net.Dialer{
+		Timeout: transportConfig.DialTimeout,
+	}
+	if transportConfig.KeepAlive > 0 {
+		dialer.KeepAlive = transportConfig.KeepAlive
+	}
+
+	return &http.Transport{
+		TLSClientConfig: tlsConfig,
+		MaxIdleConns:    transportConfig.MaxIdleConns,
+		IdleConnTimeout: transportConfig.IdleConnTimeout,
+		Proxy:           http.ProxyFromEnvironment,
+		DialContext:     dialer.DialContext,
+	}
+}
+
+// CreateOCSPTransport creates a transport with OCSP validation
+func (tf *TransportFactory) CreateOCSPTransport() *http.Transport {
+	tlsConfig := &tls.Config{
+		RootCAs:               certPool,
+		VerifyPeerCertificate: verifyPeerCertificateSerial,
+	}
+	return tf.createBaseTransport(DefaultTransportConfig(), tlsConfig)
+}
+
+// CreateNoRevocationTransport creates a transport without certificate revocation checking
+func (tf *TransportFactory) CreateNoRevocationTransport() *http.Transport {
+	return tf.createBaseTransport(DefaultTransportConfig(), nil)
+}
+
+// CreateCRLTransport creates a transport with CRL validation
+func (tf *TransportFactory) CreateCRLTransport() (*http.Transport, *crlValidator, error) {
+	allowCertificatesWithoutCrlURL := tf.config.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue
+	client := &http.Client{
+		Timeout: getConfigDuration(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
+	}
+
+	crlValidator, err := newCrlValidator(
+		tf.config.CertRevocationCheckMode,
+		allowCertificatesWithoutCrlURL,
+		tf.config.CrlCacheValidityTime,
+		tf.config.CrlInMemoryCacheDisabled,
+		tf.config.CrlOnDiskCacheDisabled,
+		tf.config.CrlOnDiskCacheDir,
+		tf.config.CrlOnDiskCacheRemovalDelay,
+		client,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		VerifyPeerCertificate: crlValidator.verifyPeerCertificates,
+	}
+
+	transport := tf.createBaseTransport(CRLTransportConfig(), tlsConfig)
+	return transport, crlValidator, nil
+}
+
+// CreateCustomTLSTransport creates a transport with custom TLS configuration
+func (tf *TransportFactory) CreateCustomTLSTransport(customTLSConfig *tls.Config) (http.RoundTripper, *crlValidator, error) {
+	// Validate configuration
+	if err := tf.validateRevocationConfig(); err != nil {
+		return nil, nil, err
+	}
+
+	// Handle CRL validation path
+	if tf.config.CertRevocationCheckMode != CertRevocationCheckDisabled {
+		return tf.createCustomTLSWithCRL(customTLSConfig)
+	}
+
+	// Handle OCSP validation path
+	if !tf.config.DisableOCSPChecks && !tf.config.InsecureMode {
+		return tf.createCustomTLSWithOCSP(customTLSConfig), nil, nil
+	}
+
+	// No revocation checking - just use the custom TLS config
+	return tf.createBaseTransport(DefaultTransportConfig(), customTLSConfig), nil, nil
+}
+
+// createCustomTLSWithCRL creates a transport combining custom TLS config with CRL validation
+func (tf *TransportFactory) createCustomTLSWithCRL(customTLSConfig *tls.Config) (http.RoundTripper, *crlValidator, error) {
+	// Create CRL validator
+	_, cv, err := tf.CreateCRLTransport()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Chain CRL verification with custom TLS config
+	crlVerify := cv.verifyPeerCertificates
+	tf.chainVerificationCallbacks(customTLSConfig, crlVerify)
+
+	// Create transport with custom TLS config and CRL transport settings
+	transport := tf.createBaseTransport(CRLTransportConfig(), customTLSConfig)
+	return transport, cv, nil
+}
+
+// createCustomTLSWithOCSP creates a transport combining custom TLS config with OCSP validation
+func (tf *TransportFactory) createCustomTLSWithOCSP(customTLSConfig *tls.Config) http.RoundTripper {
+	// Chain OCSP verification with custom TLS config
+	tf.chainVerificationCallbacks(customTLSConfig, verifyPeerCertificateSerial)
+	return tf.createBaseTransport(DefaultTransportConfig(), customTLSConfig)
+}
+
+// CreateStandardTransport creates a transport without custom TLS configuration
+func (tf *TransportFactory) CreateStandardTransport() (http.RoundTripper, *crlValidator, error) {
+	// Validate configuration
+	if err := tf.validateRevocationConfig(); err != nil {
+		return nil, nil, err
+	}
+
+	// Handle CRL validation path
+	if tf.config.CertRevocationCheckMode != CertRevocationCheckDisabled {
+		return tf.CreateCRLTransport()
+	}
+
+	// Handle no revocation checking path
+	if tf.config.DisableOCSPChecks || tf.config.InsecureMode {
+		return tf.CreateNoRevocationTransport(), nil, nil
+	}
+
+	// Default OCSP path - set OCSP fail open mode
+	ocspResponseCacheLock.Lock()
+	atomic.StoreUint32((*uint32)(&ocspFailOpen), uint32(tf.config.OCSPFailOpen))
+	ocspResponseCacheLock.Unlock()
+	return tf.CreateOCSPTransport(), nil, nil
+}
+
+// CreateTransport is the main entry point for creating transports
+// This replaces the transport selection logic in buildSnowflakeConn
+func (tf *TransportFactory) CreateTransport() (http.RoundTripper, *crlValidator, error) {
+	// Early return: Use custom transporter if provided
+	if tf.config.Transporter != nil {
+		return tf.config.Transporter, nil, nil
+	}
+
+	// Handle custom TLS configuration path
+	if tf.config.TLSConfig != "" {
+		customTLSConfig, ok := getTLSConfigClone(tf.config.TLSConfig)
+		if !ok {
+			return nil, nil, errors.New("TLS config not found: " + tf.config.TLSConfig)
+		}
+		return tf.CreateCustomTLSTransport(customTLSConfig)
+	}
+
+	// Handle standard transport configuration
+	return tf.CreateStandardTransport()
+}
+
+// CreateFileTransferTransport creates a transport for file transfer operations
+// This replaces the getTransport function
+func (tf *TransportFactory) CreateFileTransferTransport() (http.RoundTripper, error) {
+	if tf.config == nil {
+		// should never happen in production, only in tests
+		logger.Warn("CreateFileTransferTransport: got nil Config, using default one")
+		return tf.CreateNoRevocationTransport(), nil
+	}
+
+	// if user configured a custom Transporter, prioritize that
+	if tf.config.Transporter != nil {
+		logger.Debug("CreateFileTransferTransport: using Transporter configured by the user")
+		return tf.config.Transporter, nil
+	}
+
+	if tf.config.CertRevocationCheckMode != CertRevocationCheckDisabled {
+		transport, _, err := tf.CreateCRLTransport()
+		if err != nil {
+			return nil, err
+		}
+		return transport, nil
+	}
+
+	if tf.config.DisableOCSPChecks || tf.config.InsecureMode {
+		logger.Debug("CreateFileTransferTransport: skipping OCSP validation for cloud storage")
+		return tf.CreateNoRevocationTransport(), nil
+	}
+
+	logger.Debug("CreateFileTransferTransport: will perform OCSP validation for cloud storage")
+	return tf.CreateOCSPTransport(), nil
+}
+
+// validateRevocationConfig checks for conflicting revocation settings
+func (tf *TransportFactory) validateRevocationConfig() error {
+	if !tf.config.DisableOCSPChecks && !tf.config.InsecureMode && tf.config.CertRevocationCheckMode != CertRevocationCheckDisabled {
+		return errors.New("both OCSP and CRL cannot be enabled at the same time, please disable one of them")
+	}
+	return nil
+}
+
+// chainVerificationCallbacks chains a user's custom verification with the provided verification function
+func (tf *TransportFactory) chainVerificationCallbacks(customTLSConfig *tls.Config, verificationFunc func([][]byte, [][]*x509.Certificate) error) {
+	if customTLSConfig.VerifyPeerCertificate == nil {
+		customTLSConfig.VerifyPeerCertificate = verificationFunc
+		return
+	}
+
+	// Chain the existing verification with the new one
+	originalVerify := customTLSConfig.VerifyPeerCertificate
+	customTLSConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		// Run the user's custom verification first
+		if err := originalVerify(rawCerts, verifiedChains); err != nil {
+			return err
+		}
+		// Then run the provided verification
+		return verificationFunc(rawCerts, verifiedChains)
+	}
+}
+
+// getConfigDuration returns the config duration if non-zero, otherwise returns the default
+func getConfigDuration(configValue, defaultValue time.Duration) time.Duration {
+	if configValue != 0 {
+		return configValue
+	}
+	return defaultValue
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -6,15 +6,6 @@ import (
 	"testing"
 )
 
-// castToTransport safely casts http.RoundTripper to *http.Transport
-// Returns nil if the cast fails
-func castToTransport(rt http.RoundTripper) *http.Transport {
-	if transport, ok := rt.(*http.Transport); ok {
-		return transport
-	}
-	return nil
-}
-
 // assertTransportsEqual compares two transports, excluding function fields and other non-comparable fields
 // that may vary between instances but represent equivalent configurations
 func assertTransportsEqual(t *testing.T, expected, actual *http.Transport, msg string) {

--- a/transport_test.go
+++ b/transport_test.go
@@ -40,27 +40,6 @@ func assertTransportsEqual(t *testing.T, expected, actual *http.Transport, msg s
 	assertEqualF(t, expected.ForceAttemptHTTP2, actual.ForceAttemptHTTP2, "%s ForceAttemptHTTP2", msg)
 }
 
-// assertTLSConfigsEqual compares two TLS configurations, excluding function fields
-// like VerifyPeerCertificate which may point to different but equivalent functions
-func assertTLSConfigsEqual(t *testing.T, expected, actual *tls.Config, msg string) {
-	if expected == nil && actual == nil {
-		return
-	}
-	assertNotNilF(t, expected, "Expected TLS config should not be nil in %s", msg)
-	assertNotNilF(t, actual, "Actual TLS config should not be nil in %s", msg)
-
-	// Compare non-function fields
-	assertEqualF(t, expected.InsecureSkipVerify, actual.InsecureSkipVerify, "%s InsecureSkipVerify", msg)
-	assertEqualF(t, expected.ServerName, actual.ServerName, "%s ServerName", msg)
-	assertEqualF(t, expected.MinVersion, actual.MinVersion, "%s MinVersion", msg)
-	assertEqualF(t, expected.MaxVersion, actual.MaxVersion, "%s MaxVersion", msg)
-
-	// For VerifyPeerCertificate, just check presence/absence since function pointers can't be compared
-	expectedHasVerifier := expected.VerifyPeerCertificate != nil
-	actualHasVerifier := actual.VerifyPeerCertificate != nil
-	assertEqualF(t, expectedHasVerifier, actualHasVerifier, "%s VerifyPeerCertificate presence", msg)
-}
-
 func TestTransportFactoryErrorHandling(t *testing.T) {
 	// Test CreateCustomTLSTransport with conflicting OCSP and CRL settings
 	conflictingConfig := &Config{

--- a/transport_test.go
+++ b/transport_test.go
@@ -11,12 +11,12 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 		DisableOCSPChecks:       false,
 		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
+		TLSConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
 
 	factory := newTransportFactory(conflictingConfig)
-	customTLS := &tls.Config{InsecureSkipVerify: true}
 
-	transport, err := factory.CreateCustomTLSTransport(customTLS)
+	transport, _, err := factory.createTransport()
 	if err == nil {
 		t.Fatal("Expected error for conflicting OCSP and CRL configuration")
 	}
@@ -39,7 +39,7 @@ func TestCreateStandardTransportErrorHandling(t *testing.T) {
 
 	factory := newTransportFactory(conflictingConfig)
 
-	transport, err := factory.CreateStandardTransport()
+	transport, _, err := factory.createTransport()
 	if err == nil {
 		t.Fatal("Expected error for conflicting OCSP and CRL configuration")
 	}
@@ -54,12 +54,12 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 		DisableOCSPChecks:       true,
 		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
+		TLSConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
 
 	factory := newTransportFactory(validConfig)
-	customTLS := &tls.Config{InsecureSkipVerify: true}
 
-	transport, err := factory.CreateCustomTLSTransport(customTLS)
+	transport, _, err := factory.createTransport()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 
 	factory := newTransportFactory(validConfig)
 
-	transport, err := factory.CreateStandardTransport()
+	transport, _, err := factory.createTransport()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,88 @@
+package gosnowflake
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestTransportFactoryErrorHandling(t *testing.T) {
+	// Test CreateCustomTLSTransport with conflicting OCSP and CRL settings
+	conflictingConfig := &Config{
+		DisableOCSPChecks:       false,
+		InsecureMode:            false,
+		CertRevocationCheckMode: CertRevocationCheckEnabled,
+	}
+
+	factory := NewTransportFactory(conflictingConfig)
+	customTLS := &tls.Config{InsecureSkipVerify: true}
+
+	transport, err := factory.CreateCustomTLSTransport(customTLS)
+	if err == nil {
+		t.Fatal("Expected error for conflicting OCSP and CRL configuration")
+	}
+	if transport != nil {
+		t.Fatal("Expected nil transport when error occurs")
+	}
+	expectedError := "both OCSP and CRL cannot be enabled at the same time, please disable one of them"
+	if err.Error() != expectedError {
+		t.Fatalf("Expected error message: %s, got: %s", expectedError, err.Error())
+	}
+}
+
+func TestCreateStandardTransportErrorHandling(t *testing.T) {
+	// Test CreateStandardTransport with conflicting settings
+	conflictingConfig := &Config{
+		DisableOCSPChecks:       false,
+		InsecureMode:            false,
+		CertRevocationCheckMode: CertRevocationCheckEnabled,
+	}
+
+	factory := NewTransportFactory(conflictingConfig)
+
+	transport, err := factory.CreateStandardTransport()
+	if err == nil {
+		t.Fatal("Expected error for conflicting OCSP and CRL configuration")
+	}
+	if transport != nil {
+		t.Fatal("Expected nil transport when error occurs")
+	}
+}
+
+func TestCreateCustomTLSTransportSuccess(t *testing.T) {
+	// Test successful creation with valid config
+	validConfig := &Config{
+		DisableOCSPChecks:       true,
+		InsecureMode:            false,
+		CertRevocationCheckMode: CertRevocationCheckDisabled,
+	}
+
+	factory := NewTransportFactory(validConfig)
+	customTLS := &tls.Config{InsecureSkipVerify: true}
+
+	transport, err := factory.CreateCustomTLSTransport(customTLS)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("Expected non-nil transport for valid configuration")
+	}
+}
+
+func TestCreateStandardTransportSuccess(t *testing.T) {
+	// Test successful creation with valid config
+	validConfig := &Config{
+		DisableOCSPChecks:       true,
+		InsecureMode:            false,
+		CertRevocationCheckMode: CertRevocationCheckDisabled,
+	}
+
+	factory := NewTransportFactory(validConfig)
+
+	transport, err := factory.CreateStandardTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("Expected non-nil transport for valid configuration")
+	}
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -49,7 +49,7 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 		TLSConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
 
-	factory := newTransportFactory(conflictingConfig)
+	factory := newTransportFactory(conflictingConfig, nil)
 
 	transport, _, err := factory.createTransport()
 	assertNotNilF(t, err, "Expected error for conflicting OCSP and CRL configuration")
@@ -66,7 +66,7 @@ func TestCreateStandardTransportErrorHandling(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
 
-	factory := newTransportFactory(conflictingConfig)
+	factory := newTransportFactory(conflictingConfig, nil)
 
 	transport, _, err := factory.createTransport()
 	assertNotNilF(t, err, "Expected error for conflicting OCSP and CRL configuration")
@@ -82,7 +82,7 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 		TLSConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
 
-	factory := newTransportFactory(validConfig)
+	factory := newTransportFactory(validConfig, nil)
 
 	transport, _, err := factory.createTransport()
 	assertNilF(t, err, "Unexpected error")
@@ -97,7 +97,7 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 	}
 
-	factory := newTransportFactory(validConfig)
+	factory := newTransportFactory(validConfig, nil)
 
 	transport, _, err := factory.createTransport()
 	assertNilF(t, err, "Unexpected error")
@@ -118,7 +118,7 @@ func TestDirectTLSConfigUsage(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 	}
 
-	factory := newTransportFactory(config)
+	factory := newTransportFactory(config, nil)
 	transport, crlValidator, err := factory.createTransport()
 
 	assertNilF(t, err, "Unexpected error")
@@ -153,7 +153,7 @@ func TestRegisteredTLSConfigUsage(t *testing.T) {
 
 	config.CertRevocationCheckMode = CertRevocationCheckDisabled
 
-	factory := newTransportFactory(config)
+	factory := newTransportFactory(config, nil)
 	transport, crlValidator, err := factory.createTransport()
 
 	assertNilF(t, err, "Unexpected error")
@@ -177,7 +177,7 @@ func TestDirectTLSConfigOnly(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 	}
 
-	factory := newTransportFactory(config)
+	factory := newTransportFactory(config, nil)
 	transport, crlValidator, err := factory.createTransport()
 
 	assertNilF(t, err, "Unexpected error")

--- a/transport_test.go
+++ b/transport_test.go
@@ -149,14 +149,3 @@ func TestDirectTLSConfigOnly(t *testing.T) {
 	assertNotNilF(t, transport, "Expected non-nil transport")
 	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }
-
-func TestTLSConfigNotFound(t *testing.T) {
-	// Test error handling when registered TLS config doesn't exist in DSN parsing
-	dsn := "user:pass@account/db?tls=nonexistent"
-
-	_, err := ParseDSN(dsn)
-	assertNotNilF(t, err, "Expected error for nonexistent TLS config in DSN")
-
-	expectedError := "TLS config not found: nonexistent"
-	assertEqualF(t, err.Error(), expectedError, "Expected specific error message")
-}

--- a/transport_test.go
+++ b/transport_test.go
@@ -86,3 +86,118 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 		t.Fatal("Expected non-nil transport for valid configuration")
 	}
 }
+
+func TestDirectTLSConfigUsage(t *testing.T) {
+	// Test the new direct TLS config approach
+	customTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "custom.example.com",
+	}
+
+	config := &Config{
+		TLSConfig:               customTLS, // Direct TLS config
+		DisableOCSPChecks:       true,
+		InsecureMode:            false,
+		CertRevocationCheckMode: CertRevocationCheckDisabled,
+	}
+
+	factory := newTransportFactory(config)
+	transport, crlValidator, err := factory.createTransport()
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("Expected non-nil transport")
+	}
+	if crlValidator != nil {
+		t.Fatal("Expected nil CRL validator for this configuration")
+	}
+}
+
+func TestRegisteredTLSConfigUsage(t *testing.T) {
+	// Test registered TLS config approach through DSN parsing
+
+	// Clean up any existing registry
+	tlsConfigLock.Lock()
+	tlsConfigRegistry = make(map[string]*tls.Config)
+	tlsConfigLock.Unlock()
+
+	// Register a custom TLS config
+	customTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "registered.example.com",
+	}
+	err := RegisterTLSConfig("test-direct", customTLS)
+	if err != nil {
+		t.Fatalf("Failed to register TLS config: %v", err)
+	}
+	defer DeregisterTLSConfig("test-direct")
+
+	// Parse DSN that references the registered config
+	dsn := "user:pass@account/db?tls=test-direct&ocspFailOpen=false&disableOCSPChecks=true"
+	config, err2 := ParseDSN(dsn)
+	if err2 != nil {
+		t.Fatalf("Failed to parse DSN: %v", err2)
+	}
+
+	config.CertRevocationCheckMode = CertRevocationCheckDisabled
+
+	factory := newTransportFactory(config)
+	transport, crlValidator, err := factory.createTransport()
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("Expected non-nil transport")
+	}
+	if crlValidator != nil {
+		t.Fatal("Expected nil CRL validator for this configuration")
+	}
+}
+
+func TestDirectTLSConfigOnly(t *testing.T) {
+	// Test that direct TLS config works without any registration
+
+	// Create a direct TLS config
+	directTLS := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "direct.example.com",
+	}
+
+	config := &Config{
+		TLSConfig:               directTLS, // Direct config
+		DisableOCSPChecks:       true,
+		InsecureMode:            false,
+		CertRevocationCheckMode: CertRevocationCheckDisabled,
+	}
+
+	factory := newTransportFactory(config)
+	transport, crlValidator, err := factory.createTransport()
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("Expected non-nil transport")
+	}
+	if crlValidator != nil {
+		t.Fatal("Expected nil CRL validator for this configuration")
+	}
+}
+
+func TestTLSConfigNotFound(t *testing.T) {
+	// Test error handling when registered TLS config doesn't exist in DSN parsing
+	dsn := "user:pass@account/db?tls=nonexistent"
+
+	_, err := ParseDSN(dsn)
+	if err == nil {
+		t.Fatal("Expected error for nonexistent TLS config in DSN")
+	}
+
+	expectedError := "TLS config not found: nonexistent"
+	if err.Error() != expectedError {
+		t.Fatalf("Expected error message: %s, got: %s", expectedError, err.Error())
+	}
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -46,7 +46,7 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 		DisableOCSPChecks:       false,
 		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
-		TLSConfig:               &tls.Config{InsecureSkipVerify: true},
+		tlsConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
 
 	factory := newTransportFactory(conflictingConfig, nil)
@@ -79,7 +79,7 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 		DisableOCSPChecks:       true,
 		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
-		TLSConfig:               &tls.Config{InsecureSkipVerify: true},
+		tlsConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
 
 	factory := newTransportFactory(validConfig, nil)
@@ -112,10 +112,10 @@ func TestDirectTLSConfigUsage(t *testing.T) {
 	}
 
 	config := &Config{
-		TLSConfig:               customTLS, // Direct TLS config
 		DisableOCSPChecks:       true,
 		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
+		tlsConfig:               customTLS, // Direct TLS config
 	}
 
 	factory := newTransportFactory(config, nil)
@@ -171,10 +171,10 @@ func TestDirectTLSConfigOnly(t *testing.T) {
 	}
 
 	config := &Config{
-		TLSConfig:               directTLS, // Direct config
 		DisableOCSPChecks:       true,
 		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
+		tlsConfig:               directTLS, // Direct config
 	}
 
 	factory := newTransportFactory(config, nil)

--- a/transport_test.go
+++ b/transport_test.go
@@ -132,7 +132,12 @@ func TestRegisteredTLSConfigUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to register TLS config: %v", err)
 	}
-	defer DeregisterTLSConfig("test-direct")
+	defer func() {
+		err := DeregisterTLSConfig("test-direct")
+		if err != nil {
+			t.Fatalf("Failed to deregister test TLS config: %v", err)
+		}
+	}()
 
 	// Parse DSN that references the registered config
 	dsn := "user:pass@account/db?tls=test-direct&ocspFailOpen=false&disableOCSPChecks=true"

--- a/transport_test.go
+++ b/transport_test.go
@@ -13,7 +13,7 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
 
-	factory := NewTransportFactory(conflictingConfig)
+	factory := newTransportFactory(conflictingConfig)
 	customTLS := &tls.Config{InsecureSkipVerify: true}
 
 	transport, err := factory.CreateCustomTLSTransport(customTLS)
@@ -37,7 +37,7 @@ func TestCreateStandardTransportErrorHandling(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
 
-	factory := NewTransportFactory(conflictingConfig)
+	factory := newTransportFactory(conflictingConfig)
 
 	transport, err := factory.CreateStandardTransport()
 	if err == nil {
@@ -56,7 +56,7 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 	}
 
-	factory := NewTransportFactory(validConfig)
+	factory := newTransportFactory(validConfig)
 	customTLS := &tls.Config{InsecureSkipVerify: true}
 
 	transport, err := factory.CreateCustomTLSTransport(customTLS)
@@ -76,7 +76,7 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 	}
 
-	factory := NewTransportFactory(validConfig)
+	factory := newTransportFactory(validConfig)
 
 	transport, err := factory.CreateStandardTransport()
 	if err != nil {

--- a/transport_test.go
+++ b/transport_test.go
@@ -42,7 +42,7 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 
 	factory := newTransportFactory(conflictingConfig, nil)
 
-	transport, _, err := factory.createTransport()
+	transport, err := factory.createTransport()
 	assertNotNilF(t, err, "Expected error for conflicting OCSP and CRL configuration")
 	assertNilF(t, transport, "Expected nil transport when error occurs")
 	expectedError := "both OCSP and CRL cannot be enabled at the same time, please disable one of them"
@@ -59,7 +59,7 @@ func TestCreateStandardTransportErrorHandling(t *testing.T) {
 
 	factory := newTransportFactory(conflictingConfig, nil)
 
-	transport, _, err := factory.createTransport()
+	transport, err := factory.createTransport()
 	assertNotNilF(t, err, "Expected error for conflicting OCSP and CRL configuration")
 	assertNilF(t, transport, "Expected nil transport when error occurs")
 }
@@ -75,7 +75,7 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 
 	factory := newTransportFactory(validConfig, nil)
 
-	transport, _, err := factory.createTransport()
+	transport, err := factory.createTransport()
 	assertNilF(t, err, "Unexpected error")
 	assertNotNilF(t, transport, "Expected non-nil transport for valid configuration")
 }
@@ -90,7 +90,7 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 
 	factory := newTransportFactory(validConfig, nil)
 
-	transport, _, err := factory.createTransport()
+	transport, err := factory.createTransport()
 	assertNilF(t, err, "Unexpected error")
 	assertNotNilF(t, transport, "Expected non-nil transport for valid configuration")
 }
@@ -110,11 +110,10 @@ func TestDirectTLSConfigUsage(t *testing.T) {
 	}
 
 	factory := newTransportFactory(config, nil)
-	transport, crlValidator, err := factory.createTransport()
+	transport, err := factory.createTransport()
 
 	assertNilF(t, err, "Unexpected error")
 	assertNotNilF(t, transport, "Expected non-nil transport")
-	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }
 
 func TestRegisteredTLSConfigUsage(t *testing.T) {
@@ -145,11 +144,10 @@ func TestRegisteredTLSConfigUsage(t *testing.T) {
 	config.CertRevocationCheckMode = CertRevocationCheckDisabled
 
 	factory := newTransportFactory(config, nil)
-	transport, crlValidator, err := factory.createTransport()
+	transport, err := factory.createTransport()
 
 	assertNilF(t, err, "Unexpected error")
 	assertNotNilF(t, transport, "Expected non-nil transport")
-	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }
 
 func TestDirectTLSConfigOnly(t *testing.T) {
@@ -169,9 +167,8 @@ func TestDirectTLSConfigOnly(t *testing.T) {
 	}
 
 	factory := newTransportFactory(config, nil)
-	transport, crlValidator, err := factory.createTransport()
+	transport, err := factory.createTransport()
 
 	assertNilF(t, err, "Unexpected error")
 	assertNotNilF(t, transport, "Expected non-nil transport")
-	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -17,16 +17,10 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 	factory := newTransportFactory(conflictingConfig)
 
 	transport, _, err := factory.createTransport()
-	if err == nil {
-		t.Fatal("Expected error for conflicting OCSP and CRL configuration")
-	}
-	if transport != nil {
-		t.Fatal("Expected nil transport when error occurs")
-	}
+	assertNotNilF(t, err, "Expected error for conflicting OCSP and CRL configuration")
+	assertNilF(t, transport, "Expected nil transport when error occurs")
 	expectedError := "both OCSP and CRL cannot be enabled at the same time, please disable one of them"
-	if err.Error() != expectedError {
-		t.Fatalf("Expected error message: %s, got: %s", expectedError, err.Error())
-	}
+	assertEqualF(t, err.Error(), expectedError, "Expected specific error message")
 }
 
 func TestCreateStandardTransportErrorHandling(t *testing.T) {
@@ -40,12 +34,8 @@ func TestCreateStandardTransportErrorHandling(t *testing.T) {
 	factory := newTransportFactory(conflictingConfig)
 
 	transport, _, err := factory.createTransport()
-	if err == nil {
-		t.Fatal("Expected error for conflicting OCSP and CRL configuration")
-	}
-	if transport != nil {
-		t.Fatal("Expected nil transport when error occurs")
-	}
+	assertNotNilF(t, err, "Expected error for conflicting OCSP and CRL configuration")
+	assertNilF(t, transport, "Expected nil transport when error occurs")
 }
 
 func TestCreateCustomTLSTransportSuccess(t *testing.T) {
@@ -60,12 +50,8 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 	factory := newTransportFactory(validConfig)
 
 	transport, _, err := factory.createTransport()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("Expected non-nil transport for valid configuration")
-	}
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport for valid configuration")
 }
 
 func TestCreateStandardTransportSuccess(t *testing.T) {
@@ -79,12 +65,8 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 	factory := newTransportFactory(validConfig)
 
 	transport, _, err := factory.createTransport()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("Expected non-nil transport for valid configuration")
-	}
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport for valid configuration")
 }
 
 func TestDirectTLSConfigUsage(t *testing.T) {
@@ -104,15 +86,9 @@ func TestDirectTLSConfigUsage(t *testing.T) {
 	factory := newTransportFactory(config)
 	transport, crlValidator, err := factory.createTransport()
 
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("Expected non-nil transport")
-	}
-	if crlValidator != nil {
-		t.Fatal("Expected nil CRL validator for this configuration")
-	}
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport")
+	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }
 
 func TestRegisteredTLSConfigUsage(t *testing.T) {
@@ -129,37 +105,25 @@ func TestRegisteredTLSConfigUsage(t *testing.T) {
 		ServerName:         "registered.example.com",
 	}
 	err := RegisterTLSConfig("test-direct", customTLS)
-	if err != nil {
-		t.Fatalf("Failed to register TLS config: %v", err)
-	}
+	assertNilF(t, err, "Failed to register TLS config")
 	defer func() {
 		err := DeregisterTLSConfig("test-direct")
-		if err != nil {
-			t.Fatalf("Failed to deregister test TLS config: %v", err)
-		}
+		assertNilF(t, err, "Failed to deregister test TLS config")
 	}()
 
 	// Parse DSN that references the registered config
 	dsn := "user:pass@account/db?tls=test-direct&ocspFailOpen=false&disableOCSPChecks=true"
 	config, err2 := ParseDSN(dsn)
-	if err2 != nil {
-		t.Fatalf("Failed to parse DSN: %v", err2)
-	}
+	assertNilF(t, err2, "Failed to parse DSN")
 
 	config.CertRevocationCheckMode = CertRevocationCheckDisabled
 
 	factory := newTransportFactory(config)
 	transport, crlValidator, err := factory.createTransport()
 
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("Expected non-nil transport")
-	}
-	if crlValidator != nil {
-		t.Fatal("Expected nil CRL validator for this configuration")
-	}
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport")
+	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }
 
 func TestDirectTLSConfigOnly(t *testing.T) {
@@ -181,15 +145,9 @@ func TestDirectTLSConfigOnly(t *testing.T) {
 	factory := newTransportFactory(config)
 	transport, crlValidator, err := factory.createTransport()
 
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("Expected non-nil transport")
-	}
-	if crlValidator != nil {
-		t.Fatal("Expected nil CRL validator for this configuration")
-	}
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport")
+	assertNilF(t, crlValidator, "Expected nil CRL validator for this configuration")
 }
 
 func TestTLSConfigNotFound(t *testing.T) {
@@ -197,12 +155,8 @@ func TestTLSConfigNotFound(t *testing.T) {
 	dsn := "user:pass@account/db?tls=nonexistent"
 
 	_, err := ParseDSN(dsn)
-	if err == nil {
-		t.Fatal("Expected error for nonexistent TLS config in DSN")
-	}
+	assertNotNilF(t, err, "Expected error for nonexistent TLS config in DSN")
 
 	expectedError := "TLS config not found: nonexistent"
-	if err.Error() != expectedError {
-		t.Fatalf("Expected error message: %s, got: %s", expectedError, err.Error())
-	}
+	assertEqualF(t, err.Error(), expectedError, "Expected specific error message")
 }


### PR DESCRIPTION
This PR adds support for custom TLS configurations while preserving Snowflake's certificate revocation checking (OCSP/CRL). Users can now register custom TLS configs with their own root CAs, client certificates, and verification callbacks, which will be automatically chained with Snowflake's security validation.

Configs each have a name and are registered; the `tlsConfigName` parameter in the DSN can be used to reference them.

### Usage Example

```go
import (
    "crypto/x509"
    "database/sql"
    _ "github.com/snowflakedb/gosnowflake"
)

// Register custom TLS config with your root CAs
rootCertPool := x509.NewCertPool()
pem, _ := os.ReadFile("/path/to/ca-cert.pem")
rootCertPool.AppendCertsFromPEM(pem)

err := gosnowflake.RegisterTLSConfig("myCustomTLS", &tls.Config{
    RootCAs: rootCertPool,
})
if err != nil {
    // handle error case...
}

// Use in connection string
db, err := sql.Open("snowflake", "user:pass@account/db?tlsConfigName=myCustomTLS")
```

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
