### PR TITLE
SNOW-2117152 Move CRL cleanup to singleton

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -289,9 +289,6 @@ func (sc *snowflakeConn) Close() (err error) {
 	}
 	sc.stopHeartBeat()
 	sc.rest.HeartBeat = nil
-	if sc.cv != nil {
-		sc.cv.stopPeriodicCacheCleanup()
-	}
 	defer sc.cleanup()
 
 	if sc.cfg != nil && !sc.cfg.KeepSessionAlive {
@@ -824,7 +821,7 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 				return nil, err
 			}
 			sc.cv = cv
-			cv.startPeriodicCacheCleanup(sc.cfg.CrlCacheCleanerTick)
+			crlCacheCleaner.startPeriodicCacheCleanup()
 		} else if sc.cfg.DisableOCSPChecks || sc.cfg.InsecureMode {
 			// no revocation check with OCSP or CRL
 			st = snowflakeNoRevocationCheckTransport

--- a/crl.go
+++ b/crl.go
@@ -32,15 +32,19 @@ type issuingDistributionPoint struct {
 type crlValidator struct {
 	certRevocationCheckMode        CertRevocationCheckMode
 	allowCertificatesWithoutCrlURL bool
-	cacheValidityTime              time.Duration
 	inMemoryCacheDisabled          bool
 	onDiskCacheDisabled            bool
-	onDiskCacheDir                 string
-	onDiskCacheRemovalDelay        time.Duration
 	httpClient                     *http.Client
-	cleanupStopChan                chan struct{}
-	cleanupDoneChan                chan struct{}
 	telemetry                      *snowflakeTelemetry
+}
+
+type crlCacheCleanerType struct {
+	mu                      sync.Mutex
+	cacheValidityTime       time.Duration
+	onDiskCacheRemovalDelay time.Duration
+	onDiskCacheDir          string
+	cleanupStopChan         chan struct{}
+	cleanupDoneChan         chan struct{}
 }
 
 type crlInMemoryCacheValueType struct {
@@ -49,38 +53,63 @@ type crlInMemoryCacheValueType struct {
 }
 
 var (
-	crlInMemoryCache      = make(map[string]*crlInMemoryCacheValueType)
-	crlInMemoryCacheMutex = &sync.Mutex{}
-	crlURLMutexes         = make(map[string]*sync.Mutex)
+	crlCacheCleanerTickRate = time.Hour
+	crlInMemoryCache        = make(map[string]*crlInMemoryCacheValueType)
+	crlInMemoryCacheMutex   = &sync.Mutex{}
+	crlURLMutexes           = make(map[string]*sync.Mutex)
+	crlCacheCleaner         = newCrlCacheCleaner()
 )
 
-func newCrlValidator(certRevocationCheckMode CertRevocationCheckMode, allowCertificatesWithoutCrlURL bool, cacheValidityTime time.Duration, inMemoryCacheDisabled, onDiskCacheDisabled bool, onDiskCacheDir string, onDiskCacheRemovalDelay time.Duration, httpClient *http.Client, telemetry *snowflakeTelemetry) (*crlValidator, error) {
+func newCrlValidator(certRevocationCheckMode CertRevocationCheckMode, allowCertificatesWithoutCrlURL bool, inMemoryCacheDisabled, onDiskCacheDisabled bool, httpClient *http.Client, telemetry *snowflakeTelemetry) (*crlValidator, error) {
 	var err error
-	cacheValidityTime = cmp.Or(cacheValidityTime, 24*time.Hour)
-	onDiskCacheRemovalDelay = cmp.Or(onDiskCacheRemovalDelay, 7*24*time.Hour)
-	if onDiskCacheDir == "" {
-		onDiskCacheDir, err = defaultCrlOnDiskCacheDir()
-		if err != nil {
-			return nil, err
-		}
-	}
 	cv := &crlValidator{
 		certRevocationCheckMode:        certRevocationCheckMode,
 		allowCertificatesWithoutCrlURL: allowCertificatesWithoutCrlURL,
-		cacheValidityTime:              cmp.Or(cacheValidityTime, defaultCrlCacheValidityTime),
 		inMemoryCacheDisabled:          inMemoryCacheDisabled,
 		onDiskCacheDisabled:            onDiskCacheDisabled,
-		onDiskCacheDir:                 onDiskCacheDir,
-		onDiskCacheRemovalDelay:        onDiskCacheRemovalDelay,
 		httpClient:                     httpClient,
-		cleanupStopChan:                make(chan struct{}),
-		cleanupDoneChan:                make(chan struct{}),
 		telemetry:                      telemetry,
 	}
-	if err = os.MkdirAll(cv.onDiskCacheDir, 0755); err != nil {
+	if err = os.MkdirAll(crlCacheCleaner.onDiskCacheDir, 0755); err != nil {
 		return nil, err
 	}
 	return cv, nil
+}
+
+func newCrlCacheCleaner() *crlCacheCleanerType {
+	var err error
+	validityTime := defaultCrlCacheValidityTime
+	if validityTimeStr := os.Getenv("SNOWFLAKE_CRL_CACHE_VALIDITY_TIME"); validityTimeStr != "" {
+		if validityTime, err = time.ParseDuration(os.Getenv("SNOWFLAKE_CRL_CACHE_VALIDITY_TIME")); err != nil {
+			logger.Infof("failed to parse SNOWFLAKE_CRL_CACHE_VALIDITY_TIME: %v, using default value %v", err, defaultCrlCacheValidityTime)
+			validityTime = defaultCrlCacheValidityTime
+		}
+	}
+
+	onDiskCacheRemovalDelay := defaultCrlOnDiskCacheRemovalDelay
+	if onDiskCacheRemovalDelayStr := os.Getenv("SNOWFLAKE_CRL_ON_DISK_CACHE_REMOVAL_DELAY"); onDiskCacheRemovalDelayStr != "" {
+		if onDiskCacheRemovalDelay, err = time.ParseDuration(onDiskCacheRemovalDelayStr); err != nil {
+			logger.Infof("failed to parse SNOWFLAKE_CRL_ON_DISK_CACHE_REMOVAL_DELAY: %v, using default value %v", err, defaultCrlOnDiskCacheRemovalDelay)
+			onDiskCacheRemovalDelay = defaultCrlOnDiskCacheRemovalDelay
+		}
+	}
+
+	onDiskCacheDir := os.Getenv("SNOWFLAKE_CRL_ON_DISK_CACHE_DIR")
+	if onDiskCacheDir == "" {
+		if onDiskCacheDir, err = defaultCrlOnDiskCacheDir(); err != nil {
+			logger.Infof("failed to get default CRL on-disk cache directory: %v", err)
+			onDiskCacheDir = "" // it will work only if on-disk cache is disabled
+		}
+	}
+
+	return &crlCacheCleanerType{
+		cacheValidityTime:       validityTime,
+		onDiskCacheRemovalDelay: onDiskCacheRemovalDelay,
+		onDiskCacheDir:          onDiskCacheDir,
+		cleanupStopChan:         nil,
+		cleanupDoneChan:         nil,
+	}
+
 }
 
 // CertRevocationCheckMode defines the modes for certificate revocation checks.
@@ -138,9 +167,9 @@ const (
 )
 
 const (
-	defaultCrlHTTPClientTimeout = 10 * time.Second
-	defaultCrlCacheValidityTime = 24 * time.Hour
-	defaultCrlCacheCleanerTick  = time.Hour
+	defaultCrlHTTPClientTimeout       = 10 * time.Second
+	defaultCrlCacheValidityTime       = 24 * time.Hour
+	defaultCrlOnDiskCacheRemovalDelay = 7 * time.Hour
 )
 
 func createCrlTransport(cfg *Config, telemetry *snowflakeTelemetry) (*http.Transport, *crlValidator, error) {
@@ -148,7 +177,7 @@ func createCrlTransport(cfg *Config, telemetry *snowflakeTelemetry) (*http.Trans
 	client := &http.Client{
 		Timeout: cmp.Or(cfg.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
 	}
-	crlValidator, err := newCrlValidator(cfg.CertRevocationCheckMode, allowCertificatesWithoutCrlURL, cfg.CrlCacheValidityTime, cfg.CrlInMemoryCacheDisabled, cfg.CrlOnDiskCacheDisabled, cfg.CrlOnDiskCacheDir, cfg.CrlOnDiskCacheRemovalDelay, client, telemetry)
+	crlValidator, err := newCrlValidator(cfg.CertRevocationCheckMode, allowCertificatesWithoutCrlURL, cfg.CrlInMemoryCacheDisabled, cfg.CrlOnDiskCacheDisabled, client, telemetry)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -264,7 +293,7 @@ func (cv *crlValidator) validateCrlAgainstCrlURL(cert *x509.Certificate, crlURL 
 	defer mu.Unlock()
 
 	crl, downloadTime := cv.getFromCache(crlURL)
-	needsFreshCrl := crl == nil || crl.NextUpdate.Before(now) || downloadTime.Add(cv.cacheValidityTime).Before(now)
+	needsFreshCrl := crl == nil || crl.NextUpdate.Before(now) || downloadTime.Add(crlCacheCleaner.cacheValidityTime).Before(now)
 	shouldUpdateCrl := false
 
 	if needsFreshCrl {
@@ -452,7 +481,7 @@ func (cv *crlValidator) downloadCrl(crlURL string) (*x509.RevocationList, *time.
 
 func (cv *crlValidator) crlURLToPath(crlURL string) string {
 	// Convert CRL URL to a file path, e.g., by replacing slashes with underscores
-	return filepath.Join(cv.onDiskCacheDir, url.QueryEscape(crlURL))
+	return filepath.Join(crlCacheCleaner.onDiskCacheDir, url.QueryEscape(crlURL))
 }
 
 func (cv *crlValidator) verifyAgainstIdpExtension(crl *x509.RevocationList, distributionPoint string) error {
@@ -502,45 +531,53 @@ func isShortLivedCertificate(cert *x509.Certificate) bool {
 	return maximumValidityPeriod > certValidityPeriod
 }
 
-func (cv *crlValidator) startPeriodicCacheCleanup(tickRate time.Duration) {
-	tickRate = cmp.Or(tickRate, defaultCrlCacheCleanerTick)
-	logger.Debugf("starting periodic CRL cache cleanup with tick rate %v", tickRate)
-	cv.cleanupStopChan = make(chan struct{})
-	cv.cleanupDoneChan = make(chan struct{})
+func (ccc *crlCacheCleanerType) startPeriodicCacheCleanup() {
+	ccc.mu.Lock()
+	defer ccc.mu.Unlock()
+	if ccc.cleanupStopChan != nil {
+		logger.Debug("CRL cache cleaner is already running, not starting again")
+		return
+	}
+	logger.Debugf("starting periodic CRL cache cleanup with tick rate %v", crlCacheCleanerTickRate)
+	ccc.cleanupStopChan = make(chan struct{})
+	ccc.cleanupDoneChan = make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(tickRate)
+		ticker := time.NewTicker(crlCacheCleanerTickRate)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				cv.cleanupInMemoryCache()
-				cv.cleanupOnDiskCache()
-			case <-cv.cleanupStopChan:
-				close(cv.cleanupDoneChan)
+				ccc.cleanupInMemoryCache()
+				ccc.cleanupOnDiskCache()
+			case <-ccc.cleanupStopChan:
+				close(ccc.cleanupDoneChan)
 				return
 			}
 		}
 	}()
 }
 
-func (cv *crlValidator) stopPeriodicCacheCleanup() {
+func (ccc *crlCacheCleanerType) stopPeriodicCacheCleanup() {
+	ccc.mu.Lock()
+	defer ccc.mu.Unlock()
 	logger.Debug("stopping periodic CRL cache cleanup")
-	if cv.cleanupStopChan != nil {
-		close(cv.cleanupStopChan)
-		<-cv.cleanupDoneChan
+	if ccc.cleanupStopChan != nil {
+		close(ccc.cleanupStopChan)
+		<-ccc.cleanupDoneChan
+		ccc.cleanupStopChan = nil
+		ccc.cleanupDoneChan = nil
+	} else {
+		logger.Debugf("CRL cache cleaner was not running, nothing to stop")
 	}
 }
 
-func (cv *crlValidator) cleanupInMemoryCache() {
-	if cv.inMemoryCacheDisabled {
-		return
-	}
+func (ccc *crlCacheCleanerType) cleanupInMemoryCache() {
 	now := time.Now()
 	logger.Debugf("cleaning up in-memory CRL cache at %v", now)
 	crlInMemoryCacheMutex.Lock()
 	for k, v := range crlInMemoryCache {
 		expired := v.crl.NextUpdate.Before(now)
-		evicted := v.downloadTime.Add(cv.cacheValidityTime).Before(now)
+		evicted := v.downloadTime.Add(ccc.cacheValidityTime).Before(now)
 		logger.Debugf("testing CRL for %v (nextUpdate=%v, downloadTime=%v) from in-memory cache (expired: %v, evicted: %v)", k, v.crl.NextUpdate, v.downloadTime, expired, evicted)
 		if expired || evicted {
 			delete(crlInMemoryCache, k)
@@ -549,13 +586,10 @@ func (cv *crlValidator) cleanupInMemoryCache() {
 	crlInMemoryCacheMutex.Unlock()
 }
 
-func (cv *crlValidator) cleanupOnDiskCache() {
-	if cv.onDiskCacheDisabled {
-		return
-	}
+func (ccc *crlCacheCleanerType) cleanupOnDiskCache() {
 	now := time.Now()
 	logger.Debugf("cleaning up on-disk CRL cache at %v", now)
-	entries, err := os.ReadDir(cv.onDiskCacheDir)
+	entries, err := os.ReadDir(ccc.onDiskCacheDir)
 	if err != nil {
 		logger.Warnf("failed to read CRL cache dir: %v", err)
 		return
@@ -564,7 +598,7 @@ func (cv *crlValidator) cleanupOnDiskCache() {
 		if !entry.Type().IsRegular() {
 			continue
 		}
-		path := filepath.Join(cv.onDiskCacheDir, entry.Name())
+		path := filepath.Join(ccc.onDiskCacheDir, entry.Name())
 		crlBytes, err := os.ReadFile(path)
 		if err != nil {
 			logger.Warnf("failed to read CRL file %v: %v", path, err)
@@ -575,7 +609,7 @@ func (cv *crlValidator) cleanupOnDiskCache() {
 			logger.Warnf("failed to parse CRL file %v: %v", path, err)
 			continue
 		}
-		if crl.NextUpdate.Add(cv.onDiskCacheRemovalDelay).Before(now) {
+		if crl.NextUpdate.Add(ccc.onDiskCacheRemovalDelay).Before(now) {
 			logger.Debugf("CRL file %v is expired, removing", path)
 			if err := os.Remove(path); err != nil {
 				logger.Warnf("failed to remove expired CRL file %v: %v", path, err)

--- a/doc.go
+++ b/doc.go
@@ -140,19 +140,17 @@ The following connection parameters are supported:
     allow the connection to be established.
     The default is false.
 
-  - crlCacheValidityTime: specifies the validity time of the CRL cache in seconds.
+  - SNOWFLAKE_CRL_CACHE_VALIDITY_TIME (environment variable): specifies the validity time of the CRL cache in seconds.
 
   - crlInMemoryCacheDisabled: set to disable in-memory caching of CRLs.
 
   - crlOnDiskCacheDisabled: set to disable on-disk caching of CRLs (on-disk cache may help with cold starts).
 
-  - crlOnDiskCacheDir: set to customize the directory for on-disk caching of CRLs.
+  - SNOWFLAKE_CRL_ON_DISK_CACHE_DIR (environment variable): set to customize the directory for on-disk caching of CRLs.
 
-  - crlOnDiskCacheRemovalDelay: set the delay (in seconds) for removing the on-disk cache (for debuggability).
+  - SNOWFLAKE_CRL_ON_DISK_CACHE_REMOVAL_DELAY (environment variable): set the delay (in seconds) for removing the on-disk cache (for debuggability).
 
   - crlHTTPClientTimeout: customize the HTTP client timeout for downloading CRLs.
-
-  - crlCacheCleanerTick: set the interval (in seconds) for the CRL cache cleaner to run.
 
   - validateDefaultParameters: true by default. Set to false to disable checks on existence and privileges check for
     Database, Schema, Warehouse and Role when setting up the connection

--- a/dsn.go
+++ b/dsn.go
@@ -127,13 +127,9 @@ type Config struct {
 
 	CertRevocationCheckMode           CertRevocationCheckMode // revocation check mode for CRLs
 	CrlAllowCertificatesWithoutCrlURL ConfigBool              // Allow certificates (not short-lived) without CRL DP included to be treated as correct ones
-	CrlCacheValidityTime              time.Duration           // How old CRL should we treat as still valid
 	CrlInMemoryCacheDisabled          bool                    // Should the in-memory cache be disabled
 	CrlOnDiskCacheDisabled            bool                    // Should the on-disk cache be disabled
-	CrlOnDiskCacheDir                 string                  // On-disk cache directory
-	CrlOnDiskCacheRemovalDelay        time.Duration           // How long should we keep CRL on disk before removing it (for debuggability purpose only, for validity time use CrlCacheValidityTime)
 	CrlHTTPClientTimeout              time.Duration           // Timeout for HTTP client used to download CRL
-	CrlCacheCleanerTick               time.Duration           // How often should we check for CRL cache removal
 
 	ConnectionDiagnosticsEnabled       bool   // Indicates whether connection diagnostics should be enabled
 	ConnectionDiagnosticsAllowlistFile string // File path to the allowlist file for connection diagnostics. If not specified, the allowlist.json file in the current directory will be used.
@@ -292,26 +288,14 @@ func DSN(cfg *Config) (dsn string, err error) {
 	if cfg.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue {
 		params.Add("crlAllowCertificatesWithoutCrlURL", "true")
 	}
-	if cfg.CrlCacheValidityTime != 0 {
-		params.Add("crlCacheValidityTime", strconv.FormatInt(int64(cfg.CrlCacheValidityTime/time.Second), 10))
-	}
 	if cfg.CrlInMemoryCacheDisabled {
 		params.Add("crlInMemoryCacheDisabled", "true")
 	}
 	if cfg.CrlOnDiskCacheDisabled {
 		params.Add("crlOnDiskCacheDisabled", "true")
 	}
-	if cfg.CrlOnDiskCacheDir != "" {
-		params.Add("crlOnDiskCacheDir", cfg.CrlOnDiskCacheDir)
-	}
-	if cfg.CrlOnDiskCacheRemovalDelay != 0 {
-		params.Add("crlOnDiskCacheRemovalDelay", strconv.FormatInt(int64(cfg.CrlOnDiskCacheRemovalDelay/time.Second), 10))
-	}
 	if cfg.CrlHTTPClientTimeout != 0 {
 		params.Add("crlHttpClientTimeout", strconv.FormatInt(int64(cfg.CrlHTTPClientTimeout/time.Second), 10))
-	}
-	if cfg.CrlCacheCleanerTick != 0 {
-		params.Add("crlCacheCleanerTick", strconv.FormatInt(int64(cfg.CrlCacheCleanerTick/time.Second), 10))
 	}
 	if cfg.Params != nil {
 		for k, v := range cfg.Params {
@@ -1015,13 +999,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			} else {
 				cfg.CrlAllowCertificatesWithoutCrlURL = ConfigBoolFalse
 			}
-		case "crlCacheValidityTime":
-			var vv int64
-			vv, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return
-			}
-			cfg.CrlCacheValidityTime = time.Duration(vv * int64(time.Second))
 		case "crlInMemoryCacheDisabled":
 			var vv bool
 			vv, err = strconv.ParseBool(value)
@@ -1044,15 +1021,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			} else {
 				cfg.CrlOnDiskCacheDisabled = false
 			}
-		case "crlOnDiskCacheDir":
-			cfg.CrlOnDiskCacheDir = value
-		case "crlOnDiskCacheRemovalDelay":
-			var vv int64
-			vv, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return
-			}
-			cfg.CrlOnDiskCacheRemovalDelay = time.Duration(vv * int64(time.Second))
 		case "crlHttpClientTimeout":
 			var vv int64
 			vv, err = strconv.ParseInt(value, 10, 64)
@@ -1060,13 +1028,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				return
 			}
 			cfg.CrlHTTPClientTimeout = time.Duration(vv * int64(time.Second))
-		case "crlCacheCleanerTick":
-			var vv int64
-			vv, err = strconv.ParseInt(value, 10, 64)
-			if err != nil {
-				return
-			}
-			cfg.CrlCacheCleanerTick = time.Duration(vv * int64(time.Second))
 		case "connectionDiagnosticsEnabled":
 			var vv bool
 			vv, err = strconv.ParseBool(value)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1179,7 +1179,7 @@ func TestParseDSN(t *testing.T) {
 			err:      nil,
 		},
 		{
-			dsn: "u:p@a.snowflake.local:9876?account=a&certRevocationCheckMode=enabled&crlAllowCertificatesWithoutCrlURL=true&crlCacheValidityTime=60&crlInMemoryCacheDisabled=true&crlOnDiskCacheDisabled=true&crlOnDiskCacheDir=%2Ftmp%2Fcrl&crlOnDiskCacheRemovalDelay=30&crlHttpClientTimeout=10&crlCacheCleanerTick=7",
+			dsn: "u:p@a.snowflake.local:9876?account=a&certRevocationCheckMode=enabled&crlAllowCertificatesWithoutCrlURL=true&crlInMemoryCacheDisabled=true&crlOnDiskCacheDisabled=true&crlHttpClientTimeout=10",
 			config: &Config{
 				Account: "a", User: "u", Password: "p",
 				Host: "a.snowflake.local", Port: 9876,
@@ -1193,13 +1193,9 @@ func TestParseDSN(t *testing.T) {
 				IncludeRetryReason:                ConfigBoolTrue,
 				CertRevocationCheckMode:           CertRevocationCheckEnabled,
 				CrlAllowCertificatesWithoutCrlURL: ConfigBoolTrue,
-				CrlCacheValidityTime:              60 * time.Second,
 				CrlInMemoryCacheDisabled:          true,
 				CrlOnDiskCacheDisabled:            true,
-				CrlOnDiskCacheDir:                 "/tmp/crl",
-				CrlOnDiskCacheRemovalDelay:        30 * time.Second,
 				CrlHTTPClientTimeout:              10 * time.Second,
-				CrlCacheCleanerTick:               7 * time.Second,
 			},
 			ocspMode: ocspModeFailOpen,
 		},
@@ -1400,13 +1396,9 @@ func TestParseDSN(t *testing.T) {
 				assertEqualE(t, cfg.ClientConfigFile, test.config.ClientConfigFile, "client config file")
 				assertEqualE(t, cfg.CertRevocationCheckMode, test.config.CertRevocationCheckMode, "cert revocation check mode")
 				assertEqualE(t, cfg.CrlAllowCertificatesWithoutCrlURL, test.config.CrlAllowCertificatesWithoutCrlURL, "crl allow certificates without crl url")
-				assertEqualE(t, cfg.CrlCacheValidityTime, test.config.CrlCacheValidityTime, "crl cache validity time")
 				assertEqualE(t, cfg.CrlInMemoryCacheDisabled, test.config.CrlInMemoryCacheDisabled, "crl in memory cache disabled")
 				assertEqualE(t, cfg.CrlOnDiskCacheDisabled, test.config.CrlOnDiskCacheDisabled, "crl on disk cache disabled")
-				assertEqualE(t, cfg.CrlOnDiskCacheDir, test.config.CrlOnDiskCacheDir, "crl on disk cache dir")
-				assertEqualE(t, cfg.CrlOnDiskCacheRemovalDelay, test.config.CrlOnDiskCacheRemovalDelay, "crl on disk cache removal delay")
 				assertEqualE(t, cfg.CrlHTTPClientTimeout, test.config.CrlHTTPClientTimeout, "crl http client timeout")
-				assertEqualE(t, cfg.CrlCacheCleanerTick, test.config.CrlCacheCleanerTick, "crl cache cleaner tick")
 			case test.err != nil:
 				driverErrE, okE := test.err.(*SnowflakeError)
 				driverErrG, okG := err.(*SnowflakeError)
@@ -2096,15 +2088,11 @@ func TestDSN(t *testing.T) {
 				Account:                           "a.b.c",
 				CertRevocationCheckMode:           CertRevocationCheckEnabled,
 				CrlAllowCertificatesWithoutCrlURL: ConfigBoolTrue,
-				CrlCacheValidityTime:              10 * time.Minute,
 				CrlInMemoryCacheDisabled:          true,
 				CrlOnDiskCacheDisabled:            true,
-				CrlOnDiskCacheDir:                 "/tmp/crl",
-				CrlOnDiskCacheRemovalDelay:        5 * time.Minute,
 				CrlHTTPClientTimeout:              5 * time.Second,
-				CrlCacheCleanerTick:               7 * time.Second,
 			},
-			dsn: "u:p@a.b.c.snowflakecomputing.com:443?certRevocationCheckMode=ENABLED&crlAllowCertificatesWithoutCrlURL=true&crlCacheCleanerTick=7&crlCacheValidityTime=600&crlHttpClientTimeout=5&crlInMemoryCacheDisabled=true&crlOnDiskCacheDir=%2Ftmp%2Fcrl&crlOnDiskCacheDisabled=true&crlOnDiskCacheRemovalDelay=300&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?certRevocationCheckMode=ENABLED&crlAllowCertificatesWithoutCrlURL=true&crlHttpClientTimeout=5&crlInMemoryCacheDisabled=true&crlOnDiskCacheDisabled=true&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
 		},
 	}
 	for _, test := range testcases {


### PR DESCRIPTION
### Description

SNOW-2117152 Moves CRL cleanup to singleton, to not be triggered for each connection

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
