### PR TITLE
Fix ignored DisableTelemetry config in DSN generation and parsing

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -320,6 +320,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	if cfg.DisableOCSPChecks {
 		params.Add("disableOCSPChecks", strconv.FormatBool(cfg.DisableOCSPChecks))
 	}
+	if cfg.DisableTelemetry {
+		params.Add("disableTelemetry", strconv.FormatBool(cfg.DisableTelemetry))
+	}
 	if cfg.Tracing != "" {
 		params.Add("tracing", cfg.Tracing)
 	}
@@ -890,6 +893,13 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 				return
 			}
 			cfg.DisableOCSPChecks = vv
+		case "disableTelemetry":
+			var vv bool
+			vv, err = strconv.ParseBool(value)
+			if err != nil {
+				return
+			}
+			cfg.DisableTelemetry = vv
 		case "ocspFailOpen":
 			var vv bool
 			vv, err = strconv.ParseBool(value)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -51,6 +51,24 @@ func TestParseDSN(t *testing.T) {
 			err:      nil,
 		},
 		{
+			dsn: "user:pass@ac-1-laksdnflaf.global/db/schema?disableTelemetry=true",
+			config: &Config{
+				Account: "ac-1", User: "user", Password: "pass", Region: "global",
+				Protocol: "https", Host: "ac-1-laksdnflaf.global.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "schema",
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				DisableTelemetry:          true,
+				ValidateDefaultParameters: ConfigBoolTrue,
+				ClientTimeout:             defaultClientTimeout,
+				JWTClientTimeout:          defaultJWTClientTimeout,
+				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
+				CloudStorageTimeout:       defaultCloudStorageTimeout,
+				IncludeRetryReason:        ConfigBoolTrue,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
+		{
 			dsn: "user:pass@ac-laksdnflaf.global/db/schema",
 			config: &Config{
 				Account: "ac", User: "user", Password: "pass", Region: "global",
@@ -1277,6 +1295,7 @@ func TestParseDSN(t *testing.T) {
 			cfg, err := ParseDSN(test.dsn)
 			switch {
 			case test.err == nil:
+				// TODO: consider converting these checks into a deep equal assertion
 				if err != nil {
 					t.Fatalf("%d: Failed to parse the DSN. dsn: %v, err: %v", i, test.dsn, err)
 				}
@@ -1407,6 +1426,7 @@ func TestParseDSN(t *testing.T) {
 				assertEqualE(t, cfg.CrlInMemoryCacheDisabled, test.config.CrlInMemoryCacheDisabled, "crl in memory cache disabled")
 				assertEqualE(t, cfg.CrlOnDiskCacheDisabled, test.config.CrlOnDiskCacheDisabled, "crl on disk cache disabled")
 				assertEqualE(t, cfg.CrlHTTPClientTimeout, test.config.CrlHTTPClientTimeout, "crl http client timeout")
+				assertEqualE(t, cfg.DisableTelemetry, test.config.DisableTelemetry, "disable telemetry")
 			case test.err != nil:
 				driverErrE, okE := test.err.(*SnowflakeError)
 				driverErrG, okG := err.(*SnowflakeError)


### PR DESCRIPTION
### Description

Problem:
Currently setting DisableTelemetry has no impact, as the DSN generation ignores this parameter.

Solution:
Fix it by adapting the DSN generation and parsing methods. 

Testing:
I added a test case that verifies that if DisableTelemetry=true in the dsn, we parse it accordingly.

### Checklist
- [x] Created tests which fail without the change (if possible)
