### PR TITLE
SNOW-2270316: [Go] Toml file connection is not working.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -34,7 +34,13 @@ func (d SnowflakeDriver) Open(dsn string) (driver.Conn, error) {
 
 // OpenConnector creates a new connector with parsed DSN.
 func (d SnowflakeDriver) OpenConnector(dsn string) (driver.Connector, error) {
-	cfg, err := ParseDSN(dsn)
+	var cfg *Config
+	var err error
+	if dsn == "autoConfig" {
+		cfg, err = loadConnectionConfig()
+	} else {
+		cfg, err = ParseDSN(dsn)
+	}
 	if err != nil {
 		return Connector{}, err
 	}


### PR DESCRIPTION
### Description

SNOW-2270316: The TOML file connection is not working properly because the Go connector uses the OpenConnector function instead of Open. We should add the autoConfig option to address this.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
