### PR TITLE
NO-SNOW Split transport config per usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## Upcoming Release
+
 - Added temporary download files cleanup (snowflakedb/gosnowflake#1577)
 - Marked fields as deprecated (snowflakedb/gosnowflake#1556)
 - Exposed `QueryStatus` from `SnowflakeResult` and `SnowflakeRows` in `GetStatus()` function (snowflakedb/gosnowflake#1556)
+- Split timeout settings into separate groups based on target service types (snowflakedb/gosnowflake#1531)
 
 ## 1.17.0
 

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -67,7 +67,7 @@ func newOauthClient(ctx context.Context, cfg *Config, sc *snowflakeConn) (*oauth
 	}
 	logger.Debugf("Redirect URI template: %v, port: %v", redirectURITemplate, port)
 
-	transport, err := newTransportFactory(cfg, sc.telemetry).createTransport()
+	transport, err := newTransportFactory(cfg, sc.telemetry).createTransport(cfg.transportConfigFor(transportTypeOAuth))
 	if err != nil {
 		return nil, err
 	}

--- a/auth_wif.go
+++ b/auth_wif.go
@@ -267,7 +267,7 @@ func (c *gcpIdentityAttestationCreator) createTokenRequest() (*http.Request, err
 }
 
 func fetchTokenFromMetadataService(req *http.Request, cfg *Config, telemetry *snowflakeTelemetry) string {
-	transport, err := newTransportFactory(cfg, telemetry).createTransport()
+	transport, err := newTransportFactory(cfg, telemetry).createTransport(cfg.transportConfigFor(transportTypeWIF))
 	if err != nil {
 		logger.Debugf("Failed to create HTTP transport: %v", err)
 		return ""

--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -45,7 +45,7 @@ func (util *snowflakeAzureClient) createClient(info *execResponseStageInfo, _ bo
 	if err != nil {
 		return nil, err
 	}
-	transport, err := newTransportFactory(util.cfg, telemetry).createTransport()
+	transport, err := newTransportFactory(util.cfg, telemetry).createTransport(util.cfg.transportConfigFor(transportTypeCloudProvider))
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +364,7 @@ func (util *snowflakeAzureClient) detectAzureTokenExpireError(resp *http.Respons
 }
 
 func createContainerClient(clientURL string, cfg *Config, telemetry *snowflakeTelemetry) (*container.Client, error) {
-	transport, err := newTransportFactory(cfg, telemetry).createTransport()
+	transport, err := newTransportFactory(cfg, telemetry).createTransport(cfg.transportConfigFor(transportTypeCloudProvider))
 	if err != nil {
 		return nil, err
 	}

--- a/connection.go
+++ b/connection.go
@@ -884,7 +884,7 @@ func buildSnowflakeConn(ctx context.Context, config Config) (*snowflakeConn, err
 	}
 
 	transportFactory := newTransportFactory(&config, telemetry)
-	st, err := transportFactory.createTransport()
+	st, err := transportFactory.createTransport(defaultTransportConfigs.forTransportType(transportTypeSnowflake))
 	if err != nil {
 		return nil, err
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -990,7 +990,7 @@ func TestGetTransport(t *testing.T) {
 	}
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := newTransportFactory(test.cfg, nil).createTransport()
+			result, err := newTransportFactory(test.cfg, nil).createTransport(test.cfg.transportConfigFor(transportTypeSnowflake))
 			assertNilE(t, err)
 			if test.transportCheck != nil {
 				test.transportCheck(t, castToTransport(result))
@@ -1001,6 +1001,7 @@ func TestGetTransport(t *testing.T) {
 		})
 	}
 }
+
 func TestGetCRLTransport(t *testing.T) {
 	t.Run("Using CRLs", func(t *testing.T) {
 		crlCfg := &Config{
@@ -1008,10 +1009,10 @@ func TestGetCRLTransport(t *testing.T) {
 			DisableOCSPChecks:       true,
 		}
 		transportFactory := newTransportFactory(crlCfg, nil)
-		crlRoundTripper, err := transportFactory.createTransport()
+		crlRoundTripper, err := transportFactory.createTransport(crlCfg.transportConfigFor(transportTypeCRL))
 		assertNilF(t, err)
 		transport := castToTransport(crlRoundTripper)
 		assertNotNilF(t, transport, "Expected http.Transport")
-		assertEqualE(t, transport.MaxIdleConns, 5)
+		assertEqualE(t, transport.MaxIdleConns, defaultTransportConfigs.forTransportType(transportTypeCRL).MaxIdleConns)
 	})
 }

--- a/connectivity_diagnosis.go
+++ b/connectivity_diagnosis.go
@@ -89,7 +89,7 @@ func (cd *connectivityDiagnoser) createDiagnosticDialContext() func(ctx context.
 
 // enhance the transport with IP logging
 func (cd *connectivityDiagnoser) createDiagnosticTransport(cfg *Config) *http.Transport {
-	baseTransport, err := newTransportFactory(cfg, &snowflakeTelemetry{enabled: false}).createTransport()
+	baseTransport, err := newTransportFactory(cfg, &snowflakeTelemetry{enabled: false}).createTransport(cfg.transportConfigFor(transportTypeSnowflake))
 	if err != nil {
 		logger.Fatalf("[createDiagnosticTransport] failed to get the transport from the config: %v", err)
 	}
@@ -98,6 +98,7 @@ func (cd *connectivityDiagnoser) createDiagnosticTransport(cfg *Config) *http.Tr
 	if t, ok := baseTransport.(*http.Transport); ok {
 		httpTransport = t
 	} else {
+		logger.Warnf("[createDiagnosticTransport] unexpected transport type: %T, using default SnowflakeTransport", baseTransport)
 		httpTransport = SnowflakeTransport
 	}
 

--- a/connectivity_diagnosis_test.go
+++ b/connectivity_diagnosis_test.go
@@ -177,18 +177,6 @@ func TestCreateDiagnosticDialContext(t *testing.T) {
 	assertNilE(t, err, "error should be nil")
 }
 
-func TestCreateDiagnosticTransport(t *testing.T) {
-	var diagTest connectivityDiagnoser
-	config := &Config{}
-	transport := diagTest.createDiagnosticTransport(config)
-
-	assertNotNilE(t, transport, "transport should not be nil")
-	assertNotNilE(t, transport.DialContext, "dialContext should not be nil")
-
-	// by default we should use the SnowflakeTransport
-	assertTransportsEqual(t, SnowflakeTransport, transport, "diagnostic transport vs SnowflakeTransport")
-}
-
 func TestOpenAndReadAllowlistJSON(t *testing.T) {
 	var diagTest connectivityDiagnoser
 	testcases := []tcOpenAllowlistJSON{

--- a/dsn.go
+++ b/dsn.go
@@ -194,6 +194,10 @@ func (c *Config) ocspMode() string {
 	return ocspModeFailClosed
 }
 
+func (c *Config) transportConfigFor(transportType transportType) *transportConfig {
+	return defaultTransportConfigs.forTransportType(transportType)
+}
+
 // DSN constructs a DSN for Snowflake db.
 func DSN(cfg *Config) (dsn string, err error) {
 	if strings.ToLower(cfg.Region) == "us-west-2" {

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -803,7 +803,7 @@ func (util *snowflakeGcsClient) isTokenExpired(resp *http.Response) bool {
 }
 
 func newGcsClient(cfg *Config, telemetry *snowflakeTelemetry) (gcsAPI, error) {
-	transport, err := newTransportFactory(cfg, telemetry).createTransport()
+	transport, err := newTransportFactory(cfg, telemetry).createTransport(cfg.transportConfigFor(transportTypeCloudProvider))
 	if err != nil {
 		return nil, err
 	}

--- a/ocsp.go
+++ b/ocsp.go
@@ -672,7 +672,7 @@ func (ov *ocspValidator) getRevocationStatus(ctx context.Context, subject, issue
 
 	ocspClient := &http.Client{
 		Timeout:   timeout,
-		Transport: newTransportFactory(ov.cfg, nil).createNoRevocationTransport(),
+		Transport: newTransportFactory(ov.cfg, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeOCSP)),
 	}
 	ocspRes, ocspResBytes, ocspS := ov.retryOCSP(
 		ctx, ocspClient, http.NewRequest, u, headers, ocspReq, issuer, timeout)
@@ -801,7 +801,7 @@ func (ov *ocspValidator) downloadOCSPCacheServer() {
 	timeout := OcspCacheServerTimeout
 	ocspClient := &http.Client{
 		Timeout:   timeout,
-		Transport: newTransportFactory(ov.cfg, nil).createNoRevocationTransport(),
+		Transport: newTransportFactory(ov.cfg, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeOCSP)),
 	}
 	ret, ocspStatus := checkOCSPCacheServer(context.Background(), ocspClient, http.NewRequest, u, timeout)
 	if ocspStatus.code != ocspSuccess {
@@ -1177,7 +1177,7 @@ var SnowflakeTransport *http.Transport
 
 func init() {
 	factory := newTransportFactory(&Config{}, nil)
-	SnowflakeTransport = factory.createOCSPTransport()
+	SnowflakeTransport = factory.createOCSPTransport(defaultTransportConfigs.forTransportType(transportTypeSnowflake))
 	SnowflakeTransportTest = SnowflakeTransport
 }
 

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -6,17 +6,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/logging"
+	"io"
+	"net/http"
+	"os"
+	"strings"
 )
 
 const (
@@ -51,7 +50,7 @@ func (util *snowflakeS3Client) createClient(info *execResponseStageInfo, useAcce
 	s3Logger := logging.LoggerFunc(s3LoggingFunc)
 	endPoint := getS3CustomEndpoint(info)
 
-	transport, err := newTransportFactory(util.cfg, telemetry).createTransport()
+	transport, err := newTransportFactory(util.cfg, telemetry).createTransport(util.cfg.transportConfigFor(transportTypeCloudProvider))
 	if err != nil {
 		return nil, err
 	}

--- a/tls_config_test.go
+++ b/tls_config_test.go
@@ -8,27 +8,6 @@ import (
 	"testing"
 )
 
-// assertTLSConfigsEqual compares two TLS configurations, excluding function fields
-// like VerifyPeerCertificate which may point to different but equivalent functions
-func assertTLSConfigsEqual(t *testing.T, expected, actual *tls.Config, msg string) {
-	if expected == nil && actual == nil {
-		return
-	}
-	assertNotNilF(t, expected, "Expected TLS config should not be nil in %s", msg)
-	assertNotNilF(t, actual, "Actual TLS config should not be nil in %s", msg)
-
-	// Compare non-function fields
-	assertEqualF(t, expected.InsecureSkipVerify, actual.InsecureSkipVerify, "%s InsecureSkipVerify", msg)
-	assertEqualF(t, expected.ServerName, actual.ServerName, "%s ServerName", msg)
-	assertEqualF(t, expected.MinVersion, actual.MinVersion, "%s MinVersion", msg)
-	assertEqualF(t, expected.MaxVersion, actual.MaxVersion, "%s MaxVersion", msg)
-
-	// For VerifyPeerCertificate, just check presence/absence since function pointers can't be compared
-	expectedHasVerifier := expected.VerifyPeerCertificate != nil
-	actualHasVerifier := actual.VerifyPeerCertificate != nil
-	assertEqualF(t, expectedHasVerifier, actualHasVerifier, "%s VerifyPeerCertificate presence", msg)
-}
-
 func TestRegisterTLSConfig(t *testing.T) {
 	// Clean up any existing configs after testing
 	defer func() {

--- a/transport.go
+++ b/transport.go
@@ -9,10 +9,28 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
 )
+
+type transportConfigs interface {
+	forTransportType(transportType transportType) *transportConfig
+}
+
+type transportType int
+
+const (
+	transportTypeOAuth transportType = iota
+	transportTypeCloudProvider
+	transportTypeOCSP
+	transportTypeCRL
+	transportTypeSnowflake
+	transportTypeWIF
+)
+
+var defaultTransportConfigs transportConfigs = newDefaultTransportConfigs()
 
 // transportConfig holds the configuration for creating HTTP transports
 type transportConfig struct {
@@ -20,27 +38,6 @@ type transportConfig struct {
 	IdleConnTimeout time.Duration
 	DialTimeout     time.Duration
 	KeepAlive       time.Duration
-}
-
-// defaultTransportConfig returns the standard transport configuration
-func defaultTransportConfig() *transportConfig {
-	return &transportConfig{
-		MaxIdleConns:    10,
-		IdleConnTimeout: 30 * time.Minute,
-		DialTimeout:     30 * time.Second,
-		KeepAlive:       30 * time.Second,
-	}
-}
-
-// crlTransportConfig returns the transport configuration for CRL validation
-// Uses more conservative timeouts for CRL operations
-func crlTransportConfig() *transportConfig {
-	return &transportConfig{
-		MaxIdleConns:    5,
-		IdleConnTimeout: 5 * time.Minute,
-		DialTimeout:     5 * time.Second,
-		KeepAlive:       0, // No keep-alive for CRL operations
-	}
 }
 
 // TransportFactory handles creation of HTTP transports with different validation modes
@@ -91,17 +88,19 @@ func (tf *transportFactory) createBaseTransport(transportConfig *transportConfig
 		KeepAlive: transportConfig.KeepAlive,
 	}
 
+	defaultTransport := http.DefaultTransport.(*http.Transport)
 	return &http.Transport{
-		TLSClientConfig: tlsConfig,
-		MaxIdleConns:    transportConfig.MaxIdleConns,
-		IdleConnTimeout: transportConfig.IdleConnTimeout,
-		Proxy:           tf.createProxy(),
-		DialContext:     dialer.DialContext,
+		TLSClientConfig:     tlsConfig,
+		MaxIdleConns:        cmp.Or(transportConfig.MaxIdleConns, defaultTransport.MaxIdleConns),
+		MaxIdleConnsPerHost: cmp.Or(transportConfig.MaxIdleConns, defaultTransport.MaxIdleConns),
+		IdleConnTimeout:     cmp.Or(transportConfig.IdleConnTimeout, defaultTransport.IdleConnTimeout),
+		Proxy:               tf.createProxy(),
+		DialContext:         dialer.DialContext,
 	}
 }
 
 // createOCSPTransport creates a transport with OCSP validation
-func (tf *transportFactory) createOCSPTransport() *http.Transport {
+func (tf *transportFactory) createOCSPTransport(transportConfig *transportConfig) *http.Transport {
 	// Chain OCSP verification with custom TLS config
 	ov := newOcspValidator(tf.config)
 	tlsConfig := tf.config.tlsConfig
@@ -112,26 +111,27 @@ func (tf *transportFactory) createOCSPTransport() *http.Transport {
 			VerifyPeerCertificate: ov.verifyPeerCertificateSerial,
 		}
 	}
-	return tf.createBaseTransport(defaultTransportConfig(), tlsConfig)
+	return tf.createBaseTransport(transportConfig, tlsConfig)
 }
 
 // createNoRevocationTransport creates a transport without certificate revocation checking
-func (tf *transportFactory) createNoRevocationTransport() http.RoundTripper {
+func (tf *transportFactory) createNoRevocationTransport(transportConfig *transportConfig) http.RoundTripper {
 	if tf.config != nil && tf.config.Transporter != nil {
 		return tf.config.Transporter
 	}
-	return tf.createBaseTransport(defaultTransportConfig(), nil)
+	return tf.createBaseTransport(transportConfig, nil)
 }
 
 func createTestNoRevocationTransport() http.RoundTripper {
-	return newTransportFactory(&Config{}, nil).createNoRevocationTransport()
+	return newTransportFactory(&Config{}, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeSnowflake))
 }
 
 // createCRLValidator creates a CRL validator
 func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 	allowCertificatesWithoutCrlURL := tf.config.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue
 	client := &http.Client{
-		Timeout: cmp.Or(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
+		Timeout:   cmp.Or(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
+		Transport: tf.createNoRevocationTransport(tf.config.transportConfigFor(transportTypeCRL)),
 	}
 	return newCrlValidator(
 		tf.config.CertRevocationCheckMode,
@@ -144,11 +144,11 @@ func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 }
 
 // createTransport is the main entry point for creating transports
-func (tf *transportFactory) createTransport() (http.RoundTripper, error) {
+func (tf *transportFactory) createTransport(transportConfig *transportConfig) (http.RoundTripper, error) {
 	if tf.config == nil {
 		// should never happen in production, only in tests
 		logger.Warn("createTransport: got nil Config, using default one")
-		return tf.createNoRevocationTransport(), nil
+		return tf.createNoRevocationTransport(transportConfig), nil
 	}
 
 	// if user configured a custom Transporter, prioritize that
@@ -181,17 +181,17 @@ func (tf *transportFactory) createTransport() (http.RoundTripper, error) {
 			}
 		}
 
-		return tf.createBaseTransport(crlTransportConfig(), tlsConfig), nil
+		return tf.createBaseTransport(transportConfig, tlsConfig), nil
 	}
 
 	// Handle no revocation checking path
 	if tf.config.DisableOCSPChecks || tf.config.InsecureMode {
 		logger.Debug("createTransport: skipping OCSP validation")
-		return tf.createNoRevocationTransport(), nil
+		return tf.createNoRevocationTransport(transportConfig), nil
 	}
 
 	logger.Debug("createTransport: will perform OCSP validation")
-	return tf.createOCSPTransport(), nil
+	return tf.createOCSPTransport(transportConfig), nil
 }
 
 // validateRevocationConfig checks for conflicting revocation settings
@@ -218,4 +218,68 @@ func (tf *transportFactory) chainVerificationCallbacks(orignalVerificationFunc f
 		return verificationFunc(rawCerts, verifiedChains)
 	}
 	return newVerify
+}
+
+type defaultTransportConfigsType struct {
+	oauthTransportConfig         *transportConfig
+	cloudProviderTransportConfig *transportConfig
+	ocspTransportConfig          *transportConfig
+	crlTransportConfig           *transportConfig
+	snowflakeTransportConfig     *transportConfig
+	wifTransportConfig           *transportConfig
+}
+
+func newDefaultTransportConfigs() *defaultTransportConfigsType {
+	return &defaultTransportConfigsType{
+		oauthTransportConfig: &transportConfig{
+			MaxIdleConns:    1,
+			IdleConnTimeout: 30 * time.Second,
+			DialTimeout:     30 * time.Second,
+		},
+		cloudProviderTransportConfig: &transportConfig{
+			MaxIdleConns:    15,
+			IdleConnTimeout: 30 * time.Second,
+			DialTimeout:     30 * time.Second,
+		},
+		ocspTransportConfig: &transportConfig{
+			MaxIdleConns:    1,
+			IdleConnTimeout: 5 * time.Second,
+			DialTimeout:     5 * time.Second,
+			KeepAlive:       -1,
+		},
+		crlTransportConfig: &transportConfig{
+			MaxIdleConns:    1,
+			IdleConnTimeout: 5 * time.Second,
+			DialTimeout:     5 * time.Second,
+			KeepAlive:       -1,
+		},
+		snowflakeTransportConfig: &transportConfig{
+			MaxIdleConns:    3,
+			IdleConnTimeout: 30 * time.Minute,
+			DialTimeout:     30 * time.Second,
+		},
+		wifTransportConfig: &transportConfig{
+			MaxIdleConns:    1,
+			IdleConnTimeout: 30 * time.Second,
+			DialTimeout:     30 * time.Second,
+		},
+	}
+}
+
+func (dtc *defaultTransportConfigsType) forTransportType(transportType transportType) *transportConfig {
+	switch transportType {
+	case transportTypeOAuth:
+		return dtc.oauthTransportConfig
+	case transportTypeCloudProvider:
+		return dtc.cloudProviderTransportConfig
+	case transportTypeOCSP:
+		return dtc.ocspTransportConfig
+	case transportTypeCRL:
+		return dtc.crlTransportConfig
+	case transportTypeSnowflake:
+		return dtc.snowflakeTransportConfig
+	case transportTypeWIF:
+		return dtc.wifTransportConfig
+	}
+	panic("unknown transport type: " + strconv.Itoa(int(transportType)))
 }


### PR DESCRIPTION
### Description

NO-SNOW Splits connection config (like revocation checking algorithm, TLS config etc) from the target service specific characteristic (like timeouts, pool size, connection expiry etc).

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
