### PR TITLE
SNOW-2294562: Change GET to do multi-part parallel download for S3, Azure, and GCP

### DIFF
--- a/azure_storage_client.go
+++ b/azure_storage_client.go
@@ -265,7 +265,8 @@ func (util *snowflakeAzureClient) uploadFile(
 func (util *snowflakeAzureClient) nativeDownloadFile(
 	meta *fileMetadata,
 	fullDstFileName string,
-	maxConcurrency int64) error {
+	maxConcurrency int64,
+	partSize int64) error {
 	azureLoc, err := util.extractContainerNameAndPath(meta.stageInfo.Location)
 	if err != nil {
 		return err
@@ -319,7 +320,9 @@ func (util *snowflakeAzureClient) nativeDownloadFile(
 		_, err = withCloudStorageTimeout(util.cfg, func(ctx context.Context) (any, error) {
 			return blobClient.DownloadFile(
 				ctx, f, &azblob.DownloadFileOptions{
-					Concurrency: uint16(maxConcurrency)})
+					Concurrency: uint16(maxConcurrency),
+					BlockSize:   int64Max(partSize, blob.DefaultDownloadBlockSize),
+				})
 		})
 		if err != nil {
 			return err

--- a/azure_storage_client_test.go
+++ b/azure_storage_client_test.go
@@ -169,7 +169,7 @@ func TestUploadFileWithAzureUploadFailedError(t *testing.T) {
 		overwrite:          true,
 		dstCompressionType: compressionTypes["GZIP"],
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockAzureClient: &azureObjectAPIMock{
 			UploadFileFunc: func(ctx context.Context, file *os.File, o *azblob.UploadFileOptions) (azblob.UploadFileResponse, error) {
@@ -228,7 +228,7 @@ func TestUploadStreamWithAzureUploadFailedError(t *testing.T) {
 		overwrite:          true,
 		dstCompressionType: compressionTypes["GZIP"],
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockAzureClient: &azureObjectAPIMock{
 			UploadStreamFunc: func(ctx context.Context, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
@@ -291,7 +291,7 @@ func TestUploadFileWithAzureUploadTokenExpired(t *testing.T) {
 		overwrite:          true,
 		dstCompressionType: compressionTypes["GZIP"],
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockAzureClient: &azureObjectAPIMock{
 			UploadFileFunc: func(ctx context.Context, file *os.File, o *azblob.UploadFileOptions) (azblob.UploadFileResponse, error) {
@@ -368,7 +368,7 @@ func TestUploadFileWithAzureUploadNeedsRetry(t *testing.T) {
 		overwrite:          true,
 		dstCompressionType: compressionTypes["GZIP"],
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockAzureClient: &azureObjectAPIMock{
 			UploadFileFunc: func(ctx context.Context, file *os.File, o *azblob.UploadFileOptions) (azblob.UploadFileResponse, error) {
@@ -430,7 +430,7 @@ func TestDownloadOneFileToAzureFailed(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockAzureClient: &azureObjectAPIMock{
 			DownloadFileFunc: func(ctx context.Context, file *os.File, o *blob.DownloadFileOptions) (int64, error) {
@@ -576,7 +576,7 @@ func TestUploadFileToAzureClientCastFail(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		sfa: &snowflakeFileTransferAgent{
 			sc: &snowflakeConn{

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -2,9 +2,9 @@ package gosnowflake
 
 import (
 	"bytes"
-	"database/sql"
 	"crypto/rand"
 	"crypto/rsa"
+	"database/sql"
 	"fmt"
 	"io/fs"
 	"os"

--- a/connection_util.go
+++ b/connection_util.go
@@ -115,6 +115,10 @@ func (sc *snowflakeConn) processFileTransfer(
 	}
 	if sfa.options.MultiPartThreshold == 0 {
 		sfa.options.MultiPartThreshold = dataSizeThreshold
+		// for streaming download, use a smaller default part size
+		if sfa.commandType == downloadCommand && sfa.options.GetFileToStream {
+			sfa.options.MultiPartThreshold = streamingDownloadPartSize
+		}
 	}
 	if err := sfa.execute(); err != nil {
 		return nil, err

--- a/connection_util.go
+++ b/connection_util.go
@@ -114,10 +114,10 @@ func (sc *snowflakeConn) processFileTransfer(
 		sfa.options = op
 	}
 	if sfa.options.MultiPartThreshold == 0 {
-		sfa.options.MultiPartThreshold = dataSizeThreshold
+		sfa.options.MultiPartThreshold = multiPartThreshold
 		// for streaming download, use a smaller default part size
 		if sfa.commandType == downloadCommand && sfa.options.GetFileToStream {
-			sfa.options.MultiPartThreshold = streamingDownloadPartSize
+			sfa.options.MultiPartThreshold = streamingMultiPartThreshold
 		}
 	}
 	if err := sfa.execute(); err != nil {

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -32,10 +32,11 @@ type (
 )
 
 const (
-	fileProtocol              = "file://"
-	dataSizeThreshold int64   = 64 * 1024 * 1024
-	isWindows                 = runtime.GOOS == "windows"
-	mb                float64 = 1024.0 * 1024.0
+	fileProtocol                      = "file://"
+	dataSizeThreshold         int64   = 64 * 1024 * 1024
+	streamingDownloadPartSize int64   = 8 * 1024 * 1024
+	isWindows                         = runtime.GOOS == "windows"
+	mb                        float64 = 1024.0 * 1024.0
 )
 
 const (

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -32,11 +32,11 @@ type (
 )
 
 const (
-	fileProtocol                      = "file://"
-	dataSizeThreshold         int64   = 64 * 1024 * 1024
-	streamingDownloadPartSize int64   = 8 * 1024 * 1024
-	isWindows                         = runtime.GOOS == "windows"
-	mb                        float64 = 1024.0 * 1024.0
+	fileProtocol                        = "file://"
+	multiPartThreshold          int64   = 64 * 1024 * 1024
+	streamingMultiPartThreshold int64   = 8 * 1024 * 1024
+	isWindows                           = runtime.GOOS == "windows"
+	mb                          float64 = 1024.0 * 1024.0
 )
 
 const (

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -487,7 +487,7 @@ func TestUpdateMetadataWithPresignedUrl(t *testing.T) {
 			srcFileName:       path.Join(dir, "/test_data/data1.txt"),
 			overwrite:         true,
 			options: &SnowflakeFileTransferOptions{
-				MultiPartThreshold: dataSizeThreshold,
+				MultiPartThreshold: multiPartThreshold,
 			},
 		}
 
@@ -621,7 +621,7 @@ func TestUploadWhenFilesystemReadOnlyError(t *testing.T) {
 		srcFileName:       path.Join(dir, "/test_data/data1.txt"),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 
@@ -798,7 +798,7 @@ func TestCustomTmpDirPath(t *testing.T) {
 		srcFileName: uploadFile,
 		overwrite:   true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 
@@ -817,7 +817,7 @@ func TestCustomTmpDirPath(t *testing.T) {
 		dstFileName: downloadFile,
 		overwrite:   true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 
@@ -884,7 +884,7 @@ func TestReadonlyTmpDirPathShouldFail(t *testing.T) {
 		srcFileName: uploadFile,
 		overwrite:   true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 
@@ -940,7 +940,7 @@ func testUploadDownloadOneFile(t *testing.T, isStream bool) {
 		srcFileName: uploadFile,
 		overwrite:   true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		requireCompress: true,
 	}
@@ -961,7 +961,7 @@ func testUploadDownloadOneFile(t *testing.T, isStream bool) {
 		overwrite:   true,
 		parallel:    int64(10),
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -959,6 +959,7 @@ func testUploadDownloadOneFile(t *testing.T, isStream bool) {
 		srcFileName: "data.txt.gz",
 		dstFileName: downloadFile,
 		overwrite:   true,
+		parallel:    int64(10),
 		options: &SnowflakeFileTransferOptions{
 			MultiPartThreshold: dataSizeThreshold,
 		},

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -282,7 +282,8 @@ func (util *snowflakeGcsClient) uploadFile(
 func (util *snowflakeGcsClient) nativeDownloadFile(
 	meta *fileMetadata,
 	fullDstFileName string,
-	maxConcurrency int64) error {
+	maxConcurrency int64,
+	partSize int64) error {
 	downloadURL := meta.presignedURL
 	var accessToken string
 	var err error

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -19,6 +19,7 @@ const (
 	gcsMetadataEncryptionDataProp = gcsMetadataPrefix + "encryptiondata"
 	gcsFileHeaderDigest           = "gcs-file-header-digest"
 	gcsRegionMeCentral2           = "me-central2"
+	minimumDownloadPartSize       = 1024 * 1024 * 5 // 5MB
 )
 
 type snowflakeGcsClient struct {
@@ -284,6 +285,7 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 	fullDstFileName string,
 	maxConcurrency int64,
 	partSize int64) error {
+	partSize = int64Max(partSize, minimumDownloadPartSize)
 	downloadURL := meta.presignedURL
 	var accessToken string
 	var err error
@@ -303,6 +305,371 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 			gcsHeaders["Authorization"] = "Bearer " + accessToken
 		}
 	}
+
+	// First, get file size with a HEAD request to determine if multi-part download is needed
+	// Also extract metadata during this request
+	fileHeader, err := util.getFileHeaderForDownload(downloadURL, gcsHeaders, accessToken, meta)
+	if err != nil {
+		return err
+	}
+	fileSize := fileHeader.ContentLength
+
+	// Use multi-part download for files larger than partSize or when maxConcurrency > 1
+	if fileSize > partSize && maxConcurrency > 1 {
+		err = util.downloadFileInParts(downloadURL, gcsHeaders, accessToken, meta, fullDstFileName, fileSize, maxConcurrency, partSize)
+	} else {
+		// Fall back to single-part download for smaller files
+		err = util.downloadFileSinglePart(downloadURL, gcsHeaders, accessToken, meta, fullDstFileName)
+	}
+	if err != nil {
+		return err
+	}
+
+	var encryptMeta encryptMetadata
+	if fileHeader.Header.Get(gcsMetadataEncryptionDataProp) != "" {
+		var encryptData *encryptionData
+		if err = json.Unmarshal([]byte(fileHeader.Header.Get(gcsMetadataEncryptionDataProp)), &encryptData); err != nil {
+			return err
+		}
+		if encryptData != nil {
+			encryptMeta = encryptMetadata{
+				encryptData.WrappedContentKey.EncryptionKey,
+				encryptData.ContentEncryptionIV,
+				"",
+			}
+			if key := fileHeader.Header.Get(gcsMetadataMatdescKey); key != "" {
+				encryptMeta.matdesc = key
+			}
+		}
+	}
+	meta.resStatus = downloaded
+	meta.gcsFileHeaderDigest = fileHeader.Header.Get(gcsMetadataSfcDigest)
+	meta.gcsFileHeaderContentLength = fileSize
+	meta.gcsFileHeaderEncryptionMeta = &encryptMeta
+	return nil
+}
+
+// getFileHeaderForDownload gets the file header using a HEAD request
+func (util *snowflakeGcsClient) getFileHeaderForDownload(downloadURL *url.URL, gcsHeaders map[string]string, accessToken string, meta *fileMetadata) (*http.Response, error) {
+	resp, err := withCloudStorageTimeout(util.cfg, func(ctx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, "HEAD", downloadURL.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range gcsHeaders {
+			req.Header.Add(k, v)
+		}
+		client, err := newGcsClient(util.cfg, util.telemetry)
+		if err != nil {
+			return nil, err
+		}
+		// for testing only
+		if meta.mockGcsClient != nil {
+			client = meta.mockGcsClient
+		}
+		return client.Do(req)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, util.handleHTTPError(resp, meta, accessToken)
+	}
+
+	return resp, nil
+}
+
+// downloadFileInParts downloads a file using parallel range requests
+type downloadPart struct {
+	data  []byte
+	index int64
+	err   error
+}
+
+type downloadPartStream struct {
+	stream io.ReadCloser
+	index  int64
+	err    error
+}
+
+type downloadJob struct {
+	index int64
+	start int64
+	end   int64
+}
+
+func (util *snowflakeGcsClient) downloadFileInParts(
+	downloadURL *url.URL,
+	gcsHeaders map[string]string,
+	accessToken string,
+	meta *fileMetadata,
+	fullDstFileName string,
+	fileSize int64,
+	maxConcurrency int64,
+	partSize int64) error {
+
+	// Calculate number of parts based on desired part size
+	numParts := (fileSize + partSize - 1) / partSize
+
+	// For streaming, use batched approach to avoid buffering all parts in memory
+	if meta.options.GetFileToStream {
+		return util.downloadInPartsForStream(downloadURL, gcsHeaders, accessToken, meta, fileSize, numParts, maxConcurrency, partSize)
+	} else {
+		return util.downloadInPartsForFile(downloadURL, gcsHeaders, accessToken, meta, fullDstFileName, fileSize, numParts, maxConcurrency, partSize)
+	}
+
+	return nil
+}
+
+// downloadInPartsForStream downloads file in batches, streaming parts sequentially
+func (util *snowflakeGcsClient) downloadInPartsForStream(
+	downloadURL *url.URL,
+	gcsHeaders map[string]string,
+	accessToken string,
+	meta *fileMetadata,
+	fileSize, numParts, maxConcurrency, partSize int64) error {
+
+	// Create a single HTTP client for all downloads to reuse connections
+	client, err := newGcsClient(util.cfg, util.telemetry)
+	if err != nil {
+		return err
+	}
+	// for testing only
+	if meta.mockGcsClient != nil {
+		client = meta.mockGcsClient
+	}
+
+	// The first part's index for each batch
+	var nextPartIndex int64 = 0
+
+	for nextPartIndex < numParts {
+		// Calculate this batch size
+		batchSize := maxConcurrency
+		if nextPartIndex+batchSize > numParts {
+			batchSize = numParts - nextPartIndex
+		}
+
+		// Download this batch
+		jobs := make(chan downloadJob, batchSize)
+		results := make(chan downloadPartStream, batchSize)
+
+		// Start workers for this batch
+		for i := int64(0); i < batchSize; i++ {
+			go func() {
+				for job := range jobs {
+					stream, err := util.downloadRangeStream(downloadURL, gcsHeaders, accessToken, meta, client, job.start, job.end)
+					results <- downloadPartStream{stream: stream, index: job.index, err: err}
+				}
+			}()
+		}
+
+		// Send jobs for this batch
+		for i := int64(0); i < batchSize; i++ {
+			partIndex := nextPartIndex + i
+			start := partIndex * partSize
+			end := start + partSize - 1
+			if end >= fileSize {
+				end = fileSize - 1
+			}
+			jobs <- downloadJob{index: i, start: start, end: end}
+		}
+		close(jobs) // Signal no more jobs
+
+		// Collect results for this batch
+		batchResults := make([]downloadPartStream, batchSize)
+		for i := int64(0); i < batchSize; i++ {
+			result := <-results
+			if result.err != nil {
+				// Close any successful streams before returning error
+				for j := int64(0); j < i; j++ {
+					if batchResults[j].stream != nil {
+						batchResults[j].stream.Close()
+					}
+				}
+				return result.err
+			}
+			batchResults[result.index] = result
+		}
+
+		// Stream parts sequentially in order, closing streams as we go
+		for i := int64(0); i < batchSize; i++ {
+			part := batchResults[i]
+			if part.stream != nil {
+				// Stream directly from HTTP response to destination stream
+				_, err := io.Copy(meta.dstStream, part.stream)
+				part.stream.Close() // Close the stream immediately after copying
+				if err != nil {
+					// Close remaining streams before returning error
+					for j := i + 1; j < batchSize; j++ {
+						if batchResults[j].stream != nil {
+							batchResults[j].stream.Close()
+						}
+					}
+					return err
+				}
+			}
+		}
+
+		nextPartIndex += batchSize
+	}
+
+	return nil
+}
+
+// downloadInPartsForFile downloads all parts and writes to file
+func (util *snowflakeGcsClient) downloadInPartsForFile(
+	downloadURL *url.URL,
+	gcsHeaders map[string]string,
+	accessToken string,
+	meta *fileMetadata,
+	fullDstFileName string,
+	fileSize, numParts, maxConcurrency, partSize int64) error {
+
+	// Create a single HTTP client for all downloads to reuse connections
+	client, err := newGcsClient(util.cfg, util.telemetry)
+	if err != nil {
+		return err
+	}
+	// for testing only
+	if meta.mockGcsClient != nil {
+		client = meta.mockGcsClient
+	}
+
+	// Start all workers and download all parts
+	jobs := make(chan downloadJob, numParts)
+	results := make(chan downloadPart, numParts)
+
+	// Start worker pool with maxConcurrency workers
+	for i := int64(0); i < maxConcurrency; i++ {
+		go func() {
+			for job := range jobs {
+				data, err := util.downloadRangeBytes(downloadURL, gcsHeaders, accessToken, meta, client, job.start, job.end)
+				results <- downloadPart{data: data, index: job.index, err: err}
+			}
+		}()
+	}
+
+	// Send all jobs to workers
+	for i := int64(0); i < numParts; i++ {
+		start := i * partSize
+		end := start + partSize - 1
+		if end >= fileSize {
+			end = fileSize - 1
+		}
+		jobs <- downloadJob{index: i, start: start, end: end}
+	}
+	close(jobs) // Signal no more jobs
+
+	// Collect results and store in order
+	parts := make([][]byte, numParts)
+	for i := int64(0); i < numParts; i++ {
+		result := <-results
+		if result.err != nil {
+			return result.err
+		}
+		parts[result.index] = result.data
+	}
+
+	f, err := os.OpenFile(fullDstFileName, os.O_CREATE|os.O_WRONLY, readWriteFileMode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	for _, part := range parts {
+		if _, err := f.Write(part); err != nil {
+			return err
+		}
+	}
+	fi, err := os.Stat(fullDstFileName)
+	if err != nil {
+		return err
+	}
+	meta.srcFileSize = fi.Size()
+
+	return nil
+}
+
+// downloadRangeStream downloads a specific byte range and returns the response stream
+func (util *snowflakeGcsClient) downloadRangeStream(
+	downloadURL *url.URL,
+	gcsHeaders map[string]string,
+	accessToken string,
+	meta *fileMetadata,
+	client gcsAPI,
+	start, end int64) (io.ReadCloser, error) {
+
+	resp, err := withCloudStorageTimeout(util.cfg, func(ctx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, "GET", downloadURL.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add range header for partial content
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+		for k, v := range gcsHeaders {
+			req.Header.Add(k, v)
+		}
+
+		return client.Do(req)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received nil response")
+	}
+
+	// Accept both 200 (full content) and 206 (partial content) status codes
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+		return nil, util.handleHTTPError(resp, meta, accessToken)
+	}
+
+	// Return the response body stream directly - caller is responsible for closing
+	return resp.Body, nil
+}
+
+// downloadRangeBytes downloads a specific byte range and returns the bytes
+func (util *snowflakeGcsClient) downloadRangeBytes(
+	downloadURL *url.URL,
+	gcsHeaders map[string]string,
+	accessToken string,
+	meta *fileMetadata,
+	client gcsAPI,
+	start, end int64) ([]byte, error) {
+
+	stream, err := util.downloadRangeStream(downloadURL, gcsHeaders, accessToken, meta, client, start, end)
+	if err != nil {
+		return nil, err
+	}
+	defer stream.Close()
+
+	// Download the data into memory
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// downloadFileSinglePart downloads a file using a single request (original implementation)
+func (util *snowflakeGcsClient) downloadFileSinglePart(
+	downloadURL *url.URL,
+	gcsHeaders map[string]string,
+	accessToken string,
+	meta *fileMetadata,
+	fullDstFileName string) error {
 
 	resp, err := withCloudStorageTimeout(util.cfg, func(ctx context.Context) (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, "GET", downloadURL.String(), nil)
@@ -326,23 +693,12 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 	if err != nil {
 		return err
 	}
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == 403 || resp.StatusCode == 408 || resp.StatusCode == 429 || resp.StatusCode == 500 || resp.StatusCode == 503 {
-			meta.lastError = fmt.Errorf("%v", resp.Status)
-			meta.resStatus = needRetry
-		} else if resp.StatusCode == 404 {
-			meta.lastError = fmt.Errorf("%v", resp.Status)
-			meta.resStatus = notFoundFile
-		} else if accessToken == "" && resp.StatusCode == 400 && meta.lastError == nil {
-			meta.lastError = fmt.Errorf("%v", resp.Status)
-			meta.resStatus = renewPresignedURL
-		} else if accessToken != "" && util.isTokenExpired(resp) {
-			meta.lastError = fmt.Errorf("%v", resp.Status)
-			meta.resStatus = renewToken
-		} else {
-			meta.lastError = fmt.Errorf("%v", resp.Status)
-		}
-		return meta.lastError
+		return util.handleHTTPError(resp, meta, accessToken)
 	}
 
 	if meta.options.GetFileToStream {
@@ -369,28 +725,27 @@ func (util *snowflakeGcsClient) nativeDownloadFile(
 		meta.srcFileSize = fi.Size()
 	}
 
-	var encryptMeta encryptMetadata
-	if resp.Header.Get(gcsMetadataEncryptionDataProp) != "" {
-		var encryptData *encryptionData
-		if err = json.Unmarshal([]byte(resp.Header.Get(gcsMetadataEncryptionDataProp)), &encryptData); err != nil {
-			return err
-		}
-		if encryptData != nil {
-			encryptMeta = encryptMetadata{
-				encryptData.WrappedContentKey.EncryptionKey,
-				encryptData.ContentEncryptionIV,
-				"",
-			}
-			if key := resp.Header.Get(gcsMetadataMatdescKey); key != "" {
-				encryptMeta.matdesc = key
-			}
-		}
-	}
-	meta.resStatus = downloaded
-	meta.gcsFileHeaderDigest = resp.Header.Get(gcsMetadataSfcDigest)
-	meta.gcsFileHeaderContentLength = resp.ContentLength
-	meta.gcsFileHeaderEncryptionMeta = &encryptMeta
 	return nil
+}
+
+// handleHTTPError handles HTTP error responses consistently
+func (util *snowflakeGcsClient) handleHTTPError(resp *http.Response, meta *fileMetadata, accessToken string) error {
+	if resp.StatusCode == 403 || resp.StatusCode == 408 || resp.StatusCode == 429 || resp.StatusCode == 500 || resp.StatusCode == 503 {
+		meta.lastError = fmt.Errorf("%v", resp.Status)
+		meta.resStatus = needRetry
+	} else if resp.StatusCode == 404 {
+		meta.lastError = fmt.Errorf("%v", resp.Status)
+		meta.resStatus = notFoundFile
+	} else if accessToken == "" && resp.StatusCode == 400 && meta.lastError == nil {
+		meta.lastError = fmt.Errorf("%v", resp.Status)
+		meta.resStatus = renewPresignedURL
+	} else if accessToken != "" && util.isTokenExpired(resp) {
+		meta.lastError = fmt.Errorf("%v", resp.Status)
+		meta.resStatus = renewToken
+	} else {
+		meta.lastError = fmt.Errorf("%v", resp.Status)
+	}
+	return meta.lastError
 }
 
 func (util *snowflakeGcsClient) extractBucketNameAndPath(location string) *gcsLocation {

--- a/gcs_storage_client.go
+++ b/gcs_storage_client.go
@@ -375,7 +375,7 @@ func (util *snowflakeGcsClient) getFileHeaderForDownload(downloadURL *url.URL, g
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Errorf("Failed to close response body: %v", err)
+			logger.Warnf("Failed to close response body: %v", err)
 		}
 	}()
 
@@ -581,7 +581,7 @@ func (util *snowflakeGcsClient) downloadInPartsForFile(
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			logger.Errorf("Failed to close file: %v", err)
+			logger.Warnf("Failed to close file: %v", err)
 		}
 	}()
 
@@ -656,7 +656,7 @@ func (util *snowflakeGcsClient) downloadRangeBytes(
 	}
 	defer func() {
 		if err := stream.Close(); err != nil {
-			logger.Errorf("Failed to close stream: %v", err)
+			logger.Warnf("Failed to close stream: %v", err)
 		}
 	}()
 
@@ -701,7 +701,7 @@ func (util *snowflakeGcsClient) downloadFileSinglePart(
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Errorf("Failed to close response body: %v", err)
+			logger.Warnf("Failed to close response body: %v", err)
 		}
 	}()
 

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -178,7 +178,7 @@ func TestUploadFileWithGcsUploadFailedError(t *testing.T) {
 		overwrite:          true,
 		dstCompressionType: compressionTypes["GZIP"],
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -239,7 +239,7 @@ func TestUploadFileWithGcsUploadFailedWithRetry(t *testing.T) {
 		dstCompressionType: compressionTypes["GZIP"],
 		encryptionMaterial: &encMat,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -306,7 +306,7 @@ func TestUploadFileWithGcsUploadFailedWithTokenExpired(t *testing.T) {
 		srcFileName:       path.Join(dir, "/test_data/put_get_1.txt"),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -369,7 +369,7 @@ func TestDownloadOneFileFromGcsFailed(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -415,7 +415,7 @@ func TestDownloadOneFileFromGcsFailedWithRetry(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -474,7 +474,7 @@ func TestDownloadOneFileFromGcsFailedWithTokenExpired(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -533,7 +533,7 @@ func TestDownloadOneFileFromGcsFailedWithFileNotFound(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -790,7 +790,7 @@ func TestUploadStreamFailed(t *testing.T) {
 		srcStream:         bytes.NewBuffer(src),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -840,7 +840,7 @@ func TestUploadFileWithBadRequest(t *testing.T) {
 		overwrite:         true,
 		lastError:         nil,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -1000,7 +1000,7 @@ func TestUploadFileToGcsNoStatus(t *testing.T) {
 		dstCompressionType: compressionTypes["GZIP"],
 		encryptionMaterial: &encMat,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -1058,7 +1058,7 @@ func TestDownloadFileFromGcsError(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -1109,7 +1109,7 @@ func TestDownloadFileWithBadRequest(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockGcsClient: &clientMock{
 			DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -1169,7 +1169,7 @@ func Test_snowflakeGcsClient_nativeDownloadFile(t *testing.T) {
 		client:    1,
 		stageInfo: &info,
 	}
-	err := new(snowflakeGcsClient).nativeDownloadFile(&meta, "dummy data", 1, dataSizeThreshold)
+	err := new(snowflakeGcsClient).nativeDownloadFile(&meta, "dummy data", 1, multiPartThreshold)
 	if err == nil {
 		t.Error("should have raised an error")
 	}

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -1141,7 +1141,7 @@ func Test_snowflakeGcsClient_nativeDownloadFile(t *testing.T) {
 		client:    1,
 		stageInfo: &info,
 	}
-	err := new(snowflakeGcsClient).nativeDownloadFile(&meta, "dummy data", 1)
+	err := new(snowflakeGcsClient).nativeDownloadFile(&meta, "dummy data", 1, dataSizeThreshold)
 	if err == nil {
 		t.Error("should have raised an error")
 	}

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -244,6 +246,8 @@ func TestUploadFileWithGcsUploadFailedWithRetry(t *testing.T) {
 				return &http.Response{
 					Status:     "403 Forbidden",
 					StatusCode: 403,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -309,6 +313,8 @@ func TestUploadFileWithGcsUploadFailedWithTokenExpired(t *testing.T) {
 				return &http.Response{
 					Status:     "401 Unauthorized",
 					StatusCode: 401,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -416,6 +422,8 @@ func TestDownloadOneFileFromGcsFailedWithRetry(t *testing.T) {
 				return &http.Response{
 					Status:     "403 Forbidden",
 					StatusCode: 403,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -473,6 +481,8 @@ func TestDownloadOneFileFromGcsFailedWithTokenExpired(t *testing.T) {
 				return &http.Response{
 					Status:     "401 Unauthorized",
 					StatusCode: 401,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -530,6 +540,8 @@ func TestDownloadOneFileFromGcsFailedWithFileNotFound(t *testing.T) {
 				return &http.Response{
 					Status:     "404 Not Found",
 					StatusCode: 404,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -567,6 +579,8 @@ func TestGetHeaderTokenExpiredError(t *testing.T) {
 				return &http.Response{
 					Status:     "401 Unauthorized",
 					StatusCode: 401,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -601,6 +615,8 @@ func TestGetHeaderFileNotFound(t *testing.T) {
 				return &http.Response{
 					Status:     "404 Not Found",
 					StatusCode: 404,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -692,6 +708,8 @@ func TestGetHeaderBadRequest(t *testing.T) {
 				return &http.Response{
 					Status:     "400 Bad Request",
 					StatusCode: 400,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -727,6 +745,8 @@ func TestGetHeaderRetryableError(t *testing.T) {
 				return &http.Response{
 					Status:     "403 Forbidden",
 					StatusCode: 403,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -826,6 +846,8 @@ func TestUploadFileWithBadRequest(t *testing.T) {
 			DoFunc: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: 400,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -985,6 +1007,8 @@ func TestUploadFileToGcsNoStatus(t *testing.T) {
 				return &http.Response{
 					Status:     "401 Unauthorized",
 					StatusCode: 401,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -1041,6 +1065,8 @@ func TestDownloadFileFromGcsError(t *testing.T) {
 				return &http.Response{
 					Status:     "403 Unauthorized",
 					StatusCode: 401,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},
@@ -1090,6 +1116,8 @@ func TestDownloadFileWithBadRequest(t *testing.T) {
 				return &http.Response{
 					Status:     "400 Bad Request",
 					StatusCode: 400,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}, nil
 			},
 		},

--- a/local_storage_client_test.go
+++ b/local_storage_client_test.go
@@ -52,7 +52,7 @@ func TestLocalUpload(t *testing.T) {
 		srcFileName:       path.Join(tmpDir, "/test_put_get.txt.gz"),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 	uploadMeta.realSrcFileName = uploadMeta.srcFileName
@@ -147,7 +147,7 @@ func TestDownloadLocalFile(t *testing.T) {
 		srcFileName:       "test_put_get.txt.gz",
 		localLocation:     putDir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 	}
 	err = localUtil.downloadOneFile(&downloadMeta)

--- a/put_get_test.go
+++ b/put_get_test.go
@@ -489,7 +489,7 @@ func testPutGet(t *testing.T, isStream bool) {
 			ctx = WithFileTransferOptions(ctx, &SnowflakeFileTransferOptions{GetFileToStream: true})
 			ctx = WithFileGetStream(ctx, &streamBuf)
 		}
-		sql = fmt.Sprintf("get @%%%v 'file://%v'", tableName, tmpDir)
+		sql = fmt.Sprintf("get @%%%v 'file://%v' parallel=10", tableName, tmpDir)
 		sqlText = strings.ReplaceAll(sql, "\\", "\\\\")
 		rows2 := dbt.mustQueryContextT(ctx, t, sqlText)
 		defer func() {
@@ -625,7 +625,7 @@ func TestPutGetGcsDownscopedCredential(t *testing.T) {
 		dbt.mustExec(fmt.Sprintf(`copy into @%%%v from %v file_format=(type=csv
             compression='gzip')`, tableName, tableName))
 
-		sql = fmt.Sprintf("get @%%%v 'file://%v'", tableName, tmpDir)
+		sql = fmt.Sprintf("get @%%%v 'file://%v'  parallel=10", tableName, tmpDir)
 		sqlText = strings.ReplaceAll(sql, "\\", "\\\\")
 		rows2 := dbt.mustQuery(sqlText)
 		defer func() {
@@ -824,7 +824,7 @@ func TestPutGetMaxLOBSize(t *testing.T) {
 			compression='gzip')`, tableName, tableName))
 
 				// test GET command
-				sql = fmt.Sprintf("get @%%%v 'file://%v'", tableName, tmpDir)
+				sql = fmt.Sprintf("get @%%%v 'file://%v'  parallel=10", tableName, tmpDir)
 				sqlText = strings.ReplaceAll(sql, "\\", "\\\\")
 				rows2 := dbt.mustQuery(sqlText)
 				defer func() {

--- a/s3_storage_client.go
+++ b/s3_storage_client.go
@@ -270,7 +270,8 @@ type s3DownloadAPI interface {
 func (util *snowflakeS3Client) nativeDownloadFile(
 	meta *fileMetadata,
 	fullDstFileName string,
-	maxConcurrency int64) error {
+	maxConcurrency int64,
+	partSize int64) error {
 	s3Obj, _ := util.getS3Object(meta, meta.srcFileName)
 	client, ok := meta.client.(*s3.Client)
 	if !ok {
@@ -291,6 +292,7 @@ func (util *snowflakeS3Client) nativeDownloadFile(
 	var downloader s3DownloadAPI
 	downloader = manager.NewDownloader(client, func(u *manager.Downloader) {
 		u.Concurrency = int(maxConcurrency)
+		u.PartSize = int64Max(partSize, manager.DefaultDownloadPartSize)
 	})
 	// for testing only
 	if meta.mockDownloader != nil {

--- a/s3_storage_client_test.go
+++ b/s3_storage_client_test.go
@@ -84,7 +84,7 @@ func TestUploadOneFileToS3WSAEConnAborted(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, &smithy.GenericAPIError{
@@ -161,7 +161,7 @@ func TestUploadOneFileToS3ConnReset(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, &smithy.GenericAPIError{
@@ -221,7 +221,7 @@ func TestUploadFileWithS3UploadFailedError(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, &smithy.GenericAPIError{
@@ -392,7 +392,7 @@ func TestDownloadFileWithS3TokenExpired(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockDownloader: mockDownloadObjectAPI(func(ctx context.Context, w io.WriterAt, params *s3.GetObjectInput, optFns ...func(*manager.Downloader)) (int64, error) {
 			return 0, &smithy.GenericAPIError{
@@ -446,7 +446,7 @@ func TestDownloadFileWithS3ConnReset(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockDownloader: mockDownloadObjectAPI(func(ctx context.Context, w io.WriterAt, params *s3.GetObjectInput, optFns ...func(*manager.Downloader)) (int64, error) {
 			return 0, &smithy.GenericAPIError{
@@ -499,7 +499,7 @@ func TestDownloadOneFileToS3WSAEConnAborted(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockDownloader: mockDownloadObjectAPI(func(ctx context.Context, w io.WriterAt, params *s3.GetObjectInput, optFns ...func(*manager.Downloader)) (int64, error) {
 			return 0, &smithy.GenericAPIError{
@@ -553,7 +553,7 @@ func TestDownloadOneFileToS3Failed(t *testing.T) {
 		srcFileName:       "data1.txt.gz",
 		localLocation:     dir,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockDownloader: mockDownloadObjectAPI(func(ctx context.Context, w io.WriterAt, params *s3.GetObjectInput, optFns ...func(*manager.Downloader)) (int64, error) {
 			return 0, errors.New("Failed to upload file")
@@ -604,7 +604,7 @@ func TestUploadFileToS3ClientCastFail(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		sfa: &snowflakeFileTransferAgent{
 			sc: &snowflakeConn{
@@ -685,7 +685,7 @@ func TestS3UploadRetryWithHeaderNotFound(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return &manager.UploadOutput{
@@ -747,7 +747,7 @@ func TestS3UploadStreamFailed(t *testing.T) {
 		encryptMeta:       testEncryptionMeta(),
 		overwrite:         true,
 		options: &SnowflakeFileTransferOptions{
-			MultiPartThreshold: dataSizeThreshold,
+			MultiPartThreshold: multiPartThreshold,
 		},
 		mockUploader: mockUploadObjectAPI(func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*manager.Uploader)) (*manager.UploadOutput, error) {
 			return nil, errors.New("unexpected error uploading file")

--- a/storage_client.go
+++ b/storage_client.go
@@ -26,7 +26,7 @@ type cloudUtil interface {
 	createClient(*execResponseStageInfo, bool, *snowflakeTelemetry) (cloudClient, error)
 	getFileHeader(*fileMetadata, string) (*fileHeader, error)
 	uploadFile(string, *fileMetadata, int, int64) error
-	nativeDownloadFile(*fileMetadata, string, int64) error
+	nativeDownloadFile(*fileMetadata, string, int64, int64) error
 }
 
 type cloudClient interface{}
@@ -188,10 +188,11 @@ func (rsu *remoteStorageUtil) downloadOneFile(meta *fileMetadata) error {
 	}
 
 	maxConcurrency := meta.parallel
+	partSize := meta.options.MultiPartThreshold
 	var lastErr error
 	maxRetry := defaultMaxRetry
 	for retry := 0; retry < maxRetry; retry++ {
-		if err = utilClass.nativeDownloadFile(meta, fullDstFileName, maxConcurrency); err != nil {
+		if err = utilClass.nativeDownloadFile(meta, fullDstFileName, maxConcurrency, partSize); err != nil {
 			return err
 		}
 		if meta.resStatus == downloaded {


### PR DESCRIPTION
### Description

SNOW-2294562
This PR contains the following changes:
1. Pass the `parallel` parameter to S3/Azure's download API to enable multi-part download on each file.
2. Implement multi-part parallel download for GCP which utilizes the same parameters as S3 and Azure.
3. Use `meta.options.MultiPartThreshold` as the part size when calling S3/Azure's download API. This matches the behavior of the PUT command for S3 ([link](https://github.com/snowflakedb/gosnowflake/blob/858561dce1e02cd839bc2ad2e57a2c396ace14b8/s3_storage_client.go#L213)).
4. Updated tests.

Tested [put_get_test.go](https://github.com/snowflakedb/gosnowflake/pull/1549/files#diff-a3eaa8612e5469f8b99e45b5d4a7c02fc11925993c07205b069fb6a6032c10df) against both AWS and Azure deployments.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
