### PR TITLE
SNOW-2306340: Add pki-oversight as an additional owner for PKI-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @snowflakedb/Client
-/transport.go @snowflakedb/pki-oversight
 /crl.go @snowflakedb/pki-oversight
 /ocsp.go @snowflakedb/pki-oversight
+/tls_config.go @snowflakedb/pki-oversight
+/transport.go @snowflakedb/pki-oversight

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @snowflakedb/Client
+/transport.go @snowflakedb/pki-oversight
+/crl.go @snowflakedb/pki-oversight
+/ocsp.go @snowflakedb/pki-oversight


### PR DESCRIPTION
### Description

[SNOW-2306340](https://snowflakecomputing.atlassian.net/browse/SNOW-2306340)

Add an additional owner group for transport.go, ocsp.go, and crl.go. Please let me know if I got the mapping wrong. I am happy to adjust this or scope it down.

If this is too onerous, we can also look at just adding the group as an additional reviewer.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary


[SNOW-2306340]: https://snowflakecomputing.atlassian.net/browse/SNOW-2306340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ