### PR TITLE
NO-SNOW Limit big.Float parsing memory

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -29,6 +29,8 @@ const format = "2006-01-02 15:04:05.999999999"
 const numberDefaultPrecision = 38
 const jsonFormatStr = "json"
 
+const numberMaxPrecisionInBits = 127
+
 // 38 (max precision) + 1 (for possible '-') + 1 (for possible '.')
 const decfloatPrintingPrec = 40
 
@@ -1011,7 +1013,7 @@ func stringToValue(ctx context.Context, dest *driver.Value, srcColumnMeta execRe
 				*dest = *srcValue
 				return nil
 			}
-			bigFloat, _, err := big.ParseFloat(*srcValue, 10, big.MaxPrec, big.AwayFromZero)
+			bigFloat, _, err := big.ParseFloat(*srcValue, 10, numberMaxPrecisionInBits, big.AwayFromZero)
 			if err != nil {
 				return err
 			}

--- a/converter_test.go
+++ b/converter_test.go
@@ -2624,7 +2624,7 @@ func TestNumbersScanType(t *testing.T) {
 						assertEqualE(t, i3.Cmp(big.NewFloat(600.5)), 0)
 						assertEqualE(t, i4.Cmp(big.NewFloat(700.5)), 0)
 						assertEqualE(t, i5.Cmp(big.NewFloat(900.5)), 0)
-						bigInt123456789012345678901234567890, _, err := big.ParseFloat("123456789012345678901234567890.5", 10, big.MaxPrec, big.AwayFromZero)
+						bigInt123456789012345678901234567890, _, err := big.ParseFloat("123456789012345678901234567890.5", 10, numberMaxPrecisionInBits, big.AwayFromZero)
 						assertNilF(t, err)
 						assertEqualE(t, i6.Cmp(bigInt123456789012345678901234567890), 0)
 


### PR DESCRIPTION
### Description

NO-SNOW Fixes memory allocation used when parsing numbers to big.Float (for JSON response, when `WithHigherPrecision` was used). Previously every big.Float occupied ~1GB of memory, now it is a manitude of bytes.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
