### PR TITLE
SNOW-2231891 Log warn on using HTTP protocol in OAuth

### DIFF
--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -230,6 +230,8 @@ func (oauthClient *oauthClient) buildAuthorizationCodeConfig(callbackPort int) *
 	if oauthClient.eligibleForDefaultClientCredentials() {
 		clientID, clientSecret = localApplicationClientCredentials, localApplicationClientCredentials
 	}
+	oauthClient.logIfHTTPInUse(oauthClient.authorizationURL())
+	oauthClient.logIfHTTPInUse(oauthClient.tokenURL())
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -443,4 +445,15 @@ func (oauthClient *oauthClient) accessTokenSpec() *secureTokenSpec {
 
 func (oauthClient *oauthClient) refreshTokenSpec() *secureTokenSpec {
 	return newOAuthRefreshTokenSpec(oauthClient.tokenURL(), oauthClient.cfg.User)
+}
+
+func (oauthClient *oauthClient) logIfHTTPInUse(u string) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		logger.Warnf("Cannot parse URL: %v. %v", u, err)
+		return
+	}
+	if parsed.Scheme == "http" {
+		logger.Warnf("OAuth URL uses insecure HTTP protocol: %v", u)
+	}
 }


### PR DESCRIPTION
### Description

SNOW-2231891 Logs warn on using HTTP protocol in OAuth

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
