### PR TITLE
SNOW-2331330: use consistent log level for secure storage manager

### DIFF
--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -105,7 +105,7 @@ func newSecureStorageManager() secureStorageManager {
 	case "darwin", "windows":
 		return &threadSafeSecureStorageManager{&sync.Mutex{}, newKeyringBasedSecureStorageManager()}
 	default:
-		logger.Warnf("OS %v does not support credentials cache", runtime.GOOS)
+		logger.Debugf("OS %v does not support credentials cache", runtime.GOOS)
 		return newNoopSecureStorageManager()
 	}
 }


### PR DESCRIPTION
### Description

SNOW-2331330. On Linux, when the secure storage manager can't be initialized, a debug level message is emitted.

Meanwhile, when the OS isn't supported, a warning was raised. This has the side effect to print on every CLI command using this library the warning, for example on Vault, when it's not the intent of the user to debug Snowflake connection.

Fixes #1572.

### Checklist
- [x] Created tests which fail without the change (if possible) - not applicable
- [x] Extended the README / documentation, if necessary - not applicable
