### PR TITLE
SNOW-2334860: Add support for CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -46,10 +46,11 @@ const (
 )
 
 const (
-	sessionClientSessionKeepAlive          = "client_session_keep_alive"
-	sessionClientValidateDefaultParameters = "CLIENT_VALIDATE_DEFAULT_PARAMETERS"
-	sessionArrayBindStageThreshold         = "client_stage_array_binding_threshold"
-	serviceName                            = "service_name"
+	sessionClientSessionKeepAlive                   = "client_session_keep_alive"
+	sessionClientSessionKeepAliveHeartbeatFrequency = "client_session_keep_alive_heartbeat_frequency"
+	sessionClientValidateDefaultParameters          = "CLIENT_VALIDATE_DEFAULT_PARAMETERS"
+	sessionArrayBindStageThreshold                  = "client_stage_array_binding_threshold"
+	serviceName                                     = "service_name"
 )
 
 type resultType string

--- a/connection_util.go
+++ b/connection_util.go
@@ -22,13 +22,33 @@ func (sc *snowflakeConn) isClientSessionKeepAliveEnabled() bool {
 	return strings.Compare(*v, "true") == 0
 }
 
+func (sc *snowflakeConn) getClientSessionKeepAliveHeartbeatFrequency() (time.Duration, bool) {
+	paramsMutex.Lock()
+	v, ok := sc.cfg.Params[sessionClientSessionKeepAliveHeartbeatFrequency]
+	paramsMutex.Unlock()
+
+	if !ok {
+		return 0, false
+	}
+
+	num, err := strconv.Atoi(*v)
+	if err != nil {
+		logger.WithError(err).Warnf("Failed to parse client session keepalive heartbeat frequency. Falling back to default.")
+		return 0, false
+	}
+
+	return time.Duration(num) * time.Second, true
+}
+
 func (sc *snowflakeConn) startHeartBeat() {
 	if sc.cfg != nil && !sc.isClientSessionKeepAliveEnabled() {
 		return
 	}
 	if sc.rest != nil {
-		sc.rest.HeartBeat = &heartbeat{
-			restful: sc.rest,
+		if heartbeatFrequency, ok := sc.getClientSessionKeepAliveHeartbeatFrequency(); ok {
+			sc.rest.HeartBeat = newHeartBeat(sc.rest, heartbeatFrequency)
+		} else {
+			sc.rest.HeartBeat = newDefaultHeartBeat(sc.rest)
 		}
 		sc.rest.HeartBeat.start()
 	}

--- a/doc.go
+++ b/doc.go
@@ -112,9 +112,15 @@ The following connection parameters are supported:
 
   - token: a token that can be used to authenticate. Should be used in conjunction with the "oauth" authenticator.
 
-  - client_session_keep_alive: Set to true have a heartbeat in the background every hour to keep the connection alive
-    such that the connection session will never expire. Care should be taken in using this option as it opens up
-    the access forever as long as the process is alive.
+  - client_session_keep_alive: Set to true have a heartbeat in the background every hour by default or the value of
+    client_session_keep_alive_heartbeat_frequency, if set, to keep the connection alive such that the connection session
+    will never expire. Care should be taken in using this option as it opens up the access forever as long as the process is alive.
+
+  - client_session_keep_alive_heartbeat_frequency: Number of seconds in-between client attempts to update the token for the session.
+    > The default is 3600 seconds
+    > Minimum value is 900 seconds. A smaller value will be reset to 900 seconds.
+    > Maximum value is 3600 seconds. A larger value will be reset to 3600 seconds.
+    > This parameter is only valid if client_session_keep_alive is set to true.
 
   - ocspFailOpen: true by default. Set to false to make OCSP check fail closed mode.
 

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -3,6 +3,7 @@ package gosnowflake
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestUnitPostHeartbeat(t *testing.T) {
@@ -14,9 +15,7 @@ func TestUnitPostHeartbeat(t *testing.T) {
 			TokenAccessor:    getSimpleTokenAccessor(),
 			RequestTimeout:   0,
 		}
-		heartbeat := &heartbeat{
-			restful: sr,
-		}
+		heartbeat := newDefaultHeartBeat(sr)
 		err := heartbeat.heartbeatMain()
 		assertNilF(t, err, "failed to heartbeat and renew session")
 
@@ -55,4 +54,26 @@ func TestHeartbeatStartAndStop(t *testing.T) {
 	err = db.Close()
 	assertNilF(t, err, "should not cause error in Close")
 	assertNilF(t, conn.rest.HeartBeat, "heartbeat should be nil")
+}
+
+func TestHeartbeatIntervalLowerThanMin(t *testing.T) {
+	sr := &snowflakeRestful{
+		FuncPost:         postTestRenew,
+		FuncRenewSession: renewSessionTest,
+		TokenAccessor:    getSimpleTokenAccessor(),
+		RequestTimeout:   0,
+	}
+	heartbeat := newHeartBeat(sr, minHeartBeatInterval-1*time.Second)
+	assertEqualF(t, heartbeat.heartbeatInterval, minHeartBeatInterval, "heartbeat interval should be set to min")
+}
+
+func TestHeartbeatIntervalHigherThanMax(t *testing.T) {
+	sr := &snowflakeRestful{
+		FuncPost:         postTestRenew,
+		FuncRenewSession: renewSessionTest,
+		TokenAccessor:    getSimpleTokenAccessor(),
+		RequestTimeout:   0,
+	}
+	heartbeat := newHeartBeat(sr, maxHeartBeatInterval+1*time.Second)
+	assertEqualF(t, heartbeat.heartbeatInterval, maxHeartBeatInterval, "heartbeat interval should be set to max")
 }


### PR DESCRIPTION
### Description

SNOW-2334860 

Add support for the CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY parameter which enables us to configure how ofter a heartbeat requests is emited by the client. 

In the existing implementation, a default of 60 min is used, which is too high for SPCS.  The refresh rate there is 30 min.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
