### PR TITLE
SNOW-2424686 add nil checks for closing response body to prevent panic

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -237,11 +237,8 @@ func postRestfulQueryHelper(
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil {
-		return nil, fmt.Errorf("received nil response from server for %v", fullURL)
-	}
 	defer func() {
-		if resp != nil && resp.Body != nil {
+		if resp.Body != nil {
 			if closeErr := resp.Body.Close(); closeErr != nil {
 				logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", fullURL, closeErr)
 			}
@@ -289,9 +286,6 @@ func postRestfulQueryHelper(
 				logger.WithContext(ctx).Errorf("failed to get response. err: %v", err)
 				return nil, err
 			}
-			if resp == nil {
-				return nil, fmt.Errorf("received nil response from server for %v", fullURL)
-			}
 			respd = execResponse{} // reset the response
 			err = json.NewDecoder(resp.Body).Decode(&respd)
 			if err != nil {
@@ -308,7 +302,7 @@ func postRestfulQueryHelper(
 			}
 		}
 		defer func() {
-			if resp != nil && resp.Body != nil {
+			if resp.Body != nil {
 				if closeErr := resp.Body.Close(); closeErr != nil {
 					logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", fullURL, closeErr)
 				}

--- a/restful_test.go
+++ b/restful_test.go
@@ -148,20 +148,6 @@ func postTestAfterRenew(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ ma
 	}, nil
 }
 
-func postTestNilResponse(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ map[string]string, _ []byte, _ time.Duration, _ currentTimeProvider, _ *Config) (*http.Response, error) {
-	return nil, nil
-}
-
-func TestUnitPostQueryHelperNilResponse(t *testing.T) {
-	sr := &snowflakeRestful{
-		FuncPost:      postTestNilResponse,
-		TokenAccessor: getSimpleTokenAccessor(),
-	}
-	requestID := NewUUID()
-	resp, _ := postRestfulQueryHelper(context.Background(), sr, &url.Values{}, make(map[string]string), []byte{0x12, 0x34}, 0, requestID, &Config{})
-	assertNilE(t, resp, "resp should have been nil")
-}
-
 func TestUnitPostQueryHelperError(t *testing.T) {
 	sr := &snowflakeRestful{
 		FuncPost:      postTestError,


### PR DESCRIPTION
### Description

This was originally reported in Snowflake Terraform Provider (https://github.com/snowflakedb/terraform-provider-snowflake/issues/4092) but I guess it could occur outside of it too. 

The reported case was about creating a massive matview which took more time than the timeout configured in the Provider. 
This resulted in
```
Error: Plugin did not respond
The plugin encountered an error, and failed to respond to the
plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain
more details.
Stack trace from the terraform-provider-snowflake_v2.8.0 plugin:
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x193f359]
goroutine 41 [running]:
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func1()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:241 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func2()
github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:288 +0x19
panic({0x257d740?, 0x41e1700?})
runtime/panic.go:785 +0x132
Error: The terraform-provider-snowflake_v2.8.0 plugin crashed!
```

where the panic stack points to gosnowflake. Looking at the panic, apparently the server response or the Body part can be `nil` in this case.

The PR aims to address this situation by:
*  making sure response body is not `nil` before we call `Close()` on it
* small nit: moving a `defer` out of the `for` loop where we check for expired token 