### PR TITLE
NO-SNOW Omit proxy when calling WIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Ensured proper permissions for CRL cache directory (snowflakedb/gosnowflake#1588)
 - Added `CrlDownloadMaxSize` to limit the size of CRL downloads (snowflakedb/gosnowflake#1588)
 - 
+- Bypassed proxy settings for WIF metadata requests (snowflakedb/gosnowflake#1593)
+- 
 - 
 - 
 - Fixed nil pointer derereference while calling long-running queries (snowflakedb/gosnowflake#1592) (snowflakedb/gosnowflake#1596)

--- a/assert_test.go
+++ b/assert_test.go
@@ -124,12 +124,14 @@ func assertEmptyE[T any](t *testing.T, actual []T, descriptions ...string) {
 
 func fatalOnNonEmpty(t *testing.T, errMsg string) {
 	if errMsg != "" {
+		t.Helper()
 		t.Fatal(formatErrorMessage(errMsg))
 	}
 }
 
 func errorOnNonEmpty(t *testing.T, errMsg string) {
 	if errMsg != "" {
+		t.Helper()
 		t.Error(formatErrorMessage(errMsg))
 	}
 }
@@ -324,7 +326,7 @@ func isNil(value any) bool {
 		return true
 	}
 	val := reflect.ValueOf(value)
-	return slices.Contains([]reflect.Kind{reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface}, val.Kind()) && val.IsNil()
+	return slices.Contains([]reflect.Kind{reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface, reflect.Func}, val.Kind()) && val.IsNil()
 }
 
 func thrownFrom() string {


### PR DESCRIPTION
### Description

NO-SNOW Found by @sfc-gh-rsavenok - when connecting to WIF we shouldn't use proxy, as metadata server is a local resource.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
