### PR TITLE
SNOW-2439606 Fix URL passing to deferred function in a loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - 
 - 
 - 
-- Fixed nil pointer derereference while calling long running queries (snowflakedb/gosnowflake#1592)
+- Fixed nil pointer derereference while calling long-running queries (snowflakedb/gosnowflake#1592) (snowflakedb/gosnowflake#1596)
 - 
 - 
 - 

--- a/restful.go
+++ b/restful.go
@@ -237,11 +237,11 @@ func postRestfulQueryHelper(
 	if err != nil {
 		return nil, err
 	}
-	defer func(resp *http.Response) {
+	defer func(resp *http.Response, url string) {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", fullURL, closeErr)
+			logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", url, closeErr)
 		}
-	}(resp)
+	}(resp, fullURL.String())
 
 	if resp.StatusCode == http.StatusOK {
 		logger.WithContext(ctx).Infof("postQuery: resp: %v", resp)
@@ -284,11 +284,11 @@ func postRestfulQueryHelper(
 				logger.WithContext(ctx).Errorf("failed to get response. err: %v", err)
 				return nil, err
 			}
-			defer func(resp *http.Response) {
+			defer func(resp *http.Response, url string) {
 				if closeErr := resp.Body.Close(); closeErr != nil {
-					logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", fullURL, closeErr)
+					logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", url, closeErr)
 				}
-			}(resp)
+			}(resp, fullURL.String())
 			respd = execResponse{} // reset the response
 			err = json.NewDecoder(resp.Body).Decode(&respd)
 			if err != nil {


### PR DESCRIPTION
### Description

SNOW-2439606 Fix URL passing to deferred function. It is a pointer which is updated, so the first log shows incorrect value (value behind pointer was modified).

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
