### PR TITLE
Release memory earlier

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -247,8 +247,8 @@ func postRestfulQueryHelper(
 	}(resp, fullURL.String())
 
 	if resp.StatusCode == http.StatusOK {
-		var respd execResponse
-		if err = json.NewDecoder(resp.Body).Decode(&respd); err != nil {
+		respd := &execResponse{}
+		if err = json.NewDecoder(resp.Body).Decode(respd); err != nil {
 			logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func postRestfulQueryHelper(
 
 		// if asynchronous query in progress, kick off retrieval but return object
 		if respd.Code == queryInProgressAsyncCode && isAsyncMode(ctx) {
-			return sr.processAsync(ctx, &respd, headers, timeout, cfg)
+			return sr.processAsync(ctx, respd, headers, timeout, cfg)
 		}
 		for isSessionRenewed || respd.Code == queryInProgressCode ||
 			respd.Code == queryInProgressAsyncCode {
@@ -281,20 +281,8 @@ func postRestfulQueryHelper(
 			token, _, _ = sr.TokenAccessor.GetTokens()
 			headers[headerAuthorizationKey] = fmt.Sprintf(headerSnowflakeToken, token)
 
-			resp, err = sr.FuncGet(ctx, sr, fullURL, headers, timeout)
+			respd, err = getExecResponse(ctx, sr, fullURL, headers, timeout)
 			if err != nil {
-				logger.WithContext(ctx).Errorf("failed to get response. err: %v", err)
-				return nil, err
-			}
-			defer func(resp *http.Response, url string) {
-				if closeErr := resp.Body.Close(); closeErr != nil {
-					logger.WithContext(ctx).Warnf("failed to close response body for %v. err: %v", url, closeErr)
-				}
-			}(resp, fullURL.String())
-			respd = execResponse{} // reset the response
-			err = json.NewDecoder(resp.Body).Decode(&respd)
-			if err != nil {
-				logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
 				return nil, err
 			}
 			if respd.Code == sessionExpiredCode {
@@ -306,7 +294,7 @@ func postRestfulQueryHelper(
 				isSessionRenewed = false
 			}
 		}
-		return &respd, nil
+		return respd, nil
 	}
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -543,4 +531,32 @@ func getQueryIDChan(ctx context.Context) chan<- string {
 		return nil
 	}
 	return c
+}
+
+// getExecResponse fetches a response using FuncGet and decodes it and returns it.
+func getExecResponse(
+	ctx context.Context,
+	sr *snowflakeRestful,
+	fullURL *url.URL,
+	headers map[string]string,
+	timeout time.Duration) (*execResponse, error) {
+	resp, err := sr.FuncGet(ctx, sr, fullURL, headers, timeout)
+	if err != nil {
+		logger.WithContext(ctx).Errorf("failed to get response. err: %v", err)
+		return nil, err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.WithContext(ctx).Errorf("failed to close response body for %v. err: %v", fullURL, closeErr)
+		}
+	}()
+
+	// decode response and fill into an empty execResponse
+	respd := &execResponse{}
+	err = json.NewDecoder(resp.Body).Decode(respd)
+	if err != nil {
+		logger.WithContext(ctx).Errorf("failed to decode JSON. err: %v", err)
+		return nil, err
+	}
+	return respd, nil
 }


### PR DESCRIPTION
Problem:
The current approach of calling close on the
body is correct, but has two disadvantages:
- it only releases memory after finishing all iterations have finished
- The current construction is not trivial to understand and hence future refactorings might break this code again.

Solution:
Factor it out into a separate function that
does call close after the response is not used
anymore.

Use the same logic also for the async path.

No semantic changes.

### Description

SNOW-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
