### PR TITLE
NO-SNOW: Address race condition in MFA authentication test

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -728,7 +728,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 				}, func() string {
 					return ""
 				})
-			} else if sc.cfg.ClientStoreTemporaryCredential == ConfigBoolTrue {
+			} else if sc.cfg.ClientStoreTemporaryCredential == ConfigBoolTrue && sc.cfg.SingleAuthenticationPrompt != ConfigBoolFalse {
 				sc.cfg.IDToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
 			}
 		}
@@ -753,7 +753,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 			}, func() string {
 				return ""
 			})
-		} else if sc.cfg.ClientRequestMfaToken == ConfigBoolTrue {
+		} else if sc.cfg.ClientRequestMfaToken == ConfigBoolTrue && sc.cfg.SingleAuthenticationPrompt != ConfigBoolFalse {
 			sc.cfg.MfaToken = credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
 		}
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -735,12 +735,7 @@ func TestMfaParallelLogin(t *testing.T) {
 			if singleAuthenticationPrompt == ConfigBoolTrue {
 				assertEqualE(t, len(errs), 0)
 			} else {
-				// When singleAuthenticationPrompt=false, connections don't coordinate authentication,
-				// but credential caching still works globally. Due to race conditions, 1-2 connections
-				// may succeed (18-19 failures) instead of exactly 1 success (19 failures).
-				if len(errs) < 18 || len(errs) > 19 {
-					t.Fatalf("Expected 18-19 errors when singleAuthenticationPrompt=false (due to credential caching race), got %d errors", len(errs))
-				}
+				assertEqualE(t, len(errs), 19)
 			}
 		})
 
@@ -761,12 +756,7 @@ func TestMfaParallelLogin(t *testing.T) {
 				assertEqualF(t, len(errs), 1)
 				assertStringContainsE(t, errs[0].Error(), "MFA with TOTP is required")
 			} else {
-				// When singleAuthenticationPrompt=false, connections don't coordinate authentication,
-				// but credential caching still works globally. Due to race conditions, 1-2 connections
-				// may succeed (18-19 failures) instead of exactly 1 success (19 failures).
-				if len(errs) < 18 || len(errs) > 19 {
-					t.Fatalf("Expected 18-19 errors when singleAuthenticationPrompt=false (due to credential caching race), got %d errors", len(errs))
-				}
+				assertEqualE(t, len(errs), 19)
 			}
 		})
 	}


### PR DESCRIPTION
### Description

NO-SNOW: Address race condition in MFA authentication test

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
