### PR TITLE
SNOW-1553756 Remove dbus-daemon issue section from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,15 +38,6 @@ Internal changes:
 -
 -
 
-Documentation changes:
-
--
--
--
--
-- Removed the workaround for runaway dbus-daemon processes from the README as made obsolete by PR1595 (snowflakedb/gosnowflake#1623)
-
-
 ## 1.17.1
 
 - Fix unsafe reflection of nil pointer on DECFLOAT func in bind uploader (snowflakedb/gosnowflake#1604).


### PR DESCRIPTION
### Description

This is a doc-only change to complement https://github.com/snowflakedb/gosnowflake/pull/1595. 
Not initializing `keyring` on Linux makes this README entry obsolete. 