### PR TITLE
NO-SNOW Add timeout the the platform detection wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Internal changes:
 -
 -
 -
--
+- Added timeout to platform detection (snowflakedb/gosnowflake#1631)
 -
 -
 -


### PR DESCRIPTION
### Description

NO-SNOW Add a timeout to the platform detection wait. Without this, in case of starting tests that don't do authentication, but work on mocks, were blocked.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
