### PR TITLE
NO-SNOW fix create-issue GH action

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -63,14 +63,16 @@ jobs:
       - name: Update GitHub Issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          JIRA_KEY: ${{ steps.create.outputs.jira_key }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           # Update Github issue title with jira id
           curl -s \
-          -X PATCH \
+            -X PATCH \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }} \
-              -d '{
-                    "title":"${{ steps.create.outputs.jira_key }}: ${{ github.event.issue.title }}"
-              }'
+            "https://api.github.com/repos/$REPOSITORY/issues/$ISSUE_NUMBER" \
+            -d "{\"title\":\"$JIRA_KEY: $ISSUE_TITLE\"}"


### PR DESCRIPTION
### Description

This is a workflow only change, no code was touched.

seems to be broken since https://github.com/snowflakedb/gosnowflake/pull/1501 and now jiras are not created. Currently fails with error pointing to the shellscript (e.g. `/home/runner/work/_temp/7d277f21-4fcf-4bad-8f1a-455ae159390c.sh: line 45: syntax error near unexpected token `('` in [this one](https://github.com/snowflakedb/gosnowflake/actions/runs/19534847323/job/55926382168) )

This fix attempts to do the following things:
* contrary to initial thoughts (https://github.com/snowflakedb/gosnowflake/pull/1600) we don't go back to the old flow; still trying to use `curl`, but instead of the directly sent payload, we create it first as a heredoc. Perhaps easier to debug too, if it still fails. 
  * component is `19286` for `gosnowflake`, we currently using a different one `19292` which is incorrect
 * in the 'update github issue' step, earlier prior to #1501 we used 'update GH issue title' and not 'comment in GH issue', to note that a jira has been created and linked.
 
 This is significant because we have multiple processes depending on this; i.e. it needs to happen as it did before. Thus, update the issue title; don't comment in the issue.