### PR TITLE
Reduce spammy "telemetry disabled" logs

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -49,7 +49,8 @@ type snowflakeTelemetry struct {
 
 func (st *snowflakeTelemetry) addLog(data *telemetryData) error {
 	if !st.enabled {
-		return fmt.Errorf("telemetry disabled; not adding log")
+		logger.Debug("telemetry disabled; not adding log")
+		return nil
 	}
 	st.mutex.Lock()
 	st.logs = append(st.logs, data)
@@ -65,9 +66,8 @@ func (st *snowflakeTelemetry) addLog(data *telemetryData) error {
 
 func (st *snowflakeTelemetry) sendBatch() error {
 	if !st.enabled {
-		err := fmt.Errorf("telemetry disabled; not sending log")
-		logger.Debug(err)
-		return err
+		logger.Debug("telemetry disabled; not sending log")
+		return nil
 	}
 	type telemetry struct {
 		Logs []*telemetryData `json:"logs"`


### PR DESCRIPTION
Problem:
As we return an error in
these two places, the caller
emits a warning level log message
each time this happens. This
is very verbose.

Solution:
Don't return an error. Turning
off telemetry is a publicly accessible
feature so it should not
trigger a warning. Instead
we emit a debug level
log.

### Description

SNOW-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
