### PR TITLE
Reduce spammy "telemetry disabled" log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Bug fixes:
 -
 
 Internal changes:
-- 
+- Remove spammy "telemetry disabled" log messages (snowflakedb/gosnowflake#1638).
 -
 -
 -

--- a/telemetry.go
+++ b/telemetry.go
@@ -49,7 +49,8 @@ type snowflakeTelemetry struct {
 
 func (st *snowflakeTelemetry) addLog(data *telemetryData) error {
 	if !st.enabled {
-		return fmt.Errorf("telemetry disabled; not adding log")
+		logger.Debug("telemetry disabled; not adding log")
+		return nil
 	}
 	st.mutex.Lock()
 	st.logs = append(st.logs, data)
@@ -65,9 +66,8 @@ func (st *snowflakeTelemetry) addLog(data *telemetryData) error {
 
 func (st *snowflakeTelemetry) sendBatch() error {
 	if !st.enabled {
-		err := fmt.Errorf("telemetry disabled; not sending log")
-		logger.Debug(err)
-		return err
+		logger.Debug("telemetry disabled; not sending log")
+		return nil
 	}
 	type telemetry struct {
 		Logs []*telemetryData `json:"logs"`

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -225,8 +225,8 @@ func TestTelemetryDisabled(t *testing.T) {
 				queryIDKey: "123",
 			},
 			Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
-		}); err == nil {
-			t.Fatal("should have failed")
+		}); err != nil {
+			t.Fatalf("calling addLog should not return an error just because telemetry is disabled, but did: %v", err)
 		}
 		st.enabled = true
 		if err := st.addLog(&telemetryData{
@@ -240,8 +240,8 @@ func TestTelemetryDisabled(t *testing.T) {
 		}
 		st.enabled = false
 		err := st.sendBatch()
-		if err == nil {
-			t.Fatal("should have failed")
+		if err != nil {
+			t.Fatalf("calling sendBatch should not return an error just because telemetry is disabled, but did: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Problem:
As we return an error in
these two places, the caller
emits a warning level log message
each time this happens. This
is very verbose.

Solution:
Don't return an error. Turning
off telemetry is a publicly accessible
feature so it should not
trigger a warning. Instead
we emit a debug level
log.

### Description

SNOW-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
