### PR TITLE
Fix residuals in bindings_test

### DIFF
--- a/bindings_test.go
+++ b/bindings_test.go
@@ -44,8 +44,6 @@ const (
 	disableLargeVarcharAndBinary = "ALTER SESSION SET ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT=FALSE"
 	unsetLargeVarcharAndBinary   = "ALTER SESSION UNSET ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT"
 
-	maxVarcharAndBinarySizeParam = "varchar_and_binary_max_size_in_result"
-
 	smallSize = 16 * 1024 * 1024 // 16 MB - right at LOB threshold
 	largeSize = 64 * 1024 * 1024 // 64 MB - well above LOB threshold
 	// range to use for generating random numbers
@@ -1424,16 +1422,6 @@ func TestLOBRetrievalWithJSON(t *testing.T) {
 
 func testLOBRetrieval(t *testing.T, useArrowFormat bool) {
 	runDBTest(t, func(dbt *DBTest) {
-		parameters := dbt.connParams()
-		varcharBinaryMaxSizeRaw := parameters[maxVarcharAndBinarySizeParam]
-		if varcharBinaryMaxSizeRaw != nil && *varcharBinaryMaxSizeRaw != "" {
-			varcharBinaryMaxSize, err := strconv.ParseFloat(*varcharBinaryMaxSizeRaw, 64)
-			assertNilF(t, err, "error during varcharBinaryMaxSize conversion")
-			actualMaxSize := int(varcharBinaryMaxSize)
-			dbt.Logf("using %v as configured max LOB size, testing up to %v", actualMaxSize, largeSize)
-		} else {
-			dbt.Logf("using default LOB sizes for testing: %v and %v", smallSize, largeSize)
-		}
 		if useArrowFormat {
 			dbt.mustExec(forceARROW)
 		} else {
@@ -1459,7 +1447,6 @@ func testLOBRetrieval(t *testing.T, useArrowFormat bool) {
 				assertEqualF(t, len(res), testSize)
 			})
 		}
-		dbt.mustExec(unsetFeatureMaxLOBSize)
 	})
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -212,17 +212,6 @@ type DBTest struct {
 	conn *sql.Conn
 }
 
-func (dbt *DBTest) connParams() map[string]*string {
-	var params map[string]*string
-	err := dbt.conn.Raw(func(driverConn any) error {
-		conn := driverConn.(*snowflakeConn)
-		params = conn.cfg.Params
-		return nil
-	})
-	assertNilF(dbt.T, err)
-	return params
-}
-
 func (dbt *DBTest) mustQueryT(t *testing.T, query string, args ...any) (rows *RowsExtended) {
 	// handler interrupt signal
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
A couple of things were not cleaned up from the
test, when it was simplified. This change
fixes it.

Mainly doing this to avoid the error message
when calling exec.

### Description

SNOW-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
