### PR TITLE
SNOW-2871406 Expand user home dir only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Bug fixes:
 -
 -
 -
--
+- Fix unnecessary user expansion for file paths (snowflakedb/gosnowflake#1646).
 -
 
 Internal changes:

--- a/file_util.go
+++ b/file_util.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	usr "os/user"
 	"path/filepath"
 	"strings"
 )
@@ -215,15 +214,17 @@ func baseName(path string) string {
 
 // expandUser returns the argument with an initial component of ~
 func expandUser(path string) (string, error) {
-	usr, err := usr.Current()
+	if !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	dir := usr.HomeDir
 	if path == "~" {
-		path = dir
+		path = homeDir
 	} else if strings.HasPrefix(path, "~/") {
-		path = filepath.Join(dir, path[2:])
+		path = filepath.Join(homeDir, path[2:])
 	}
 	return path, nil
 }

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -43,6 +43,7 @@ func TestBaseName(t *testing.T) {
 }
 
 func TestExpandUser(t *testing.T) {
+	skipOnMissingHome(t)
 	usr, err := user.Current()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### Description

SNOW-2871406 In environments where we can't look up the current user (we encountered it in PE), we shouldn't depend on it. In such cases, there's no point in expanding `~` to user home.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
