### PR TITLE
NO-SNOW Fix TestMfaParallelLogin

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -716,6 +716,12 @@ func TestUnitAuthenticateWithConfigMFA(t *testing.T) {
 	}
 }
 
+// This test creates two groups of scenarios:
+// a) singleAuthenticationPrompt=true - in this case, we start authenticating threads at once,
+// but due to locking mechanism only one should reach wiremock without MFA token.
+// b) singleAuthenticationPrompt=false - in this case, there is no locking, so all threads should rush,
+// but on Wiremock only first will be served with correct response (simulating a user confirming MFA only once).
+// The remaining threads should return error.
 func TestMfaParallelLogin(t *testing.T) {
 	skipOnMissingHome(t)
 	skipOnMac(t, "interactive keyring access not available on macOS runners")

--- a/driver_test.go
+++ b/driver_test.go
@@ -2351,7 +2351,10 @@ func initPoolWithSizeAndReturnErrors(db *sql.DB, poolSize int) []error {
 	for i := 0; i < poolSize; i++ {
 		go func(wg *sync.WaitGroup) {
 			defer wg.Done()
-			time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+			// Wiremock handles incoming request in parallel, in non-atomic way.
+			// If two requests start at the same time, they both see the same scenario state,
+			// even if it should be changed after the request is matched to a particular scenario state.
+			time.Sleep(time.Duration(i * 5 * int(time.Millisecond)))
 			err := runSmokeQueryAndReturnErrors(db)
 			if err != nil {
 				errMu.Lock()


### PR DESCRIPTION
### Description

NO-SNOW Fixes TestMfaParallelLogin. It was flaky due to the randomness in the delay of new connections. If two initial connections started very soon one after the other, Wiremock didn't make it to switch scenario state.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
