### PR TITLE
SNOW-3022347 Fix path escaping for GCS urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Bug fixes:
 -
 -
 -
--
+- Fixed path escaping for GCS urls (snowflakedb/gosnowflake#1678).
 
 Internal changes:
 

--- a/gcs_storage_client_test.go
+++ b/gcs_storage_client_test.go
@@ -100,6 +100,7 @@ func TestGenerateFileURL(t *testing.T) {
 	testcases := []tcFileURL{
 		{"sfc-eng-regression/test_sub_dir/", "file1", "sfc-eng-regression", "test_sub_dir/file1"},
 		{"sfc-eng-regression/dir/test_stg/test_sub_dir/", "file2", "sfc-eng-regression", "dir/test_stg/test_sub_dir/file2"},
+		{"sfc-eng-regression/dir/test_stg/test sub dir/", "file2", "sfc-eng-regression", "dir/test_stg/test sub dir/file2"},
 		{"sfc-eng-regression/", "file3", "sfc-eng-regression", "file3"},
 		{"sfc-eng-regression//", "file4", "sfc-eng-regression", "/file4"},
 		{"sfc-eng-regression///", "file5", "sfc-eng-regression", "//file5"},
@@ -110,7 +111,7 @@ func TestGenerateFileURL(t *testing.T) {
 			stageInfo.Location = test.location
 			gcsURL, err := gcsUtil.generateFileURL(stageInfo, test.fname)
 			assertNilF(t, err, "error should be nil")
-			expectedURL, err := url.Parse("https://storage.googleapis.com/" + test.bucket + "/" + url.QueryEscape(test.filepath))
+			expectedURL, err := url.Parse("https://storage.googleapis.com/" + test.bucket + "/" + url.PathEscape(test.filepath))
 			assertNilF(t, err, "error should be nil")
 			assertEqualE(t, gcsURL.String(), expectedURL.String(), "failed. expected: %v but got: %v", expectedURL.String(), gcsURL.String())
 		})
@@ -122,7 +123,7 @@ func TestGenerateFileURL(t *testing.T) {
 			stageInfo.Location = test.location
 			gcsURL, err := gcsUtil.generateFileURL(stageInfo, test.fname)
 			assertNilF(t, err, "error should be nil")
-			expectedURL, err := url.Parse("https://storage.googleapis.com/" + test.bucket + "/" + url.QueryEscape(test.filepath))
+			expectedURL, err := url.Parse("https://storage.googleapis.com/" + test.bucket + "/" + url.PathEscape(test.filepath))
 			assertNilF(t, err, "error should be nil")
 			assertEqualE(t, gcsURL.String(), expectedURL.String(), "failed. expected: %v but got: %v", expectedURL.String(), gcsURL.String())
 		})
@@ -135,7 +136,7 @@ func TestGenerateFileURL(t *testing.T) {
 			stageInfo.UseVirtualURL = true
 			gcsURL, err := gcsUtil.generateFileURL(stageInfo, test.fname)
 			assertNilF(t, err, "error should be nil")
-			expectedURL, err := url.Parse("https://sfc-eng-regression.storage.googleapis.com/" + url.QueryEscape(test.filepath))
+			expectedURL, err := url.Parse("https://sfc-eng-regression.storage.googleapis.com/" + url.PathEscape(test.filepath))
 			assertNilF(t, err, "error should be nil")
 			assertEqualE(t, gcsURL.String(), expectedURL.String(), "failed. expected: %v but got: %v", expectedURL.String(), gcsURL.String())
 		})


### PR DESCRIPTION
### Description

SNOW-3022347 Fixed GCS URLs escaping. We used `queryEscape` function which is used to escape query strings. It escapes spaces as `+`s. Now we use `pathEscape` which escapes spaces as `%20` - which is correct for path part.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
