### PR TITLE
Bump package version to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+
+Breaking changes:
+
 ## Upcoming Release
 
 New features:

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ go mod init example.com/snowflake
 Get Gosnowflake source code, if not installed.
 
 ```sh
-go get -u github.com/snowflakedb/gosnowflake
+go get -u github.com/snowflakedb/gosnowflake/v2
 ```
 
 # Docs
 
 For detailed documentation and basic usage examples, please see the documentation at
-[godoc.org](https://godoc.org/github.com/snowflakedb/gosnowflake/).
+[godoc.org](https://godoc.org/github.com/snowflakedb/gosnowflake/v2).
 
 ## Notes
 
@@ -77,7 +77,7 @@ Congrats! You have successfully run SELECT 1 with Snowflake DB!
 
 # Development
 
-The developer notes are hosted with the source code on [GitHub](https://github.com/snowflakedb/gosnowflake).
+The developer notes are hosted with the source code on [GitHub](https://github.com/snowflakedb/gosnowflake/v2).
 
 ## Testing Code
 
@@ -112,7 +112,7 @@ This is for debugging Large SQL statements (greater than 300 characters). If you
 
 If you would like to ensure that certain tags are always present in the logs, `RegisterClientLogContextHook` can be used in your init function. See example below.
 ```go
-import "github.com/snowflakedb/gosnowflake"
+import "github.com/snowflakedb/gosnowflake/v2"
 
 func init() {
     // each time the logger is used, the logs will contain a REQUEST_ID field with requestID the value extracted 
@@ -126,7 +126,7 @@ func init() {
 ## Setting Log Level
 If you want to change the log level, `SetLogLevel` can be used in your init function like this:
 ```go
-import "github.com/snowflakedb/gosnowflake"
+import "github.com/snowflakedb/gosnowflake/v2"
 
 func init() {
     // The following line changes the log level to debug

--- a/auth.go
+++ b/auth.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/snowflakedb/gosnowflake/internal/compilation"
-	internalos "github.com/snowflakedb/gosnowflake/internal/os"
+	"github.com/snowflakedb/gosnowflake/v2/internal/compilation"
+	internalos "github.com/snowflakedb/gosnowflake/v2/internal/os"
 )
 
 const (

--- a/cmd/arrow/batches/arrow_batches.go
+++ b/cmd/arrow/batches/arrow_batches.go
@@ -14,7 +14,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 type sampleRecord struct {

--- a/cmd/arrow/transform_batches_to_rows/transform_batches_to_rows.go
+++ b/cmd/arrow/transform_batches_to_rows/transform_batches_to_rows.go
@@ -6,7 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"flag"
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 	"io"
 	"log"
 )

--- a/cmd/async/async.go
+++ b/cmd/async/async.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/connectionproxy/connectionproxy.go
+++ b/cmd/connectionproxy/connectionproxy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/distributedfetch/distributedfetch.go
+++ b/cmd/distributedfetch/distributedfetch.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/externalbrowser/externalbrowser.go
+++ b/cmd/externalbrowser/externalbrowser.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 // A simple test program for authenticating with an external browser.

--- a/cmd/fetchresultbyid/fetchresultbyid.go
+++ b/cmd/fetchresultbyid/fetchresultbyid.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"strings"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/filestransfer/filestransfer.go
+++ b/cmd/filestransfer/filestransfer.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"path/filepath"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 const customFormatCsvDataToUpload = "NUM; TEXT\n1; foo\n2; bar\n3; baz"

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"time"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func runQuery(db *sql.DB, query string) {

--- a/cmd/keypair/keypair.go
+++ b/cmd/keypair/keypair.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 	"log"
 	"strings"
 )

--- a/cmd/mfa/mfa.go
+++ b/cmd/mfa/mfa.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/multistatement/multistatement.go
+++ b/cmd/multistatement/multistatement.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"time"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/noconnpool/noconnpool.go
+++ b/cmd/noconnpool/noconnpool.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"sync"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"os"
 
-	_ "github.com/snowflakedb/gosnowflake"
+	_ "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/programmatic_access_token/pat.go
+++ b/cmd/programmatic_access_token/pat.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 	"log"
 )
 

--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/selectmany/selectmany.go
+++ b/cmd/selectmany/selectmany.go
@@ -12,7 +12,7 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 var (

--- a/cmd/showparam/showparam.go
+++ b/cmd/showparam/showparam.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/tomlfileconnection/tomlfileconnection.go
+++ b/cmd/tomlfileconnection/tomlfileconnection.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/snowflakedb/gosnowflake"
+	_ "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/variant/insertvariantobject.go
+++ b/cmd/variant/insertvariantobject.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/verifycert/verifycert.go
+++ b/cmd/verifycert/verifycert.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 )
 
 func main() {

--- a/cmd/workload_identity/workload_identity.go
+++ b/cmd/workload_identity/workload_identity.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	sf "github.com/snowflakedb/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake/v2"
 	"log"
 	"os"
 )

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ Clients can use the database/sql package directly. For example:
 	import (
 		"database/sql"
 
-		_ "github.com/snowflakedb/gosnowflake"
+		_ "github.com/snowflakedb/gosnowflake/v2"
 
 		"log"
 	)
@@ -311,7 +311,7 @@ If you want to define S3 client logging, override S3LoggingMode variable using c
 Example:
 
 	    import (
-	      sf "github.com/snowflakedb/gosnowflake"
+	      sf "github.com/snowflakedb/gosnowflake/v2"
 	      "github.com/aws/aws-sdk-go-v2/aws"
 	    )
 
@@ -1008,7 +1008,7 @@ any subsequent time.Time type to the DATE, TIME, TIMESTAMP_LTZ, TIMESTAMP_NTZ
 or BINARY data type. The above example could be rewritten as follows:
 
 	import (
-		sf "github.com/snowflakedb/gosnowflake"
+		sf "github.com/snowflakedb/gosnowflake/v2"
 	)
 	dbt.mustExec("CREATE OR REPLACE TABLE tztest (id int, ntz, timestamp_ntz, ltz timestamp_ltz)")
 	// ...
@@ -1051,7 +1051,7 @@ The application may change the number of result set chunk downloader if required
 memory footprint by itself. Consider Custom JSON Decoder.
 
 	import (
-		sf "github.com/snowflakedb/gosnowflake"
+		sf "github.com/snowflakedb/gosnowflake/v2"
 	)
 	sf.MaxChunkDownloadWorkers = 2
 
@@ -1060,7 +1060,7 @@ Custom JSON Decoder for Parsing Result Set (Experimental)
 The application may have the driver use a custom JSON decoder that incrementally parses the result set as follows.
 
 	import (
-		sf "github.com/snowflakedb/gosnowflake"
+		sf "github.com/snowflakedb/gosnowflake/v2"
 	)
 	sf.CustomJSONDecoderEnabled = true
 	...
@@ -1329,7 +1329,7 @@ and before retrieving the results. For a more elaborative example please see cmd
 			"fmt"
 			"log"
 			"os"
-			sf "github.com/snowflakedb/gosnowflake"
+			sf "github.com/snowflakedb/gosnowflake/v2"
 	    )
 
 		...

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/snowflakedb/gosnowflake
+module github.com/snowflakedb/gosnowflake/v2
 
 go 1.23.0
 

--- a/minicore.go
+++ b/minicore.go
@@ -3,7 +3,7 @@ package gosnowflake
 import (
 	"bufio"
 	"fmt"
-	"github.com/snowflakedb/gosnowflake/internal/compilation"
+	"github.com/snowflakedb/gosnowflake/v2/internal/compilation"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/minicore_disabled_test.go
+++ b/minicore_disabled_test.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/snowflakedb/gosnowflake/internal/compilation"
+	"github.com/snowflakedb/gosnowflake/v2/internal/compilation"
 )
 
 func TestMiniCoreDisabledAtCompileTime(t *testing.T) {


### PR DESCRIPTION
### Description

SNOW-1881542 Bumped gosnowflake package version to v2. The list of suggested changes is described in [the announcement](https://github.com/snowflakedb/gosnowflake/issues/1586). After v2 is merged and released, we will create a `v1` branch containing the stable state of v1. V1 will get only the most critical and blocking updates. We will encourage to migrate to v2.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
