### PR TITLE
SNOW-2924941: Fix OCSP cache clearer stop() race condition

### DIFF
--- a/ocsp.go
+++ b/ocsp.go
@@ -106,7 +106,7 @@ const (
 	maxClockSkew           = 900 * time.Second // buffer for clock skew
 )
 
-var stopOCSPCacheClearing = make(chan struct{}, 2)
+var stopOCSPCacheClearing = make(chan struct{})
 
 type ocspStatusCode int
 


### PR DESCRIPTION
The stopOCSPCacheClearing channel was defined as a buffered channel with capacity 2, which caused a race condition in the stop() method. With a buffered channel, the send operation in stop() would put a value into the buffer (non-blocking), and the receive operation could immediately read that same value back, causing stop() to return without the goroutine ever seeing the stop signal.

This fix changes the channel to be unbuffered, ensuring proper synchronization:
- The send in stop() blocks until the goroutine receives
- The goroutine's acknowledgment send blocks until stop() receives

This ensures the handshake pattern works correctly and prevents:
- Goroutine leaks when StopOCSPCacheClearer() is called
- Resources (ticker) not being released
- Non-deterministic behavior in tests

Fixes #1669

### Description

SNOW-XXX Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
