### PR TITLE
SNOW-1881542 Cleanup Config struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Breaking changes:
 - Hid streaming chunk downloader. It will be removed completely in the future (snowflakedb/gosnowflake#1696).
 - Maximum number of chunk download goroutines is now configured with `CLIENT_PREFETCH_THREADS` session parameter (snowflakedb/gosnowflake#1696).
 - Fixed typo in `GOSNOWFLAKE_SKIP_REGISTRATION` env variable (snowflakedb/gosnowflake#1696).
+- Removed `ClientIP` field from `Config` struct. This field was never used and is not needed for any functionality (snowflakedb/gosnowflake#1692).
+- Unexported MfaToken and IdToken (snowflakedb/gosnowflake#1692).
+- Removed `InsecureMode` field from `Config` struct. Use `DisableOCSPChecks` instead (snowflakedb/gosnowflake#1692).
+- Renamed `KeepSessionAlive` field in `Config` struct to `ServerSessionKeepAlive` to adjust with the remaining drivers (snowflakedb/gosnowflake#1692).
+- Removed `DisableTelemetry` field from `Config` struct. Use `CLIENT_TELEMETRY_ENABLED` session parameter instead (snowflakedb/gosnowflake#1692).
 
 Bug fixes:
 

--- a/auth.go
+++ b/auth.go
@@ -507,9 +507,9 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 
 	switch sc.cfg.Authenticator {
 	case AuthTypeExternalBrowser:
-		if sc.cfg.IDToken != "" {
+		if sc.cfg.idToken != "" {
 			requestMain.Authenticator = idTokenAuthenticator
-			requestMain.Token = sc.cfg.IDToken
+			requestMain.Token = sc.cfg.idToken
 			requestMain.LoginName = sc.cfg.User
 		} else {
 			requestMain.ProofKey = string(proofKey)
@@ -570,8 +570,8 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]interface
 		requestMain.LoginName = sc.cfg.User
 		requestMain.Password = sc.cfg.Password
 		switch {
-		case sc.cfg.MfaToken != "":
-			requestMain.Token = sc.cfg.MfaToken
+		case sc.cfg.mfaToken != "":
+			requestMain.Token = sc.cfg.mfaToken
 		case sc.cfg.PasscodeInPassword:
 			requestMain.ExtAuthnDuoMethod = "passcode"
 		case sc.cfg.Passcode != "":
@@ -760,7 +760,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 			if isEligibleForParallelLogin(sc.cfg, sc.cfg.ClientStoreTemporaryCredential) {
 				valueAwaiter := valueAwaitHolder.get(idTokenLockKey)
 				defer valueAwaiter.resumeOne()
-				sc.cfg.IDToken, _ = awaitValue(valueAwaiter, func() (string, error) {
+				sc.cfg.idToken, _ = awaitValue(valueAwaiter, func() (string, error) {
 					credential := credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
 					return credential, nil
 				}, func(s string, err error) bool {
@@ -769,7 +769,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 					return ""
 				})
 			} else if sc.cfg.ClientStoreTemporaryCredential == ConfigBoolTrue {
-				sc.cfg.IDToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
+				sc.cfg.idToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
 			}
 		}
 		// Disable console login by default
@@ -785,7 +785,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 		if isEligibleForParallelLogin(sc.cfg, sc.cfg.ClientRequestMfaToken) {
 			valueAwaiter := valueAwaitHolder.get(mfaTokenLockKey)
 			defer valueAwaiter.resumeOne()
-			sc.cfg.MfaToken, _ = awaitValue(valueAwaiter, func() (string, error) {
+			sc.cfg.mfaToken, _ = awaitValue(valueAwaiter, func() (string, error) {
 				credential := credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
 				return credential, nil
 			}, func(s string, err error) bool {
@@ -794,14 +794,14 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 				return ""
 			})
 		} else if sc.cfg.ClientRequestMfaToken == ConfigBoolTrue {
-			sc.cfg.MfaToken = credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
+			sc.cfg.mfaToken = credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
 		}
 	}
 
 	logger.WithContext(sc.ctx).Infof("Authenticating via %v", sc.cfg.Authenticator.String())
 	switch sc.cfg.Authenticator {
 	case AuthTypeExternalBrowser:
-		if sc.cfg.IDToken == "" {
+		if sc.cfg.idToken == "" {
 			samlResponse, proofKey, err = authenticateByExternalBrowser(
 				sc.ctx,
 				sc.rest,
@@ -849,6 +849,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 		valueAwaiter.done()
 	}
 	sc.populateSessionParameters(authData.Parameters)
+	sc.configureTelemetry()
 	sc.ctx = context.WithValue(sc.ctx, SFSessionIDKey, authData.SessionID)
 	return nil
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -686,7 +686,7 @@ func TestUnitAuthenticateUsernamePasswordMfa(t *testing.T) {
 	}
 
 	sr.FuncPostAuth = postAuthCheckUsernamePasswordMfaToken
-	sc.cfg.MfaToken = "mockedMfaToken"
+	sc.cfg.mfaToken = "mockedMfaToken"
 	_, err = authenticate(context.Background(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)
@@ -939,7 +939,7 @@ func TestUnitAuthenticateExternalBrowser(t *testing.T) {
 	}
 
 	sr.FuncPostAuth = postAuthCheckExternalBrowserToken
-	sc.cfg.IDToken = "mockedIDToken"
+	sc.cfg.idToken = "mockedIDToken"
 	_, err = authenticate(context.Background(), sc, []byte{}, []byte{})
 	if err != nil {
 		t.Fatalf("failed to run. err: %v", err)

--- a/auth_with_external_browser_test.go
+++ b/auth_with_external_browser_test.go
@@ -117,7 +117,7 @@ func TestClientStoreCredentials(t *testing.T) {
 		rows.Close()
 	})
 
-	t.Run("Verify validation of IDToken if option disabled", func(t *testing.T) {
+	t.Run("Verify validation of idToken if option disabled", func(t *testing.T) {
 		cleanupBrowserProcesses(t)
 		cfg.ClientStoreTemporaryCredential = 0
 		db := getDbHandlerFromConfig(t, cfg)

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -649,7 +648,6 @@ type streamChunkFetcher interface {
 type httpStreamChunkFetcher struct {
 	ctx           context.Context
 	client        *http.Client
-	clientIP      net.IP
 	headers       map[string]string
 	maxRetryCount int
 	qrmk          string

--- a/connection_configuration.go
+++ b/connection_configuration.go
@@ -140,9 +140,6 @@ func handleSingleParam(cfg *Config, key string, value interface{}) error {
 		err = determineAuthenticatorType(cfg, v)
 	case "disableocspchecks":
 		cfg.DisableOCSPChecks, err = parseBool(value)
-	case "insecuremode":
-		logInsecureModeDeprecationInfo()
-		cfg.InsecureMode, err = parseBool(value)
 	case "ocspfailopen":
 		var vv ConfigBool
 		vv, err = parseConfigBool(value)

--- a/connection_configuration_test.go
+++ b/connection_configuration_test.go
@@ -206,7 +206,7 @@ func TestReadTokenValueWithTokenFilePath(t *testing.T) {
 	token, err := cfg.getToken()
 	assertNilE(t, err)
 	assertEqualF(t, token, "mock_token123456")
-	assertEqualE(t, cfg.InsecureMode, true)
+	assertEqualE(t, cfg.DisableOCSPChecks, true)
 }
 
 func TestLoadConnectionConfigWitNonExistingDSN(t *testing.T) {
@@ -329,7 +329,7 @@ func TestParseToml(t *testing.T) {
 			values: []interface{}{"300", 500},
 		},
 		{
-			testParams: []string{"ocspFailOpen", "ocsp_fail_open", "insecureMode", "insecure_mode", "PasscodeInPassword", "passcode_in_password", "validateDEFAULTParameters", "validate_default_parameters",
+			testParams: []string{"ocspFailOpen", "ocsp_fail_open", "PasscodeInPassword", "passcode_in_password", "validateDEFAULTParameters", "validate_default_parameters",
 				"clientRequestMFAtoken", "client_request_mfa_token", "clientStoreTemporaryCredential", "client_store_temporary_credential", "disableQueryContextCache", "disable_query_context_cache", "disable_ocsp_checks",
 				"includeRetryReason", "include_retry_reason", "disableConsoleLogin", "disable_console_login", "disableSamlUrlCheck", "disable_saml_url_check"},
 			values: []interface{}{true, "true", false, "false"},
@@ -373,7 +373,7 @@ func TestParseTomlWithWrongValue(t *testing.T) {
 			values: []interface{}{"wrong_value", false},
 		},
 		{
-			testParams: []string{"ocspFailOpen", "insecureMode", "PasscodeInPassword", "validateDEFAULTParameters", "clientRequestMFAtoken",
+			testParams: []string{"ocspFailOpen", "PasscodeInPassword", "validateDEFAULTParameters", "clientRequestMFAtoken",
 				"clientStoreTemporaryCredential", "disableQueryContextCache", "includeRetryReason", "disableConsoleLogin", "disableSamlUrlCheck"},
 			values: []interface{}{"wrong_value", 1},
 		},

--- a/connection_test.go
+++ b/connection_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"net/http"
 	"net/url"
@@ -464,7 +465,7 @@ func TestClientSessionPersist(t *testing.T) {
 		rest:      sr,
 		telemetry: testTelemetry,
 	}
-	sc.cfg.KeepSessionAlive = true
+	sc.cfg.ServerSessionKeepAlive = true
 	count := closedSessionCount
 	if sc.Close() != nil {
 		t.Error("Connection close should not return error")
@@ -759,6 +760,31 @@ func TestAddTelemetryDataViaSnowflakeConnection(t *testing.T) {
 	assertNilF(t, err)
 }
 
+func TestConfigureTelemetry(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(strconv.FormatBool(enabled), func(t *testing.T) {
+			wiremock.registerMappings(t,
+				wiremockMapping{
+					filePath: "auth/password/successful_flow_with_telemetry.json",
+					params:   map[string]string{"%CLIENT_TELEMETRY_ENABLED%": strconv.FormatBool(enabled)},
+				},
+			)
+			cfg := wiremock.connectionConfig()
+			connector := NewConnector(SnowflakeDriver{}, *cfg)
+			db := sql.OpenDB(connector)
+			defer db.Close()
+			conn, err := db.Conn(context.Background())
+			assertNilF(t, err)
+			err = conn.Raw(func(x any) error {
+				sc := x.(*snowflakeConn)
+				assertEqualE(t, sc.telemetry.enabled, enabled)
+				return nil
+			})
+			assertNilF(t, err)
+		})
+	}
+}
+
 func TestGetInvalidQueryStatus(t *testing.T) {
 	runSnowflakeConnTest(t, func(sct *SCTest) {
 		sct.sc.rest.RequestTimeout = 1 * time.Second
@@ -1017,8 +1043,8 @@ func TestGetTransport(t *testing.T) {
 		roundTripperCheck func(t *testing.T, roundTripper http.RoundTripper)
 	}{
 		{
-			name: "DisableOCSPChecks and InsecureMode false",
-			cfg:  &Config{Account: "one", DisableOCSPChecks: false, InsecureMode: false},
+			name: "DisableOCSPChecks",
+			cfg:  &Config{Account: "one", DisableOCSPChecks: false},
 			transportCheck: func(t *testing.T, transport *http.Transport) {
 				// We should have a verifier function
 				assertNotNilF(t, transport)
@@ -1027,25 +1053,7 @@ func TestGetTransport(t *testing.T) {
 			},
 		},
 		{
-			name: "DisableOCSPChecks true and InsecureMode false",
-			cfg:  &Config{Account: "two", DisableOCSPChecks: true, InsecureMode: false},
-			transportCheck: func(t *testing.T, transport *http.Transport) {
-				// We should not have a TLSClientConfig
-				assertNotNilF(t, transport)
-				assertNilF(t, transport.TLSClientConfig)
-			},
-		},
-		{
-			name: "DisableOCSPChecks false and InsecureMode true",
-			cfg:  &Config{Account: "three", DisableOCSPChecks: false, InsecureMode: true},
-			transportCheck: func(t *testing.T, transport *http.Transport) {
-				// We should not have a TLSClientConfig
-				assertNotNilF(t, transport)
-				assertNilF(t, transport.TLSClientConfig)
-			},
-		},
-		{
-			name: "DisableOCSPChecks and InsecureMode missing from Config",
+			name: "DisableOCSPChecks missing from Config",
 			cfg:  &Config{Account: "four"},
 			transportCheck: func(t *testing.T, transport *http.Transport) {
 				// We should have a verifier function
@@ -1065,7 +1073,7 @@ func TestGetTransport(t *testing.T) {
 		},
 		{
 			name: "Using custom Transporter",
-			cfg:  &Config{Account: "five", DisableOCSPChecks: true, InsecureMode: false, Transporter: EmptyTransporter{}},
+			cfg:  &Config{Account: "five", DisableOCSPChecks: true, Transporter: EmptyTransporter{}},
 			roundTripperCheck: func(t *testing.T, roundTripper http.RoundTripper) {
 				// We should have a custom Transporter
 				assertNotNilF(t, roundTripper)

--- a/doc.go
+++ b/doc.go
@@ -111,8 +111,6 @@ The following connection parameters are supported:
     OCSP module caches responses internally. If your application is long running, you can enable cache clearing by calling StartOCSPCacheClearer and disable by calling StopOCSPCacheClearer.
     IMPORTANT: Change the default value for testing or emergency situations only.
 
-  - insecureMode: deprecated. Use disableOCSPChecks instead.
-
   - token: a token that can be used to authenticate. Should be used in conjunction with the "oauth" authenticator.
 
   - client_session_keep_alive: Set to true have a heartbeat in the background every hour by default or the value of
@@ -1334,7 +1332,7 @@ and before retrieving the results. For a more elaborative example please see cmd
 			...
 		}
 
-==> Some considerations related to the KeepSessionAlive configuration option in context of asynchronous query execution
+==> Some considerations related to the ServerSessionKeepAlive configuration option in context of asynchronous query execution
 
 When SQL Go connection is being closed, it performs the following actions:
 
@@ -1342,11 +1340,11 @@ When SQL Go connection is being closed, it performs the following actions:
 
 * cleans up all the http connections which are already idle - doesn't touch the ones which are in active use currently
 
-* if Config.KeepSessionAlive is false (default), then actively logs out the current Snowflake session.
+* if Config.ServerSessionKeepAlive is false (default), then actively logs out the current Snowflake session.
 
 !! Caveat: If there are any queries which are currently executing in the same Snowflake session (e.g. async queries sent with WithAsyncMode()), then those queries are automatically cancelled from the client side a couple minutes later after the Close() call, as a Snowflake session which has been actively logged out from, cannot sustain any queries.
 
-You can govern this behaviour with setting Config.KeepSessionAlive to true; when the corresponding Snowflake session will be kept alive for a long time (determined by the Snowflake engine) even after an explicit Connection.Close() call past the time when the last running query in the session finished executing.
+You can govern this behaviour with setting Config.ServerSessionKeepAlive to true; when the corresponding Snowflake session will be kept alive for a long time (determined by the Snowflake engine) even after an explicit Connection.Close() call past the time when the last running query in the session finished executing.
 
 The behaviour is also dependent on ABORT_DETACHED_QUERY parameter, please see the detailed explanation in the parameter description at https://docs.snowflake.com/en/sql-reference/parameters#abort-detached-query.
 

--- a/driver_ocsp_test.go
+++ b/driver_ocsp_test.go
@@ -736,8 +736,8 @@ func TestOCSPUnexpectedResponses(t *testing.T) {
 			wiremockMapping{filePath: "auth/password/successful_flow.json"},
 		)
 		runSampleQuery(cfg)
-		assertEqualE(t, countingRoundTripper.postReqCount[wiremock.baseURL()], 3)
-		assertEqualE(t, countingRoundTripper.getReqCount[wiremock.baseURL()], 3)
+		assertEqualE(t, countingRoundTripper.postReqCount[wiremock.baseURL()], 2)
+		assertEqualE(t, countingRoundTripper.getReqCount[wiremock.baseURL()], 2)
 	})
 
 	t.Run("should not fallback to GET when for POST unauthorized is returned", func(t *testing.T) {
@@ -750,7 +750,7 @@ func TestOCSPUnexpectedResponses(t *testing.T) {
 			wiremockMapping{filePath: "auth/password/successful_flow.json"},
 		)
 		runSampleQuery(cfg)
-		assertEqualE(t, countingRoundTripper.postReqCount[wiremock.baseURL()], 3)
+		assertEqualE(t, countingRoundTripper.postReqCount[wiremock.baseURL()], 2)
 		assertEqualE(t, countingRoundTripper.getReqCount[wiremock.baseURL()], 0)
 	})
 }
@@ -774,14 +774,12 @@ func TestConnectionToMultipleConfigurations(t *testing.T) {
 	cfgForFailOpen.Transporter = nil
 	cfgForFailOpen.TLSConfigName = "wiremock"
 	cfgForFailOpen.MaxRetryCount = 1
-	cfgForFailOpen.DisableTelemetry = true
 
 	cfgForFailClose := wiremockHTTPS.connectionConfig(t)
 	cfgForFailClose.OCSPFailOpen = OCSPFailOpenFalse
 	cfgForFailClose.Transporter = nil
 	cfgForFailClose.TLSConfigName = "wiremock"
 	cfgForFailClose.MaxRetryCount = 1
-	cfgForFailClose.DisableTelemetry = true
 
 	// we ignore closing here, since these are only wiremock connections
 	failOpenDb := sql.OpenDB(NewConnector(SnowflakeDriver{}, *cfgForFailOpen))

--- a/driver_test.go
+++ b/driver_test.go
@@ -2200,7 +2200,7 @@ func TestOpenWithConfig(t *testing.T) {
 
 func TestOpenWithConfigCancel(t *testing.T) {
 	wiremock.registerMappings(t,
-		wiremockMapping{filePath: "auth/password/successful_flow.json"},
+		wiremockMapping{filePath: "auth/password/successful_flow_with_telemetry.json", params: map[string]string{"%CLIENT_TELEMETRY_ENABLED%": "true"}},
 	)
 	driver := SnowflakeDriver{}
 	config := wiremock.connectionConfig()
@@ -2268,20 +2268,6 @@ func TestOpenWithTransport(t *testing.T) {
 	// Test that transport override also works in OCSP checks disabled.
 	countingTransport.reset()
 	config.DisableOCSPChecks = true
-	db, err = driver.OpenWithConfig(context.Background(), *config)
-	assertNilF(t, err, fmt.Sprintf("failed to open with config. config: %v", config))
-	conn = db.(*snowflakeConn)
-	if conn.rest.Client.Transport != transport {
-		t.Fatal("transport doesn't match")
-	}
-	db.Close()
-	if countingTransport.totalRequests() == 0 {
-		t.Fatal("transport did not receive any requests")
-	}
-
-	// Test that transport override also works in insecure mode
-	countingTransport.reset()
-	config.InsecureMode = true
 	db, err = driver.OpenWithConfig(context.Background(), *config)
 	assertNilF(t, err, fmt.Sprintf("failed to open with config. config: %v", config))
 	conn = db.(*snowflakeConn)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -52,24 +52,6 @@ func TestParseDSN(t *testing.T) {
 			err:      nil,
 		},
 		{
-			dsn: "user:pass@ac-1-laksdnflaf.global/db/schema?disableTelemetry=true",
-			config: &Config{
-				Account: "ac-1", User: "user", Password: "pass", Region: "global",
-				Protocol: "https", Host: "ac-1-laksdnflaf.global.snowflakecomputing.com", Port: 443,
-				Database: "db", Schema: "schema",
-				OCSPFailOpen:              OCSPFailOpenTrue,
-				DisableTelemetry:          true,
-				ValidateDefaultParameters: ConfigBoolTrue,
-				ClientTimeout:             defaultClientTimeout,
-				JWTClientTimeout:          defaultJWTClientTimeout,
-				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
-				CloudStorageTimeout:       defaultCloudStorageTimeout,
-				IncludeRetryReason:        ConfigBoolTrue,
-			},
-			ocspMode: ocspModeFailOpen,
-			err:      nil,
-		},
-		{
 			dsn: "user:pass@ac-laksdnflaf.global/db/schema",
 			config: &Config{
 				Account: "ac", User: "user", Password: "pass", Region: "global",
@@ -693,12 +675,12 @@ func TestParseDSN(t *testing.T) {
 			},
 		},
 		{
-			dsn: "u:p@a?database=d&schema=s&role=r&application=aa&authenticator=snowflake&insecureMode=true&passcode=pp&passcodeInPassword=true",
+			dsn: "u:p@a?database=d&schema=s&role=r&application=aa&authenticator=snowflake&disableOCSPChecks=true&passcode=pp&passcodeInPassword=true",
 			config: &Config{
 				Account: "a", User: "u", Password: "p",
 				Protocol: "https", Host: "a.snowflakecomputing.com", Port: 443,
 				Database: "d", Schema: "s", Role: "r", Authenticator: AuthTypeSnowflake, Application: "aa",
-				InsecureMode: true, Passcode: "pp", PasscodeInPassword: true,
+				DisableOCSPChecks: true, Passcode: "pp", PasscodeInPassword: true,
 				OCSPFailOpen:              OCSPFailOpenTrue,
 				ValidateDefaultParameters: ConfigBoolTrue,
 				ClientTimeout:             defaultClientTimeout,
@@ -726,43 +708,6 @@ func TestParseDSN(t *testing.T) {
 				IncludeRetryReason:        ConfigBoolTrue,
 			},
 			ocspMode: ocspModeInsecure,
-			err:      nil,
-		},
-		{
-			dsn: "u:p@a?database=d&schema=s&role=r&application=aa&authenticator=snowflake&disableOCSPChecks=true&passcode=pp&passcodeInPassword=true",
-			config: &Config{
-				Account: "a", User: "u", Password: "p",
-				Protocol: "https", Host: "a.snowflakecomputing.com", Port: 443,
-				Database: "d", Schema: "s", Role: "r", Authenticator: AuthTypeSnowflake, Application: "aa",
-				InsecureMode: false, DisableOCSPChecks: true, Passcode: "pp", PasscodeInPassword: true,
-				OCSPFailOpen:              OCSPFailOpenTrue,
-				ValidateDefaultParameters: ConfigBoolTrue,
-				ClientTimeout:             defaultClientTimeout,
-				JWTClientTimeout:          defaultJWTClientTimeout,
-				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
-				CloudStorageTimeout:       defaultCloudStorageTimeout,
-				IncludeRetryReason:        ConfigBoolTrue,
-			},
-			ocspMode: ocspModeInsecure,
-			err:      nil,
-		},
-		// disableOCSPChecks should take precedence over insecureMode
-		{
-			dsn: "u:p@a?database=d&schema=s&role=r&application=aa&authenticator=snowflake&disableOCSPChecks=false&insecureMode=true&passcode=pp&passcodeInPassword=true",
-			config: &Config{
-				Account: "a", User: "u", Password: "p",
-				Protocol: "https", Host: "a.snowflakecomputing.com", Port: 443,
-				Database: "d", Schema: "s", Role: "r", Authenticator: AuthTypeSnowflake, Application: "aa",
-				DisableOCSPChecks: false, Passcode: "pp", PasscodeInPassword: true,
-				OCSPFailOpen:              OCSPFailOpenTrue,
-				ValidateDefaultParameters: ConfigBoolTrue,
-				ClientTimeout:             defaultClientTimeout,
-				JWTClientTimeout:          defaultJWTClientTimeout,
-				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
-				CloudStorageTimeout:       defaultCloudStorageTimeout,
-				IncludeRetryReason:        ConfigBoolTrue,
-			},
-			ocspMode: ocspModeFailOpen,
 			err:      nil,
 		},
 		{
@@ -948,22 +893,6 @@ func TestParseDSN(t *testing.T) {
 			err:      nil,
 		},
 		{
-			dsn: "user:pass@account/db/s?insecureMode=true&ocspFailOpen=false",
-			config: &Config{
-				Account: "account", User: "user", Password: "pass",
-				Protocol: "https", Host: "account.snowflakecomputing.com", Port: 443,
-				Database: "db", Schema: "s", OCSPFailOpen: OCSPFailOpenFalse, InsecureMode: true,
-				ValidateDefaultParameters: ConfigBoolTrue,
-				ClientTimeout:             defaultClientTimeout,
-				JWTClientTimeout:          defaultJWTClientTimeout,
-				ExternalBrowserTimeout:    defaultExternalBrowserTimeout,
-				CloudStorageTimeout:       defaultCloudStorageTimeout,
-				IncludeRetryReason:        ConfigBoolTrue,
-			},
-			ocspMode: ocspModeInsecure,
-			err:      nil,
-		},
-		{
 			dsn: "user:pass@account/db/s?validateDefaultParameters=true",
 			config: &Config{
 				Account: "account", User: "user", Password: "pass",
@@ -1020,6 +949,37 @@ func TestParseDSN(t *testing.T) {
 				CloudStorageTimeout:      defaultCloudStorageTimeout,
 				DisableQueryContextCache: false,
 				IncludeRetryReason:       ConfigBoolFalse,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
+		{
+			dsn: "u:p@a.r.c.snowflakecomputing.com/db/s?account=a.r.c&serverSessionKeepAlive=false",
+			config: &Config{
+				Account: "a", User: "u", Password: "p",
+				Protocol: "https", Host: "a.r.c.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "s", ValidateDefaultParameters: ConfigBoolTrue, OCSPFailOpen: OCSPFailOpenTrue,
+				ClientTimeout:          defaultClientTimeout,
+				JWTClientTimeout:       defaultJWTClientTimeout,
+				ExternalBrowserTimeout: defaultExternalBrowserTimeout,
+				CloudStorageTimeout:    defaultCloudStorageTimeout,
+				IncludeRetryReason:     ConfigBoolTrue,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
+		{
+			dsn: "u:p@a.r.c.snowflakecomputing.com/db/s?account=a.r.c&serverSessionKeepAlive=true",
+			config: &Config{
+				Account: "a", User: "u", Password: "p",
+				Protocol: "https", Host: "a.r.c.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "s", ValidateDefaultParameters: ConfigBoolTrue, OCSPFailOpen: OCSPFailOpenTrue,
+				ServerSessionKeepAlive: true,
+				ClientTimeout:          defaultClientTimeout,
+				JWTClientTimeout:       defaultJWTClientTimeout,
+				ExternalBrowserTimeout: defaultExternalBrowserTimeout,
+				CloudStorageTimeout:    defaultCloudStorageTimeout,
+				IncludeRetryReason:     ConfigBoolTrue,
 			},
 			ocspMode: ocspModeFailOpen,
 			err:      nil,
@@ -1400,6 +1360,7 @@ func TestParseDSN(t *testing.T) {
 				assertEqualE(t, cfg.TmpDirPath, test.config.TmpDirPath, fmt.Sprintf("Test %d: TmpDirPath mismatch", i))
 				assertEqualE(t, cfg.DisableQueryContextCache, test.config.DisableQueryContextCache, fmt.Sprintf("Test %d: DisableQueryContextCache mismatch", i))
 				assertEqualE(t, cfg.IncludeRetryReason, test.config.IncludeRetryReason, fmt.Sprintf("Test %d: IncludeRetryReason mismatch", i))
+				assertEqualE(t, cfg.ServerSessionKeepAlive, test.config.ServerSessionKeepAlive, fmt.Sprintf("Test %d: ServerSessionKeepAlive mismatch", i))
 				assertEqualE(t, cfg.DisableConsoleLogin, test.config.DisableConsoleLogin, fmt.Sprintf("Test %d: DisableConsoleLogin mismatch", i))
 				assertEqualE(t, cfg.DisableSamlURLCheck, test.config.DisableSamlURLCheck, fmt.Sprintf("Test %d: DisableSamlURLCheck mismatch", i))
 				assertEqualE(t, cfg.OauthClientID, test.config.OauthClientID, fmt.Sprintf("Test %d: OauthClientID mismatch", i))
@@ -1416,7 +1377,6 @@ func TestParseDSN(t *testing.T) {
 				assertEqualE(t, cfg.CrlInMemoryCacheDisabled, test.config.CrlInMemoryCacheDisabled, "crl in memory cache disabled")
 				assertEqualE(t, cfg.CrlOnDiskCacheDisabled, test.config.CrlOnDiskCacheDisabled, "crl on disk cache disabled")
 				assertEqualE(t, cfg.CrlHTTPClientTimeout, test.config.CrlHTTPClientTimeout, "crl http client timeout")
-				assertEqualE(t, cfg.DisableTelemetry, test.config.DisableTelemetry, "disable telemetry")
 			case test.err != nil:
 				driverErrE, okE := test.err.(*SnowflakeError)
 				driverErrG, okG := err.(*SnowflakeError)
@@ -1839,15 +1799,6 @@ func TestDSN(t *testing.T) {
 		},
 		{
 			cfg: &Config{
-				User:         "u",
-				Password:     "p",
-				Account:      "a",
-				InsecureMode: true,
-			},
-			dsn: "u:p@a.snowflakecomputing.com:443?insecureMode=true&ocspFailOpen=true&validateDefaultParameters=true",
-		},
-		{
-			cfg: &Config{
 				User:              "u",
 				Password:          "p",
 				Account:           "a",
@@ -1860,17 +1811,6 @@ func TestDSN(t *testing.T) {
 				User:              "u",
 				Password:          "p",
 				Account:           "a",
-				InsecureMode:      true,
-				DisableOCSPChecks: false,
-			},
-			dsn: "u:p@a.snowflakecomputing.com:443?insecureMode=true&ocspFailOpen=true&validateDefaultParameters=true",
-		},
-		{
-			cfg: &Config{
-				User:              "u",
-				Password:          "p",
-				Account:           "a",
-				InsecureMode:      false,
 				DisableOCSPChecks: true,
 			},
 			dsn: "u:p@a.snowflakecomputing.com:443?disableOCSPChecks=true&ocspFailOpen=true&validateDefaultParameters=true",
@@ -2024,6 +1964,15 @@ func TestDSN(t *testing.T) {
 				MaxRetryCount:      30,
 			},
 			dsn: "u:p@a.b.c.snowflakecomputing.com:443?includeRetryReason=false&maxRetryCount=30&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
+		},
+		{
+			cfg: &Config{
+				User:                   "u",
+				Password:               "p",
+				Account:                "a.b.c",
+				ServerSessionKeepAlive: true,
+			},
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?ocspFailOpen=true&region=b.c&serverSessionKeepAlive=true&validateDefaultParameters=true",
 		},
 		{
 			cfg: &Config{

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -74,38 +74,6 @@ func TestTelemetrySQLException(t *testing.T) {
 	})
 }
 
-func TestDisableTelemetry(t *testing.T) {
-	config, err := ParseDSN(dsn)
-	if err != nil {
-		t.Error(err)
-	}
-	config.DisableTelemetry = true
-	sc, err := buildSnowflakeConn(context.Background(), *config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = authenticateWithConfig(sc); err != nil {
-		t.Fatal(err)
-	}
-	if !sc.cfg.DisableTelemetry {
-		t.Errorf("DisableTelemetry should be true. DisableTelemetry: %v", sc.cfg.DisableTelemetry)
-	}
-	if sc.telemetry.enabled {
-		t.Errorf("telemetry should be disabled.")
-	}
-}
-
-func TestEnableTelemetry(t *testing.T) {
-	runSnowflakeConnTest(t, func(sct *SCTest) {
-		if sct.sc.cfg.DisableTelemetry {
-			t.Errorf("DisableTelemetry should be false. DisableTelemetry: %v", sct.sc.cfg.DisableTelemetry)
-		}
-		if !sct.sc.telemetry.enabled {
-			t.Errorf("telemetry should be enabled.")
-		}
-	})
-}
-
 func funcPostTelemetryRespFail(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ map[string]string, _ []byte, _ time.Duration, _ currentTimeProvider, _ *Config) (*http.Response, error) {
 	return nil, errors.New("failed to upload metrics to telemetry")
 }

--- a/test_data/connections.toml
+++ b/test_data/connections.toml
@@ -45,7 +45,7 @@ schema = 'test_default_go'
 protocol = 'https'
 authenticator = 'oauth'
 token_file_path = './test_data/snowflake/session/token'
-insecureMode = true
+disable_ocsp_checks = true
 
 [snake-case]
 account = 'snowdriverswarsaw.us-west-2.aws'

--- a/test_data/wiremock/mappings/auth/password/successful_flow_with_telemetry.json
+++ b/test_data/wiremock/mappings/auth/password/successful_flow_with_telemetry.json
@@ -1,0 +1,64 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPathPattern": "/session/v1/login-request.*",
+        "method": "POST",
+        "bodyPatterns": [
+          {
+            "equalToJson" : {
+              "data": {
+                "LOGIN_NAME": "testUser",
+                "PASSWORD": "testPassword"
+              }
+            },
+            "ignoreExtraElements" : true
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "data": {
+            "masterToken": "master token",
+            "token": "session token",
+            "validityInSeconds": 3600,
+            "masterValidityInSeconds": 14400,
+            "displayUserName": "TEST_USER",
+            "serverVersion": "8.48.0 b2024121104444034239f05",
+            "firstLogin": false,
+            "remMeToken": null,
+            "remMeValidityInSeconds": 0,
+            "healthCheckInterval": 45,
+            "newClientForUpgrade": "3.12.3",
+            "sessionId": 1172562260498,
+            "parameters": [
+              {
+                "name": "CLIENT_PREFETCH_THREADS",
+                "value": 4
+              },
+              {
+                "name": "CLIENT_TELEMETRY_ENABLED",
+                "value": %CLIENT_TELEMETRY_ENABLED%
+              }
+            ],
+            "sessionInfo": {
+              "databaseName": "TEST_DB",
+              "schemaName": "TEST_GO",
+              "warehouseName": "TEST_XSMALL",
+              "roleName": "ANALYST"
+            },
+            "idToken": null,
+            "idTokenValidityInSeconds": 0,
+            "responseData": null,
+            "mfaToken": null,
+            "mfaTokenValidityInSeconds": 0
+          },
+          "code": null,
+          "message": null,
+          "success": true
+        }
+      }
+    }
+  ]
+}

--- a/transport.go
+++ b/transport.go
@@ -199,7 +199,7 @@ func (tf *transportFactory) createTransport(transportConfig *transportConfig) (h
 	}
 
 	// Handle no revocation checking path
-	if tf.config.DisableOCSPChecks || tf.config.InsecureMode {
+	if tf.config.DisableOCSPChecks {
 		logger.Debug("createTransport: skipping OCSP validation")
 		return tf.createNoRevocationTransport(transportConfig), nil
 	}
@@ -210,7 +210,7 @@ func (tf *transportFactory) createTransport(transportConfig *transportConfig) (h
 
 // validateRevocationConfig checks for conflicting revocation settings
 func (tf *transportFactory) validateRevocationConfig() error {
-	if !tf.config.DisableOCSPChecks && !tf.config.InsecureMode && tf.config.CertRevocationCheckMode != CertRevocationCheckDisabled {
+	if !tf.config.DisableOCSPChecks && tf.config.CertRevocationCheckMode != CertRevocationCheckDisabled {
 		return errors.New("both OCSP and CRL cannot be enabled at the same time, please disable one of them")
 	}
 	return nil

--- a/transport_test.go
+++ b/transport_test.go
@@ -10,7 +10,6 @@ func TestTransportFactoryErrorHandling(t *testing.T) {
 	// Test CreateCustomTLSTransport with conflicting OCSP and CRL settings
 	conflictingConfig := &Config{
 		DisableOCSPChecks:       false,
-		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 		tlsConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
@@ -28,7 +27,6 @@ func TestCreateStandardTransportErrorHandling(t *testing.T) {
 	// Test CreateStandardTransport with conflicting settings
 	conflictingConfig := &Config{
 		DisableOCSPChecks:       false,
-		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckEnabled,
 	}
 
@@ -43,7 +41,6 @@ func TestCreateCustomTLSTransportSuccess(t *testing.T) {
 	// Test successful creation with valid config
 	validConfig := &Config{
 		DisableOCSPChecks:       true,
-		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 		tlsConfig:               &tls.Config{InsecureSkipVerify: true},
 	}
@@ -59,7 +56,6 @@ func TestCreateStandardTransportSuccess(t *testing.T) {
 	// Test successful creation with valid config
 	validConfig := &Config{
 		DisableOCSPChecks:       true,
-		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 	}
 
@@ -79,7 +75,6 @@ func TestDirectTLSConfigUsage(t *testing.T) {
 
 	config := &Config{
 		DisableOCSPChecks:       true,
-		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 		tlsConfig:               customTLS, // Direct TLS config
 	}
@@ -136,7 +131,6 @@ func TestDirectTLSConfigOnly(t *testing.T) {
 
 	config := &Config{
 		DisableOCSPChecks:       true,
-		InsecureMode:            false,
 		CertRevocationCheckMode: CertRevocationCheckDisabled,
 		tlsConfig:               directTLS, // Direct config
 	}


### PR DESCRIPTION
### Description

SNOW-1881542 Cleanup Config struct
1. Removed `ClientIP`.
2. Unexported `MfaToken` and `IdToken`.
3. Removed `InsecureMode` - it is fully replaced by `DisableOCSPChecks` now.
4. Replaced `KeepSessionAlive` with `ServerSessionKeepAlive` - and also added it to DSN.
5. Removed `DisableTelemetry` and replaced it with regular session param `CLIENT_TELEMETRY_ENABLED`.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
