### PR TITLE
SNOW-1881542 Migrate context keys to private iota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Breaking changes:
 - Renamed `KeepSessionAlive` field in `Config` struct to `ServerSessionKeepAlive` to adjust with the remaining drivers (snowflakedb/gosnowflake#1692).
 - Removed `DisableTelemetry` field from `Config` struct. Use `CLIENT_TELEMETRY_ENABLED` session parameter instead (snowflakedb/gosnowflake#1692).
 - Removed stream chunk downloader. Use a regular, default downloader instead. (snowflakedb/gosnowflake#1702).
+- Migrated context keys to unexported types to avoid potential collisions. Use `gosnowflake.WithXXX` functions to create required contexts (snowflakedb/gosnowflake#1705).
 
 Bug fixes:
 

--- a/connection.go
+++ b/connection.go
@@ -55,17 +55,11 @@ const (
 type resultType string
 
 const (
-	snowflakeResultType contextKey = "snowflakeResultType"
-	execResultType      resultType = "exec"
-	queryResultType     resultType = "query"
+	execResultType  resultType = "exec"
+	queryResultType resultType = "query"
 )
 
-type execKey string
-
-const (
-	executionType          execKey = "executionType"
-	executionTypeStatement string  = "statement"
-)
+const executionTypeStatement string = "statement"
 
 // snowflakeConn manages its own context.
 // External cancellation should not be supported because the connection
@@ -123,10 +117,10 @@ func (sc *snowflakeConn) exec(
 		QueryContext: queryContext,
 	}
 	if key := ctx.Value(multiStatementCount); key != nil {
-		req.Parameters[string(multiStatementCount)] = key
+		req.Parameters["MULTI_STATEMENT_COUNT"] = key
 	}
 	if tag := ctx.Value(queryTag); tag != nil {
-		req.Parameters[string(queryTag)] = tag
+		req.Parameters["QUERY_TAG"] = tag
 	}
 	logger.WithContext(ctx).Debugf("parameters: %v", req.Parameters)
 

--- a/log.go
+++ b/log.go
@@ -15,10 +15,10 @@ import (
 )
 
 // SFSessionIDKey is context key of session id
-const SFSessionIDKey contextKey = "LOG_SESSION_ID"
+const SFSessionIDKey = sfSessionIDKey
 
-// SFSessionUserKey is context key of  user id of a session
-const SFSessionUserKey contextKey = "LOG_USER"
+// SFSessionUserKey is context key of user id of a session
+const SFSessionUserKey = sfSessionUserKey
 
 // map which stores a string which will be used as a log key to the function which
 // will be called to get the log value out of the context
@@ -466,7 +466,7 @@ func context2Fields(ctx context.Context) *rlog.Fields {
 
 	for i := 0; i < len(LogKeys); i++ {
 		if ctx.Value(LogKeys[i]) != nil {
-			fields[string(LogKeys[i])] = ctx.Value(LogKeys[i])
+			fields[LogKeys[i].String()] = ctx.Value(LogKeys[i])
 		}
 	}
 

--- a/util.go
+++ b/util.go
@@ -14,32 +14,50 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 )
 
-type contextKey string
+type contextKey int
 
 const (
-	multiStatementCount              contextKey = "MULTI_STATEMENT_COUNT"
-	asyncMode                        contextKey = "ASYNC_MODE_QUERY"
-	queryIDChannel                   contextKey = "QUERY_ID_CHANNEL"
-	snowflakeRequestIDKey            contextKey = "SNOWFLAKE_REQUEST_ID"
-	fetchResultByID                  contextKey = "SF_FETCH_RESULT_BY_ID"
-	filePutStream                    contextKey = "STREAMING_PUT_FILE"
-	fileGetStream                    contextKey = "STREAMING_GET_FILE"
-	fileTransferOptions              contextKey = "FILE_TRANSFER_OPTIONS"
-	enableHigherPrecision            contextKey = "ENABLE_HIGHER_PRECISION"
-	enableDecfloat                   contextKey = "ENABLE_DECFLOAT"
-	enableArrowBatchesUtf8Validation contextKey = "ENABLE_ARROW_BATCHES_UTF8_VALIDATION"
-	arrowBatches                     contextKey = "ARROW_BATCHES"
-	arrowAlloc                       contextKey = "ARROW_ALLOC"
-	arrowBatchesTimestampOption      contextKey = "ARROW_BATCHES_TIMESTAMP_OPTION"
-	queryTag                         contextKey = "QUERY_TAG"
-	enableStructuredTypes            contextKey = "ENABLE_STRUCTURED_TYPES"
-	embeddedValuesNullable           contextKey = "EMBEDDED_VALUES_NULLABLE"
-	describeOnly                     contextKey = "DESCRIBE_ONLY"
-	internalQuery                    contextKey = "INTERNAL_QUERY"
-	cancelRetry                      contextKey = "CANCEL_RETRY"
-	logQueryText                     contextKey = "LOG_QUERY_TEXT"
-	logQueryParameters               contextKey = "LOG_QUERY_PARAMETERS"
+	multiStatementCount contextKey = iota
+	asyncMode
+	queryIDChannel
+	snowflakeRequestIDKey
+	fetchResultByID
+	filePutStream
+	fileGetStream
+	fileTransferOptions
+	enableHigherPrecision
+	enableDecfloat
+	enableArrowBatchesUtf8Validation
+	arrowBatches
+	arrowAlloc
+	arrowBatchesTimestampOption
+	queryTag
+	enableStructuredTypes
+	embeddedValuesNullable
+	describeOnly
+	internalQuery
+	cancelRetry
+	logQueryText
+	logQueryParameters
+	snowflakeResultType
+	executionType
+	sfSessionIDKey
+	sfSessionUserKey
 )
+
+// contextKeyNames maps the log-relevant context keys to their display names.
+var contextKeyNames = map[contextKey]string{
+	sfSessionIDKey:   "LOG_SESSION_ID",
+	sfSessionUserKey: "LOG_USER",
+}
+
+// String returns a human-readable name for context keys used in logging.
+func (k contextKey) String() string {
+	if name, ok := contextKeyNames[k]; ok {
+		return name
+	}
+	return fmt.Sprintf("contextKey(%d)", int(k))
+}
 
 var (
 	defaultTimeProvider = &unixTimeProvider{}


### PR DESCRIPTION
### Description

SNOW-1881542 Migrate context keys to private iota

Migrated context keys from strings to private iota. Using a private iota fixes the problem with context key clashes.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
