### PR TITLE
NO-SNOW Add support for Go 1.26, drop support for Go 1.23

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
           - name: Setup go
             uses: actions/setup-go@v5
             with:
-              go-version: '1.24'
+              go-version: '1.25'
           - name: golangci-lint
             uses: golangci/golangci-lint-action@v7
             with:
@@ -49,7 +49,7 @@ jobs:
             fail-fast: false
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.23', '1.24', '1.25' ]
+                go: [ '1.24', '1.25', '1.26' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Ubuntu
         steps:
             - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.24'
+            go-version: '1.25'
         - name: Test
           shell: bash
           env:
@@ -112,7 +112,7 @@ jobs:
             fail-fast: false
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.23', '1.24', '1.25' ]
+                go: [ '1.24', '1.25', '1.26' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Mac
         steps:
             - uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.24'
+            go-version: '1.25'
         - name: Test
           shell: bash
           env:
@@ -173,7 +173,7 @@ jobs:
             fail-fast: false
             matrix:
                 cloud: [ 'AWS', 'AZURE', 'GCP' ]
-                go: [ '1.23', '1.24', '1.25' ]
+                go: [ '1.24', '1.25', '1.26' ]
         name: ${{ matrix.cloud }} Go ${{ matrix.go }} on Windows
         steps:
             - uses: actions/checkout@v4
@@ -220,7 +220,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.24'
+            go-version: '1.25'
         - name: Test
           shell: bash
           env:
@@ -244,7 +244,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.24'
+            go-version: '1.25'
         - name: Test
           shell: bash
           env:
@@ -267,7 +267,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.24'
+            go-version: '1.25'
         - uses: actions/setup-python@v5
           with:
             python-version: '3.x'
@@ -296,7 +296,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.24'
+            go-version: '1.25'
         - name: Test
           shell: bash
           env:
@@ -316,11 +316,11 @@ jobs:
             matrix:
               cloud_go:
               - cloud: 'AWS'
-                go: '1.23.4'
-              - cloud: 'AZURE'
                 go: '1.24.2'
-              - cloud: 'GCP'
+              - cloud: 'AZURE'
                 go: '1.25.0'
+              - cloud: 'GCP'
+                go: '1.26.0'
         name: ${{ matrix.cloud_go.cloud }} Go ${{ matrix.cloud_go.go }} on Rocky Linux 9
         steps:
             - uses: actions/checkout@v4
@@ -342,11 +342,11 @@ jobs:
         matrix:
           cloud_go:
             - cloud: 'AWS'
-              go: '1.23'
-            - cloud: 'AZURE'
               go: '1.24'
-            - cloud: 'GCP'
+            - cloud: 'AZURE'
               go: '1.25'
+            - cloud: 'GCP'
+              go: '1.26'
       name: ${{ matrix.cloud_go.cloud }} Go ${{ matrix.cloud_go.go }} on Ubuntu ARM
       steps:
         - uses: actions/checkout@v4
@@ -385,11 +385,11 @@ jobs:
         matrix:
           cloud_go:
             - cloud: 'AWS'
-              go: '1.23'
-            - cloud: 'AZURE'
               go: '1.24'
-            - cloud: 'GCP'
+            - cloud: 'AZURE'
               go: '1.25'
+            - cloud: 'GCP'
+              go: '1.26'
       name: ${{ matrix.cloud_go.cloud }} Go ${{ matrix.cloud_go.cloud }} on Windows ARM
       steps:
         - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Release
 
+New features:
+
+- Added support for Go 1.26, dropped support for Go 1.23 (snowflakedb/gosnowflake#1707).
+
 Bug fixes:
 
 - Added panic recovery block for stage file uploads and downloads operation (snowflakedb/gosnowflake#1687).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following software packages are required to use the Go Snowflake Driver.
 
 ## Go
 
-The latest driver requires the [Go language](https://golang.org/) 1.23 or higher. The supported operating systems are 64-bits Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
+The latest driver requires the [Go language](https://golang.org/) 1.24 or higher. The supported operating systems are 64-bits Linux, Mac OS, and Windows, but you may run the driver on other platforms if the Go language works correctly on those platforms.
 
 # Installation
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snowflakedb/gosnowflake
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
### Description

NO-SNOW Add support for Go 1.26, drop support for Go 1.23

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
