### PR TITLE
SNOW-3161003 Fix isPrefixEqual to actually compare the second URL's port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug fixes:
 
 - Added panic recovery block for stage file uploads and downloads operation (snowflakedb/gosnowflake#1687).
 - Fixed WIF metadata request from Azure container, manifested with HTTP 400 error (snowflakedb/gosnowflake#1701).
+- Fixed SAML authentication port validation bypass in `isPrefixEqual` where the second URL's port was never checked (snowflakedb/gosnowflake#1712).
 
 ## 1.19.0
 

--- a/authokta.go
+++ b/authokta.go
@@ -191,8 +191,8 @@ func isPrefixEqual(u1 *url.URL, u2 *url.URL) bool {
 	if p1 == "" && u1.Scheme == "https" {
 		p1 = "443"
 	}
-	p2 := u1.Port()
-	if p2 == "" && u1.Scheme == "https" {
+	p2 := u2.Port()
+	if p2 == "" && u2.Scheme == "https" {
 		p2 = "443"
 	}
 	return u1.Hostname() == u2.Hostname() && p1 == p2 && u1.Scheme == u2.Scheme

--- a/authokta_test.go
+++ b/authokta_test.go
@@ -36,6 +36,37 @@ func TestUnitPostBackURL(t *testing.T) {
 	}
 }
 
+func TestUnitIsPrefixEqual(t *testing.T) {
+	mustParse := func(raw string) *url.URL {
+		u, err := url.Parse(raw)
+		assertNilF(t, err, "parsing URL: "+raw)
+		return u
+	}
+	tests := []struct {
+		name     string
+		u1       string
+		u2       string
+		expected bool
+	}{
+		{"same origin", "https://abc.com", "https://abc.com", true},
+		{"same origin with path", "https://abc.com/foo", "https://abc.com/bar", true},
+		{"explicit 443 vs implicit", "https://abc.com:443", "https://abc.com", true},
+		{"implicit vs explicit 443", "https://abc.com", "https://abc.com:443", true},
+		{"both explicit same port", "https://abc.com:8443", "https://abc.com:8443", true},
+		{"different port on same host", "https://abc.com", "https://abc.com:9443", false},
+		{"different port both explicit", "https://abc.com:8443", "https://abc.com:9443", false},
+		{"different hostname", "https://abc.com", "https://xyz.com", false},
+		{"different scheme", "https://abc.com", "http://abc.com", false},
+		{"http port mismatch", "http://abc.com", "http://abc.com:9090", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPrefixEqual(mustParse(tc.u1), mustParse(tc.u2))
+			assertEqualF(t, got, tc.expected, tc.name)
+		})
+	}
+}
+
 func getTestError(_ context.Context, _ *snowflakeRestful, _ *url.URL, _ map[string]string, _ time.Duration) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,


### PR DESCRIPTION
isPrefixEqual had a copy-paste bug where both p1 and p2 were derived from u1, meaning the port of u2 was never checked. This made the port validation in SAML authentication a no-op — URLs on the same hostname but different ports would incorrectly pass the prefix check.

Fix by reading p2 from u2 instead of u1, and add table-driven unit tests covering port mismatch scenarios that would have passed before the fix.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
