### PR TITLE
SNOW-3166926 Fix tokenFilePath DSN validation false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Bug fixes:
 - Fixed WIF metadata request from Azure container, manifested with HTTP 400 error (snowflakedb/gosnowflake#1701).
 - Fixed SAML authentication port validation bypass in `isPrefixEqual` where the second URL's port was never checked (snowflakedb/gosnowflake#1712).
 - Fixed a race condition in OCSP cache clearer (snowflakedb/gosnowflake#1704).
+- Fixed `tokenFilePath` DSN parameter triggering false validation error claiming both `token` and `tokenFilePath` were specified when only `tokenFilePath` was provided in the DSN string (snowflakedb/gosnowflake#1715).
 
 ## 1.19.0
 

--- a/dsn.go
+++ b/dsn.go
@@ -176,6 +176,8 @@ func (c *Config) getToken() (string, error) {
 	return c.Token, nil
 }
 
+var errTokenConfigConflict = errors.New("token and tokenFilePath cannot be specified at the same time")
+
 // Validate enables testing if config is correct.
 // A driver client may call it manually, but it is also called during opening first connection.
 func (c *Config) Validate() error {
@@ -188,7 +190,7 @@ func (c *Config) Validate() error {
 		return errors.New("WorkloadIdentityImpersonationPath is not supported for Azure")
 	}
 	if c.Token != "" && c.TokenFilePath != "" {
-		return errors.New("token and tokenFilePath cannot be specified at the same time")
+		return errTokenConfigConflict
 	}
 	return nil
 }
@@ -1013,10 +1015,6 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.Token = value
 		case "tokenFilePath":
 			cfg.TokenFilePath = value
-			cfg.Token, err = readToken(value)
-			if err != nil {
-				return
-			}
 		case "tlsConfigName":
 			cfg.TLSConfigName = value
 		case "workloadIdentityProvider":

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1172,7 +1172,6 @@ func TestParseDSN(t *testing.T) {
 				CloudStorageTimeout:       defaultCloudStorageTimeout,
 				IncludeRetryReason:        ConfigBoolTrue,
 				DisableSamlURLCheck:       ConfigBoolFalse,
-				Token:                     "mock_token123456",
 				TokenFilePath:             "test_data/snowflake/session/token",
 			},
 			ocspMode: ocspModeFailOpen,
@@ -2427,4 +2426,22 @@ func TestDSNParsingWithTLSConfig(t *testing.T) {
 
 		})
 	}
+}
+
+func TestTokenAndTokenFilePathValidation(t *testing.T) {
+	cfg := &Config{
+		Account:       "a",
+		User:          "u",
+		Password:      "p",
+		Token:         "direct-token",
+		TokenFilePath: "test_data/snowflake/session/token",
+	}
+	assertErrIsE(t, cfg.Validate(), errTokenConfigConflict, "Expected validation error when both Token and TokenFilePath are set")
+
+	cfg.TokenFilePath = ""
+	assertNilE(t, cfg.Validate(), "Should have accepted Token on its own")
+
+	cfg.Token = ""
+	cfg.TokenFilePath = "test_data/snowflake/session/token"
+	assertNilE(t, cfg.Validate(), "Should have accepted TokenFilePath on its own")
 }


### PR DESCRIPTION
The tokenFilePath DSN parameter was unusable due to a premature token file read during DSN parsing that triggered a false validation error.

When parsing the tokenFilePath DSN parameter, the code immediately read the token file and populated BOTH cfg.TokenFilePath and cfg.Token. Later validation checked if both fields were set and rejected the configuration with "token and tokenFilePath cannot be specified at the same time", even though the user only specified tokenFilePath in the DSN.

This PR removes the premature token file read during DSN parsing. In addition, remove redundant validation in parseDSNParams.

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
