### PR TITLE
SNOW-3169547 Update Jenkins job to use main branch instead of bptp-stable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ timestamps {
       env.GIT_COMMIT = scmInfo.GIT_COMMIT
     }
     params = [
-      string(name: 'svn_revision', value: 'bptp-stable'),
+      string(name: 'svn_revision', value: 'main'),
       string(name: 'branch', value: 'main'),
       string(name: 'client_git_commit', value: scmInfo.GIT_COMMIT),
       string(name: 'client_git_branch', value: scmInfo.GIT_BRANCH),


### PR DESCRIPTION
Changed svn_revision parameter from 'bptp-stable' to 'main' to match the updated Jenkins job configuration.

This prevents git checkout failures when the refspec doesn't include tags and ensures the job uses the main branch of snowflake-eng/snowflake for accessing test infrastructure.

Depends on: jenkins_utils/25056


