### PR TITLE
Add headless SSO authentication

### DIFF
--- a/authexternalbrowser.go
+++ b/authexternalbrowser.go
@@ -1,6 +1,7 @@
 package gosnowflake
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -12,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +31,8 @@ You can close this window now and go back where you started from.
 
 	bufSize = 8192
 )
+
+var ErrBrowserOpen = errors.New("browser open error")
 
 // Builds a response to show to the user after successfully
 // getting a response from Snowflake.
@@ -94,9 +98,34 @@ func openBrowser(browserURL string) error {
 	err = browser.OpenURL(browserURL)
 	if err != nil {
 		logger.Errorf("failed to open a browser. err: %v", err)
-		return err
+		return fmt.Errorf("%w: %v", ErrBrowserOpen, err)
 	}
 	return nil
+}
+
+func promptForRedirectedURL(browserURL string) (string, error) {
+	fmt.Println(browserURL)
+	fmt.Println("We were unable to open a browser window for you, please open the url above manually then paste the URL you are redirected to into the terminal.")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("error reading input: %w", err)
+	}
+
+	return strings.TrimSpace(input), nil
+}
+
+func extractTokenFromURL(rawURL string) ([]byte, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing input url: %w", err)
+	}
+	token := u.Query().Get("token")
+	if token == "" {
+		return nil, fmt.Errorf("error getting token from input url")
+	}
+	return []byte(token), nil
 }
 
 // Gets the IDP Url and Proof Key from Snowflake.
@@ -265,6 +294,19 @@ func doAuthenticateByExternalBrowser(ctx context.Context, sr *snowflakeRestful, 
 	}
 
 	if err = defaultSamlResponseProvider().run(loginURL); err != nil {
+		if errors.Is(err, ErrBrowserOpen) {
+			logger.WithContext(ctx).Infof(
+				"error while opening browser: %v. Falling back to headless SAML response provider",
+				err,
+			)
+			headlessProvider := &headlessSamlResponseProvider{}
+			if err = headlessProvider.run(loginURL); err != nil {
+				logger.Errorf("error while attempting headless auth. err: %v", err)
+				return authenticateByExternalBrowserResult{nil, nil, err}
+			}
+			return authenticateByExternalBrowserResult{headlessProvider.token, []byte(proofKey), nil}
+		}
+
 		return authenticateByExternalBrowserResult{nil, nil, err}
 	}
 
@@ -349,6 +391,19 @@ type externalBrowserSamlResponseProvider struct {
 
 func (e externalBrowserSamlResponseProvider) run(url string) error {
 	return openBrowser(url)
+}
+
+type headlessSamlResponseProvider struct {
+	token []byte
+}
+
+func (h *headlessSamlResponseProvider) run(url string) error {
+	redirectedURL, err := promptForRedirectedURL(url)
+	if err != nil {
+		return err
+	}
+	h.token, err = extractTokenFromURL(redirectedURL)
+	return err
 }
 
 var defaultSamlResponseProvider = func() samlResponseProvider {


### PR DESCRIPTION
### Description

Make headless SSO authentication possible to enable SSO when running in the container, similar to how [snowflake-connector-python](https://github.com/snowflakedb/snowflake-connector-python) does it by prompting the user to open the URL and paste back the redirected URL with the token.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
