### PR TITLE
NO-SNOW Update CI/CD Go version to 1.26

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -98,7 +98,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.25'
+            go-version: '1.26'
         - name: Test
           shell: bash
           env:
@@ -161,7 +161,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.25'
+            go-version: '1.26'
         - name: Test
           shell: bash
           env:
@@ -229,7 +229,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: ${{ matrix.go }}
+            go-version: '1.26'
         - name: Test
           shell: bash
           env:
@@ -264,7 +264,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.25'
+            go-version: '1.26'
         - name: Test
           shell: bash
           env:
@@ -288,7 +288,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.25'
+            go-version: '1.26'
         - name: Test
           shell: bash
           env:
@@ -311,7 +311,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.25'
+            go-version: '1.26'
         - uses: actions/setup-python@v5
           with:
             python-version: '3.x'
@@ -340,7 +340,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.25'
+            go-version: '1.26'
         - name: Test
           shell: bash
           env:
@@ -364,7 +364,7 @@ jobs:
               - cloud: 'AZURE'
                 go: '1.25.0'
               - cloud: 'GCP'
-                go: '1.26.0'
+                go: '1.26'
         name: ${{ matrix.cloud_go.cloud }} Go ${{ matrix.cloud_go.go }} on Rocky Linux 9
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -371,7 +371,7 @@ jobs:
               - cloud: 'AZURE'
                 go: '1.25.0'
               - cloud: 'GCP'
-                go: '1.26'
+                go: '1.26.3'
         name: ${{ matrix.cloud_go.cloud }} Go ${{ matrix.cloud_go.go }} on Rocky Linux 9
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,6 +27,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Go version used by all single-version jobs (lint, *-no-home, fipsOnly,
+  # *-minicore-disabled, ecc). Multi-version compatibility matrices below
+  # intentionally pin literal versions and cannot reference env (GitHub
+  # Actions does not expose the env context to strategy.matrix).
+  GO_VERSION: '1.26'
+
 jobs:
     lint:
         runs-on: ubuntu-latest
@@ -36,7 +43,7 @@ jobs:
           - name: Setup go
             uses: actions/setup-go@v5
             with:
-              go-version: '1.26'
+              go-version: ${{ env.GO_VERSION }}
           - name: golangci-lint
             uses: golangci/golangci-lint-action@v7
             with:
@@ -98,7 +105,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - name: Test
           shell: bash
           env:
@@ -161,7 +168,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - name: Test
           shell: bash
           env:
@@ -229,7 +236,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - name: Test
           shell: bash
           env:
@@ -264,7 +271,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - name: Test
           shell: bash
           env:
@@ -288,7 +295,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - name: Test
           shell: bash
           env:
@@ -311,7 +318,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - uses: actions/setup-python@v5
           with:
             python-version: '3.x'
@@ -340,7 +347,7 @@ jobs:
         - name: Setup go
           uses: actions/setup-go@v5
           with:
-            go-version: '1.26'
+            go-version: ${{ env.GO_VERSION }}
         - name: Test
           shell: bash
           env:


### PR DESCRIPTION
## Summary

Updates the GitHub Actions CI/CD workflow so every single-version job runs on Go 1.26 (latest minor), centralizes the Go version in one place, and fixes a latent bug in the `fipsOnly` job.

## Changes

- Bumps the remaining `'1.25'` / `'1.26.0'` Go pins in `.github/workflows/build-test.yml` to `'1.26'`, so the `lint`, `*-no-home`, `*-minicore-disabled`, and `ecc` jobs all run on the latest minor line. The multi-version compatibility matrices (`build-test-{linux,mac,windows}`, `build-test-rockylinux9`, `build-test-{ubuntu,windows}-arm`) keep enumerating `1.24`, `1.25`, `1.26` for cross-version coverage.
- Introduces a workflow-level `env: GO_VERSION: '1.26'` and replaces the eight standalone `go-version: '1.26'` literals with `${{ env.GO_VERSION }}` so future bumps are a one-line change. Matrices keep literal versions because GitHub Actions does not expose the `env` context to `strategy.matrix`.
- Fixes the `fipsOnly` job, which referenced `${{ matrix.go }}` despite having no `strategy.matrix` defined; it now uses `${{ env.GO_VERSION }}` like the other single-version jobs.
- Pins the Rocky Linux 9 GCP matrix entry to a full patch version (`'1.26.3'`). That job builds its own Go inside a Docker layer via `https://golang.org/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz`, which only resolves fully-qualified releases — the same reason the sibling AWS (`'1.24.2'`) and AZURE (`'1.25.0'`) entries pin patch versions too.

## Testing

Full CI is green on `abe02f7e`: every Build-and-Test cell (Ubuntu/Mac/Windows × AWS/AZURE/GCP × Go 1.24/1.25/1.26), Rocky Linux 9, ARM, no-HOME, minicore-disabled, FIPS, elliptic-curves, linter, CodeQL, Semgrep, Snyk, and CLA pass. The two red `Jenkins` / `continuous-integration/jenkins/pr-merge` checks are pre-existing legacy-infra noise (same pattern on already-merged PR #1798) and are not caused by this change.
