### PR TITLE
fix(config): derive account from host in FillMissingConfigParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming release
 
+Bug fixes:
+
+- Fixed empty `Account` when connecting with programmatic `Config` and `database/sql.Connector` by deriving `Account` from the first DNS label of `Host` in `FillMissingConfigParameters` when `Host` matches the Snowflake hostname pattern (snowflakedb/gosnowflake#1432).
+
 ## 2.0.1
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bug fixes:
 
-- Fixed empty `Account` when connecting with programmatic `Config` and `database/sql.Connector` by deriving `Account` from the first DNS label of `Host` in `FillMissingConfigParameters` when `Host` matches the Snowflake hostname pattern (snowflakedb/gosnowflake#1432).
+- Fixed empty `Account` when connecting with programmatic `Config` and `database/sql.Connector` by deriving `Account` from the first DNS label of `Host` in `FillMissingConfigParameters` when `Host` matches the Snowflake hostname pattern (snowflakedb/gosnowflake#1772).
 
 ## 2.0.1
 

--- a/doc.go
+++ b/doc.go
@@ -224,8 +224,8 @@ Alternatively, use OpenWithConfig() function to create a database handle with th
 
 # Connection Config
 
-You can also connect to your warehouse using the connection config. The dbSql library states that when you want to take advantage of driver-specific connection features that aren’t
-available in a connection string. Each driver supports its own set of connection properties, often providing ways to customize the connection request specific to the DBMS
+You can also connect to your warehouse using the connection config. The database/sql package is appropriate when you want driver-specific connection features that aren’t
+available in a connection string. Each driver supports its own set of connection properties, often providing ways to customize the connection request specific to the DBMS.
 For example:
 
 	c := &gosnowflake.Config{
@@ -234,23 +234,27 @@ For example:
 	connector := gosnowflake.NewConnector(gosnowflake.SnowflakeDriver{}, *c)
 	db := sql.OpenDB(connector)
 
-If you are using this method, you dont need to pass a driver name to specify the driver type in which
+When Host is a full Snowflake hostname (the host string contains ".snowflakecomputing.", consistent with DSN-based URLs) and Account is left empty, the driver derives Account from the first DNS label of Host while completing configuration (for example, database/sql.Connector Connect invokes FillMissingConfigParameters). If Host does not contain that substring, you must set Account explicitly (for example private-link or custom endpoints).
+
+When Account is already non-empty, it is kept as provided. Truncating a dotted account value from DSN query parameters happens inside ParseDSN before FillMissingConfigParameters; that normalization does not apply to every programmatic Config.
+
+If you are using this method, you don't need to pass a driver name to specify the driver type in which
 you are looking to connect. Since the driver name is not needed, you can optionally bypass driver registration
-on startup. To do this, set `GOSNOWFLAKE_SKIP_REGISTRATION` in your environment. This is useful you wish to
-register multiple verions of the driver.
+on startup. To do this, set `GOSNOWFLAKE_SKIP_REGISTRATION` in your environment. This is useful if you wish to
+register multiple versions of the driver.
 
 Note: `GOSNOWFLAKE_SKIP_REGISTRATION` should not be used if sql.Open() is used as the method
 to connect to the server, as sql.Open will require registration so it can map the driver name
 to the driver type, which in this case is "snowflake" and SnowflakeDriver{}.
 
-You can load the connnection configuration with .toml file format.
+You can load the connection configuration with .toml file format.
 With two environment variables, `SNOWFLAKE_HOME` (`connections.toml` file directory) and `SNOWFLAKE_DEFAULT_CONNECTION_NAME` (DSN name),
 the driver will search the config file and load the connection. You can find how to use this connection way at ./cmd/tomlfileconnection
 or Snowflake doc: https://docs.snowflake.com/en/developer-guide/snowflake-cli-v2/connecting/specify-credentials
 
 If the connection.toml file is readable by others, a warning will be logged. To disable it you need to set the environment variable `SF_SKIP_WARNING_FOR_READ_PERMISSIONS_ON_CONFIG_FILE` to true.
 
-It you wish to specify a custom transporter (e.g. to provide a custom TLS config to be used with your custom truststore) pass it through the `NewConnector`. Example:
+If you wish to specify a custom transporter (e.g. to provide a custom TLS config to be used with your custom truststore) pass it through the `NewConnector`. Example:
 
 	tlsConfig := &tls.Config{
 	    // your custom fields here
@@ -262,7 +266,7 @@ It you wish to specify a custom transporter (e.g. to provide a custom TLS config
 	    },
 	}
 
-	connector := NewConnector(SnowflakeDriver{}, *cfg)
+	connector := NewConnector(SnowflakeDriver{}, config)
 	db := sql.OpenDB(connector)
 
 As an alternative, you can use the `RegisterTLSConfig` / `DeregisterTLSConfig` functions as seen in the unit tests: https://github.com/snowflakedb/gosnowflake/blob/v1.16.0/transport_test.go#L127
@@ -293,7 +297,7 @@ When these parameters are provided in the connection string or DSN, they take pr
 | `proxyUser`     | Username for proxy authentication.                                          |         |
 | `proxyPassword` | Password for proxy authentication.                                          |         |
 | `proxyProtocol` | Protocol to use for proxy connection. Valid values: `http`, `https`.        | `http`  |
-| `NoProxy“       | Comma-separated list of hosts that should bypass the proxy.                 |         |
+| `noProxy`       | Comma-separated list of hosts that should bypass the proxy.                 |         |
 
 For more details, please refer to the example in ./cmd/proxyconnection.
 

--- a/internal/config/assert_test.go
+++ b/internal/config/assert_test.go
@@ -46,6 +46,11 @@ func assertTrueE(t *testing.T, actual bool, descriptions ...string) {
 	errorOnNonEmpty(t, validateEqual(actual, true, descriptions...))
 }
 
+func assertTrueF(t *testing.T, actual bool, descriptions ...string) {
+	t.Helper()
+	fatalOnNonEmpty(t, validateEqual(actual, true, descriptions...))
+}
+
 func assertFalseE(t *testing.T, actual bool, descriptions ...string) {
 	t.Helper()
 	errorOnNonEmpty(t, validateEqual(actual, false, descriptions...))

--- a/internal/config/dsn.go
+++ b/internal/config/dsn.go
@@ -398,14 +398,7 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 			return
 		}
 	}
-	if cfg.Account == "" && hostIncludesTopLevelDomain(cfg.Host) {
-		posDot := strings.Index(cfg.Host, ".")
-		if posDot > 0 {
-			cfg.Account = cfg.Host[:posDot]
-		}
-	}
-	posDot := strings.Index(cfg.Account, ".")
-	if posDot >= 0 {
+	if posDot := strings.Index(cfg.Account, "."); posDot >= 0 {
 		cfg.Account = cfg.Account[:posDot]
 	}
 
@@ -449,8 +442,30 @@ func ParseDSN(dsn string) (cfg *Config, err error) {
 	return cfg, nil
 }
 
+// applyAccountFromHostIfMissing sets Account to the first DNS label of Host when Account is empty
+// and Host matches the Snowflake hostname heuristic (hostIncludesTopLevelDomain). FillMissingConfigParameters
+// invokes this so programmatic Config (e.g. database/sql.Connector) matches behavior that DSN users
+// already got via ParseDSN plus FillMissingConfigParameters. ParseDSN still truncates dotted account
+// values from parameters before FillMissingConfigParameters; that step does not apply to non-empty
+// Account set directly on a programmatic Config.
+func applyAccountFromHostIfMissing(cfg *Config) {
+	if strings.TrimSpace(cfg.Account) != "" {
+		return
+	}
+	if !hostIncludesTopLevelDomain(cfg.Host) {
+		return
+	}
+	posDot := strings.Index(cfg.Host, ".")
+	if posDot <= 0 {
+		return
+	}
+	cfg.Account = cfg.Host[:posDot]
+}
+
 // FillMissingConfigParameters fills in default values for missing config parameters.
 func FillMissingConfigParameters(cfg *Config) error {
+	applyAccountFromHostIfMissing(cfg)
+
 	posDash := strings.LastIndex(cfg.Account, "-")
 	if posDash > 0 {
 		if strings.Contains(strings.ToLower(cfg.Host), ".global.") {

--- a/internal/config/dsn_test.go
+++ b/internal/config/dsn_test.go
@@ -2407,6 +2407,52 @@ func TestTokenAndTokenFilePathValidation(t *testing.T) {
 	assertNilE(t, cfg.Validate(), "Should have accepted TokenFilePath on its own")
 }
 
+func TestFillMissingConfigParametersDerivesAccountFromHost(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "myacct.us-east-1.snowflakecomputing.com",
+		Port:          443,
+		Account:       "",
+		Authenticator: AuthTypeSnowflake,
+	}
+	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters")
+	if cfg.Account != "myacct" {
+		t.Fatalf("Account: want myacct, got %q", cfg.Account)
+	}
+}
+
+func TestFillMissingConfigParametersDerivesAccountFromCNHost(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "myacct.cn-north-1.snowflakecomputing.cn",
+		Port:          443,
+		Account:       "",
+		Authenticator: AuthTypeSnowflake,
+	}
+	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters")
+	if cfg.Account != "myacct" {
+		t.Fatalf("Account: want myacct, got %q", cfg.Account)
+	}
+}
+
+func TestFillMissingConfigParametersNonSnowflakeHostRequiresAccount(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "snowflake.internal.example.com",
+		Port:          443,
+		Account:       "",
+		Authenticator: AuthTypeSnowflake,
+	}
+	err := FillMissingConfigParameters(cfg)
+	assertNotNilF(t, err, "expected error for empty Account with non-Snowflake host")
+	sfErr, ok := err.(*sferrors.SnowflakeError)
+	assertTrueF(t, ok, "expected SnowflakeError")
+	assertEqualE(t, sfErr.Number, sferrors.ErrCodeEmptyAccountCode, "error number")
+}
+
 // helper function to generate PKCS8 encoded base64 string of a private key
 func generatePKCS8StringSupress(key *rsa.PrivateKey) string {
 	// Error would only be thrown when the private key type is not supported


### PR DESCRIPTION
### Description

SNOW-XXX (replace if applicable; community context: fixes https://github.com/snowflakedb/gosnowflake/issues/1432)

Programmatic `Config` with a full Snowflake `Host` and empty `Account` worked when built through `ParseDSN`, but `database/sql.Connector` paths call `FillMissingConfigParameters` without that earlier step, so `Account` stayed empty and connect failed with the empty-account error.

This change derives `Account` from the first DNS label of `Host` when `Account` is blank and `Host` matches the existing Snowflake hostname heuristic (`hostIncludesTopLevelDomain`), at the start of `FillMissingConfigParameters`. Dotted-account truncation from DSN query parameters remains in `ParseDSN` only; non-empty programmatic `Account` values are unchanged.

`doc.go` documents that split, fixes a few typos, corrects the `NewConnector` example variable name, and fixes the proxy parameter table row to `noProxy`. Tests cover US-style host, China region host, and a non-Snowflake internal hostname that still requires an explicit `Account`.

### Checklist

- [ ] Added proper logging (if possible) (not applicable)
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary (`doc.go` package documentation)
