### PR TITLE
SNOW-2875919 Use metadata.google.internal for GCP WIF to support IPv6-only instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bug fixes:
 - Fixed empty `Account` when connecting with programmatic `Config` and `database/sql.Connector` by deriving `Account` from the first DNS label of `Host` in `FillMissingConfigParameters` when `Host` matches the Snowflake hostname pattern (snowflakedb/gosnowflake#1772).
 - Fixed PAT (Programmatic Access Token) `authenticator` to actually require the Token or TokenFilePath field, instead of silently accepting Password which was never forwarded (snowflakedb/gosnowflake#1772).
 - Fix logger reporting incorrect source location when called without `WithContext` (snowflakedb/gosnowflake#1768).
+- GCP WIF attestation now uses hostname `metadata.google.internal` instead of the IPv4 link-local address, so it works on IPv6-only GCP VMs (snowflakedb/gosnowflake#1775).
 
 ## 2.0.1
 

--- a/auth_wif.go
+++ b/auth_wif.go
@@ -32,7 +32,8 @@ const (
 
 	gcpMetadataFlavorHeaderName  = "Metadata-Flavor"
 	gcpMetadataFlavor            = "Google"
-	defaultMetadataServiceBase   = "http://169.254.169.254"
+	defaultGcpMetadataServiceBase   = "http://metadata.google.internal"
+	defaultAzureMetadataServiceBase = "http://169.254.169.254"
 	defaultGcpIamCredentialsBase = "https://iamcredentials.googleapis.com"
 	snowflakeAudience            = "snowflakecomputing.com"
 )
@@ -70,7 +71,7 @@ func createWifAttestationProvider(ctx context.Context, cfg *Config, telemetry *s
 		gcpCreator: &gcpIdentityAttestationCreator{
 			cfg:                    cfg,
 			telemetry:              telemetry,
-			metadataServiceBaseURL: defaultMetadataServiceBase,
+			metadataServiceBaseURL: defaultGcpMetadataServiceBase,
 			iamCredentialsURL:      defaultGcpIamCredentialsBase,
 		},
 		azureCreator: &azureIdentityAttestationCreator{
@@ -78,7 +79,7 @@ func createWifAttestationProvider(ctx context.Context, cfg *Config, telemetry *s
 			cfg:                              cfg,
 			telemetry:                        telemetry,
 			workloadIdentityEntraResource:    determineEntraResource(cfg),
-			azureMetadataServiceBaseURL:      defaultMetadataServiceBase,
+			azureMetadataServiceBaseURL:      defaultAzureMetadataServiceBase,
 		},
 		oidcCreator: &oidcIdentityAttestationCreator{token: func() (string, error) { return sfconfig.GetToken(cfg) }},
 	}

--- a/auth_wif.go
+++ b/auth_wif.go
@@ -30,12 +30,12 @@ const (
 	azureWif wifProviderType = "AZURE"
 	oidcWif  wifProviderType = "OIDC"
 
-	gcpMetadataFlavorHeaderName  = "Metadata-Flavor"
-	gcpMetadataFlavor            = "Google"
+	gcpMetadataFlavorHeaderName     = "Metadata-Flavor"
+	gcpMetadataFlavor               = "Google"
 	defaultGcpMetadataServiceBase   = "http://metadata.google.internal"
 	defaultAzureMetadataServiceBase = "http://169.254.169.254"
-	defaultGcpIamCredentialsBase = "https://iamcredentials.googleapis.com"
-	snowflakeAudience            = "snowflakecomputing.com"
+	defaultGcpIamCredentialsBase    = "https://iamcredentials.googleapis.com"
+	snowflakeAudience               = "snowflakecomputing.com"
 )
 
 type wifProviderType string

--- a/auth_wif_test.go
+++ b/auth_wif_test.go
@@ -772,7 +772,8 @@ func TestWorkloadIdentityAuthOnCloudVM(t *testing.T) {
 				} else {
 					config.WorkloadIdentityProvider = "OIDC"
 					config.Token = func() string {
-						cmd := exec.Command("wget", "-O", "-", "--header=Metadata-Flavor: Google", "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com")
+						metadataURL := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com", defaultGcpMetadataServiceBase)
+						cmd := exec.Command("wget", "-O", "-", "--header=Metadata-Flavor: Google", metadataURL)
 						output, err := cmd.Output()
 						if err != nil {
 							t.Fatalf("error executing GCP metadata request: %v", err)

--- a/auth_wif_test.go
+++ b/auth_wif_test.go
@@ -772,7 +772,7 @@ func TestWorkloadIdentityAuthOnCloudVM(t *testing.T) {
 				} else {
 					config.WorkloadIdentityProvider = "OIDC"
 					config.Token = func() string {
-						cmd := exec.Command("wget", "-O", "-", "--header=Metadata-Flavor: Google", "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com")
+						cmd := exec.Command("wget", "-O", "-", "--header=Metadata-Flavor: Google", "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=snowflakecomputing.com")
 						output, err := cmd.Output()
 						if err != nil {
 							t.Fatalf("error executing GCP metadata request: %v", err)


### PR DESCRIPTION
## Summary
- Split `defaultMetadataServiceBase` (`169.254.169.254`) into `defaultGcpMetadataServiceBase` (`metadata.google.internal`) and `defaultAzureMetadataServiceBase` (`169.254.169.254`)
- GCP WIF attestation now uses the hostname that resolves to both IPv4 and IPv6 via DNS, enabling it to work on IPv6-only GCP VMs
- Updated integration test to use `metadata.google.internal` consistently

## Context
On IPv6-only cloud instances, the IPv4 link-local address `169.254.169.254` is unreachable. GCP platform detection already uses `metadata.google.internal` (which resolves correctly on both IPv4 and IPv6 networks), but WIF attestation was still using the hardcoded IPv4 address.

- **AWS**: No code change needed — the AWS SDK v2 handles IPv6 IMDS natively via `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE=IPv6`
- **Azure**: No change possible — Azure IMDS has no IPv6 endpoint
- **GCP**: Fixed — switched from `169.254.169.254` to `metadata.google.internal`

## Test plan
- [ ] Existing WIF unit tests pass (they inject wiremock URLs directly, not via the constants)
- [ ] `go test -run TestDetectPlatforms` passes (platform_detection vars unchanged)
- [ ] Full `go test ./...` — no regressions
- [ ] On GCP IPv6-only VM: WIF integration test with `SNOWFLAKE_TEST_WIF_PROVIDER=GCP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)