### PR TITLE
Expose QueryResultFormat on ArrowStreamLoader interface

### DIFF
--- a/arrow_stream.go
+++ b/arrow_stream.go
@@ -32,6 +32,8 @@ type ArrowStreamLoader interface {
 	RowTypes() []query.ExecResponseRowType
 	Location() *time.Location
 	JSONData() [][]*string
+	// QueryResultFormat returns the format of the query result data ("arrow" or "json").
+	QueryResultFormat() string
 }
 
 // ArrowStreamBatch is a type describing a potentially yet-to-be-downloaded
@@ -137,8 +139,9 @@ type snowflakeArrowStreamChunkDownloader struct {
 	Qrmk        string
 	ChunkHeader map[string]string
 	FuncGet     func(context.Context, *snowflakeConn, string, map[string]string, time.Duration) (*http.Response, error)
-	RowSet      rowSetType
-	resultIDs   []string
+	RowSet            rowSetType
+	resultIDs         []string
+	queryResultFormat string
 }
 
 func (scd *snowflakeArrowStreamChunkDownloader) Location() *time.Location {
@@ -156,6 +159,10 @@ func (scd *snowflakeArrowStreamChunkDownloader) RowTypes() []query.ExecResponseR
 
 func (scd *snowflakeArrowStreamChunkDownloader) JSONData() [][]*string {
 	return scd.RowSet.JSON
+}
+
+func (scd *snowflakeArrowStreamChunkDownloader) QueryResultFormat() string {
+	return scd.queryResultFormat
 }
 
 func (scd *snowflakeArrowStreamChunkDownloader) maybeFirstBatch() ([]byte, error) {
@@ -248,6 +255,7 @@ func (scd *snowflakeArrowStreamChunkDownloader) NextResultSet(ctx context.Contex
 		JSON:         resp.Data.RowSet,
 		RowSetBase64: resp.Data.RowSetBase64,
 	}
+	scd.queryResultFormat = resp.Data.QueryResultFormat
 	return nil
 }
 

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -549,6 +549,18 @@ func TestQueryArrowStreamMultiStatement(t *testing.T) {
 	})
 }
 
+func TestQueryArrowStreamQueryResultFormat(t *testing.T) {
+	runSnowflakeConnTest(t, func(sct *SCTest) {
+		loader, err := sct.sc.QueryArrowStream(sct.sc.ctx, "SELECT 1")
+		assertNilF(t, err)
+		assertEqualF(t, loader.QueryResultFormat(), "arrow", "expected arrow format for SELECT query")
+
+		loader, err = sct.sc.QueryArrowStream(sct.sc.ctx, "SHOW WAREHOUSES")
+		assertNilF(t, err)
+		assertEqualF(t, loader.QueryResultFormat(), "json", "expected json format for SHOW query")
+	})
+}
+
 func TestQueryArrowStreamMultiStatementForJSONData(t *testing.T) {
 	runSnowflakeConnTest(t, func(sct *SCTest) {
 		ctx := WithMultiStatement(ia.EnableArrowBatches(sct.sc.ctx), 2)

--- a/connection.go
+++ b/connection.go
@@ -581,7 +581,8 @@ func (sc *snowflakeConn) QueryArrowStream(ctx context.Context, query string, bin
 			JSON:         data.Data.RowSet,
 			RowSetBase64: data.Data.RowSetBase64,
 		},
-		resultIDs: resultIDs,
+		resultIDs:         resultIDs,
+		queryResultFormat: data.Data.QueryResultFormat,
 	}
 
 	if scd.hasNextResultSet() {


### PR DESCRIPTION
## Summary

- Add `QueryResultFormat() string` method to the `ArrowStreamLoader` interface, returning `"arrow"` or `"json"` based on the server response
- Store and propagate `queryResultFormat` through `snowflakeArrowStreamChunkDownloader` (both initial construction and `NextResultSet`)
- Add integration test verifying the format for Arrow (`SELECT`) and JSON (`SHOW`) queries

## Motivation

The ADBC Snowflake driver ([adbc-drivers/snowflake#114](https://github.com/adbc-drivers/snowflake/pull/114)) reports that `CALL <stored_proc>` fails with `arrow/ipc: could not read message schema: unexpected EOF` because downloadable chunks contain JSON instead of Arrow IPC.

### When does Snowflake return JSON despite Arrow being requested?

The Snowflake backend **deliberately forces** `queryResultFormat: "json"` for stored procedure results,
regardless of the client's `GO_QUERY_RESULT_FORMAT = 'ARROW'` session setting. This is implemented
in `QueryResultFormatComputerImpl.computeResultFormatInternal()`, which sets
`forceJsonFormat = true` when `isReturnTableStoredProc` is true, blocking Arrow format selection.
Apparently it's done this way for libsnowflakeclient compatibility.

The same JSON forcing applies to SHOW, DESCRIBE, and other metadata queries (via `StatementType.supportArrow()` returning false for non-SELECT/non-CALL types).

### The gap in gosnowflake

The regular `chunk_downloader.go` path correctly checks `queryResultFormat` and routes JSON vs Arrow decoding (`chunk_downloader.go:479`). The `QueryArrowStream` path (used by ADBC) never stored or exposed this field, so consumers had no authoritative signal and were forced to use fragile byte-peeking heuristics (checking for the `0xFFFFFFFF` Arrow IPC continuation token). This change exposes the field so consumers can route decoding correctly.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [ ] `TestQueryArrowStreamQueryResultFormat` verifies `"arrow"` for SELECT and `"json"` for SHOW WAREHOUSES
- [ ] Existing `TestQueryArrowStream*` tests continue to pass
- [ ] ADBC driver can use `loader.QueryResultFormat()` instead of byte-peeking to detect JSON chunks

