### PR TITLE
SNOW-3445534: better error message for when Host is misconfigured with scheme thus trips up port parsing due to ':'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ New features:
 
 Bug fixes:
 
+- Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#XXXX).
+
 Internal changes:
 
 - Introduced `SKIP_FILE_PERMISSIONS_VERIFICATION` environment variable to allow bypassing file permissions checks for `connections.toml` and the credential cache, which is useful for environments where strict permissions cannot be set (snowflakedb/gosnowflake#1780).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features:
 
 Bug fixes:
 
-- Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#XXXX).
+- Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#1784).
 
 Internal changes:
 

--- a/errors.go
+++ b/errors.go
@@ -123,6 +123,8 @@ const (
 	ErrCodeEmptyToken = sferrors.ErrCodeEmptyToken
 	// ErrCodeEmptyOAuthParameters is an error code for the case where the client ID or client secret are not provided for OAuth flows.
 	ErrCodeEmptyOAuthParameters = sferrors.ErrCodeEmptyOAuthParameters
+	// ErrCodeHostWithScheme is an error code for the case where the host includes a URL scheme (e.g. "https://")
+	ErrCodeHostWithScheme = sferrors.ErrCodeHostWithScheme
 	// ErrMissingAccessATokenButRefreshTokenPresent is an error code for the case when access token is not found in cache, but the refresh token is present.
 	ErrMissingAccessATokenButRefreshTokenPresent = sferrors.ErrMissingAccessATokenButRefreshTokenPresent
 	// ErrCodeMissingTLSConfig is an error code for the case where the TLS config is missing.

--- a/internal/config/dsn.go
+++ b/internal/config/dsn.go
@@ -466,6 +466,13 @@ func applyAccountFromHostIfMissing(cfg *Config) {
 func FillMissingConfigParameters(cfg *Config) error {
 	applyAccountFromHostIfMissing(cfg)
 
+	if cfg.Host != "" {
+		lower := strings.ToLower(cfg.Host)
+		if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+			return sferrors.ErrHostWithScheme(cfg.Host)
+		}
+	}
+
 	posDash := strings.LastIndex(cfg.Account, "-")
 	if posDash > 0 {
 		if strings.Contains(strings.ToLower(cfg.Host), ".global.") {

--- a/internal/config/dsn_test.go
+++ b/internal/config/dsn_test.go
@@ -2502,18 +2502,6 @@ func TestFillMissingConfigParametersRejectsHostWithHTTPScheme(t *testing.T) {
 	assertEqualE(t, sfErr.Number, sferrors.ErrCodeHostWithScheme, "error number")
 }
 
-func TestFillMissingConfigParametersAcceptsHostWithoutScheme(t *testing.T) {
-	cfg := &Config{
-		User:          "u",
-		Password:      "p",
-		Host:          "myorg-myaccount.snowflakecomputing.com",
-		Port:          443,
-		Account:       "myorg-myaccount",
-		Authenticator: AuthTypeSnowflake,
-	}
-	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters should accept host without scheme")
-}
-
 // helper function to generate PKCS8 encoded base64 string of a private key
 func generatePKCS8StringSupress(key *rsa.PrivateKey) string {
 	// Error would only be thrown when the private key type is not supported

--- a/internal/config/dsn_test.go
+++ b/internal/config/dsn_test.go
@@ -2470,6 +2470,50 @@ func TestFillMissingConfigParametersNonSnowflakeHostRequiresAccount(t *testing.T
 	assertEqualE(t, sfErr.Number, sferrors.ErrCodeEmptyAccountCode, "error number")
 }
 
+func TestFillMissingConfigParametersRejectsHostWithHTTPSScheme(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "https://myorg-myaccount.snowflakecomputing.com",
+		Port:          443,
+		Account:       "myorg-myaccount",
+		Authenticator: AuthTypeSnowflake,
+	}
+	err := FillMissingConfigParameters(cfg)
+	assertNotNilF(t, err, "expected error for Host with https:// scheme")
+	sfErr, ok := err.(*sferrors.SnowflakeError)
+	assertTrueF(t, ok, "expected SnowflakeError")
+	assertEqualE(t, sfErr.Number, sferrors.ErrCodeHostWithScheme, "error number")
+}
+
+func TestFillMissingConfigParametersRejectsHostWithHTTPScheme(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "http://myorg-myaccount.snowflakecomputing.com",
+		Port:          443,
+		Account:       "myorg-myaccount",
+		Authenticator: AuthTypeSnowflake,
+	}
+	err := FillMissingConfigParameters(cfg)
+	assertNotNilF(t, err, "expected error for Host with http:// scheme")
+	sfErr, ok := err.(*sferrors.SnowflakeError)
+	assertTrueF(t, ok, "expected SnowflakeError")
+	assertEqualE(t, sfErr.Number, sferrors.ErrCodeHostWithScheme, "error number")
+}
+
+func TestFillMissingConfigParametersAcceptsHostWithoutScheme(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "myorg-myaccount.snowflakecomputing.com",
+		Port:          443,
+		Account:       "myorg-myaccount",
+		Authenticator: AuthTypeSnowflake,
+	}
+	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters should accept host without scheme")
+}
+
 // helper function to generate PKCS8 encoded base64 string of a private key
 func generatePKCS8StringSupress(key *rsa.PrivateKey) string {
 	// Error would only be thrown when the private key type is not supported

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -90,6 +90,8 @@ const (
 	ErrCodeMissingTLSConfig = 260019
 	// ErrCodeEmptyToken is an error code for the case where token-based auth (e.g. PAT) is used but neither token nor tokenFilePath is provided.
 	ErrCodeEmptyToken = 260020
+	// ErrCodeHostWithScheme is an error code for the case where the host includes a URL scheme (e.g. "https://")
+	ErrCodeHostWithScheme = 260021
 
 	/* network */
 
@@ -272,6 +274,7 @@ const (
 	ErrMsgInvalidExecutablePermissionToFile  = "file '%v' is executable — this poses a security risk because the file could be misused as a script or executed unintentionally. Your Permission: %v"
 	ErrMsgNonArrowResponseInArrowBatches     = "arrow batches enabled, but the response is not Arrow based"
 	ErrMsgMissingTLSConfig                   = "TLS config not found: %v"
+	ErrMsgHostWithScheme                     = "host includes a URL scheme (e.g. \"https://\"). Specify the hostname only, without a scheme prefix. Use \"myorg-myaccount.snowflakecomputing.com\" instead of \"https://myorg-myaccount.snowflakecomputing.com\". Got: %v"
 )
 
 // ErrEmptyAccount is returned if a DSN doesn't include account parameter.
@@ -319,6 +322,15 @@ func ErrEmptyOAuthParameters() *SnowflakeError {
 	return &SnowflakeError{
 		Number:  ErrCodeEmptyOAuthParameters,
 		Message: "client ID or client secret are empty",
+	}
+}
+
+// ErrHostWithScheme is returned if the host configuration value includes a URL scheme (e.g. "https://").
+func ErrHostWithScheme(host string) *SnowflakeError {
+	return &SnowflakeError{
+		Number:      ErrCodeHostWithScheme,
+		Message:     ErrMsgHostWithScheme,
+		MessageArgs: []any{host},
 	}
 }
 


### PR DESCRIPTION
### Description

This comes from a Terraform use-case, please see https://github.com/snowflakedb/terraform-provider-snowflake/issues/4691 . 

When user misconfigures the Provider as:
```
provider "snowflake" {
  organization_name = "myorgname"
  account_name      = "myaccountname"
  user              = "myuser"
  password          = "mypassword"
  host              = "https://myaccountlocator.us-east-1.snowflakecomputing.com"
}
```

it emits an error
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: open snowflake connection: 260004: failed to parse a port number. port: 
│ 
```

which is absolutely unhelpful in diagnosing what the actual problem is: [parseAccountHostPort](https://github.com/snowflakedb/gosnowflake/blob/v2.0.2/internal/config/dsn.go#L672-L691) in gosnowflake believes the `:` is part of the expected `host:port` notation, and parses `https` as the hostname and `//myaccountlocator.us-east-1.snowflakecomputing.com` as the port, which of course won't work, but there's no further details on that. 

This cryptic error message already caused at least 2 issues:
* https://github.com/snowflakedb/terraform-provider-snowflake/issues/1000
* https://github.com/snowflakedb/terraform-provider-snowflake/issues/4691

and apparently keeps baffling the users and spend a lot of time on debugging instead of spending 1 second on correcting the config, were the error more descriptive. 

This PR aims to do that - provide a more descriptive error message by detecting the misconfiguration early in `FillMissingConfigParameters` and error out with a newly introduced specific, and actionable error message. 

Also added new tests to verify the functionality. 

### Checklist
- [x] Added proper logging (if possible)
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
