### PR TITLE
SNOW-3474718: don't drop legal files having names with trailing dot from PUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features:
 
 Bug fixes:
 
-- Fixed `baseName` silently dropping files whose name ends with a dot (e.g. `myfile.txt.`), which caused PUT uploads to discard such files without error (snowflakedb/gosnowflake#XXXX).
+- Fixed `baseName` silently dropping files whose name ends with a dot (e.g. `myfile.txt.`), which caused PUT uploads to discard such files without error (snowflakedb/gosnowflake#1788).
 - Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#1784).
 
 Internal changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 
 Bug fixes:
 
+- Fixed `baseName` silently dropping files whose name ends with a dot (e.g. `myfile.txt.`), which caused PUT uploads to discard such files without error (snowflakedb/gosnowflake#XXXX).
 - Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#1784).
 
 Internal changes:

--- a/file_util.go
+++ b/file_util.go
@@ -206,6 +206,9 @@ func baseName(path string) string {
 	if base == "." || base == ".." || base == string(filepath.Separator) {
 		return ""
 	}
+	if len(path) > 0 && os.IsPathSeparator(path[len(path)-1]) {
+		return ""
+	}
 	return base
 }
 

--- a/file_util.go
+++ b/file_util.go
@@ -203,10 +203,7 @@ func getReaderFromBuffer(src **bytes.Buffer) io.Reader {
 // baseName returns the pathname of the path provided
 func baseName(path string) string {
 	base := filepath.Base(path)
-	if base == "." || base == "/" {
-		return ""
-	}
-	if len(base) > 1 && (path[len(path)-1:] == "." || path[len(path)-1:] == "/") {
+	if base == "." || base == ".." || base == string(filepath.Separator) {
 		return ""
 	}
 	return base

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -3,6 +3,7 @@ package gosnowflake
 import (
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -30,14 +31,41 @@ func TestBaseName(t *testing.T) {
 		{"/tmp", "tmp"},
 		{"/home/desktop/.", ""},
 		{"/home/desktop/..", ""},
+		{".", ""},
+		{"..", ""},
+		{"/", ""},
+		{"/home/desktop/", "desktop"},
+		{"archive.tar.gz", "archive.tar.gz"},
+		{"/path/to/archive.tar.gz", "archive.tar.gz"},
+		{"trailing-dot.tar.gz.", "trailing-dot.tar.gz."},
+		{"/path/to/trailing-dot.tar.gz.", "trailing-dot.tar.gz."},
 	}
 
 	for _, test := range testcases {
 		t.Run(test.in, func(t *testing.T) {
-			base := baseName(test.in)
-			if test.out != base {
-				t.Errorf("Failed to get base, input %v, expected: %v, got: %v", test.in, test.out, base)
-			}
+			actual := baseName(test.in)
+			assertEqualE(t, actual, test.out, "baseName(%q)", test.in)
+		})
+	}
+}
+
+func TestBaseNameWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific path tests")
+	}
+	testcases := []tcBaseName{
+		{`C:\Users\file.txt`, "file.txt"},
+		{`C:\Users\`, "Users"},
+		{`C:\`, `\`},
+		{`C:\Users\trailing-dot.txt.`, "trailing-dot.txt."},
+		{`C:\path\to\.`, ""},
+		{`C:\path\to\..`, ""},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.in, func(t *testing.T) {
+			actual := baseName(test.in)
+			assertEqualE(t, actual, test.out, "baseName(%q)", test.in)
 		})
 	}
 }

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -57,7 +57,9 @@ func TestBaseNameWindows(t *testing.T) {
 	testcases := []tcBaseName{
 		{`C:\Users\file.txt`, "file.txt"},
 		{`C:\Users\`, "Users"},
-		{`C:\`, `\`},
+		// filepath.Base: "If the path consists entirely of separators, Base returns a single separator"
+		// "C:\" -> "\" which is not a file name, but a root path, so should be rejected
+		{`C:\`, ""},
 		{`C:\Users\trailing-dot.txt.`, "trailing-dot.txt."},
 		{`C:\path\to\Untitled 1.`, "Untitled 1."},
 		{`C:\path\to\.`, ""},

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -39,6 +39,7 @@ func TestBaseName(t *testing.T) {
 		{"/path/to/archive.tar.gz", "archive.tar.gz"},
 		{"trailing-dot.tar.gz.", "trailing-dot.tar.gz."},
 		{"/path/to/trailing-dot.tar.gz.", "trailing-dot.tar.gz."},
+		{"/path/to/Untitled 1.", "Untitled 1."},
 	}
 
 	for _, test := range testcases {
@@ -58,6 +59,7 @@ func TestBaseNameWindows(t *testing.T) {
 		{`C:\Users\`, "Users"},
 		{`C:\`, `\`},
 		{`C:\Users\trailing-dot.txt.`, "trailing-dot.txt."},
+		{`C:\path\to\Untitled 1.`, "Untitled 1."},
 		{`C:\path\to\.`, ""},
 		{`C:\path\to\..`, ""},
 	}

--- a/file_util_test.go
+++ b/file_util_test.go
@@ -34,7 +34,7 @@ func TestBaseName(t *testing.T) {
 		{".", ""},
 		{"..", ""},
 		{"/", ""},
-		{"/home/desktop/", "desktop"},
+		{"/home/desktop/", ""},
 		{"archive.tar.gz", "archive.tar.gz"},
 		{"/path/to/archive.tar.gz", "archive.tar.gz"},
 		{"trailing-dot.tar.gz.", "trailing-dot.tar.gz."},
@@ -45,7 +45,7 @@ func TestBaseName(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.in, func(t *testing.T) {
 			actual := baseName(test.in)
-			assertEqualE(t, actual, test.out, "baseName(%q)", test.in)
+			assertEqualE(t, actual, test.out, "baseName:", test.in)
 		})
 	}
 }
@@ -56,7 +56,7 @@ func TestBaseNameWindows(t *testing.T) {
 	}
 	testcases := []tcBaseName{
 		{`C:\Users\file.txt`, "file.txt"},
-		{`C:\Users\`, "Users"},
+		{`C:\Users\`, ""},
 		// filepath.Base: "If the path consists entirely of separators, Base returns a single separator"
 		// "C:\" -> "\" which is not a file name, but a root path, so should be rejected
 		{`C:\`, ""},
@@ -69,7 +69,7 @@ func TestBaseNameWindows(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.in, func(t *testing.T) {
 			actual := baseName(test.in)
-			assertEqualE(t, actual, test.out, "baseName(%q)", test.in)
+			assertEqualE(t, actual, test.out, "baseName:", test.in)
 		})
 	}
 }


### PR DESCRIPTION
### Description

This came from a Snowsight use-case, where the team noticed that files like  `Untitled 1.` got confirmed on the GUI to be uploaded, but actually wasn't `PUT` to the stage. 

Turns out [the validation we have in place](https://github.com/snowflakedb/gosnowflake/blob/v2.0.2/file_util.go#L209-L210) for years just silently drops even legal file names when they end with `.` char. 

This change aims  to address this issue and allow files legally ending with `.` to be uploaded to the stage.
Also added new tests. 

Manual tests done:
* upload `/path/to/Untitled 1.` to user stage, then list out user stage to confirm 

