### PR TITLE
minicore: skip -ldl on OpenBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug fixes:
 - Fixed stale OCSP cache `.lck` directory permanently blocking cache writes (and forcing an online OCSP validation if OCSP is enabled, as is by default) by using `os.RemoveAll` instead of `os.Remove` for stale lock recovery (snowflakedb/gosnowflake#1793).
 - Fixed `baseName` silently dropping files whose name ends with a dot (e.g. `myfile.txt.`), which caused PUT uploads to discard such files without error (snowflakedb/gosnowflake#1788).
 - Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#1784).
+- Fixed minicore build on OpenBSD by skipping the `-ldl` linker flag, since libdl is not a separate library on OpenBSD (`dlopen`/`dlsym` are provided by libc) (snowflakedb/gosnowflake#1791).
 
 Internal changes:
 

--- a/minicore_posix.go
+++ b/minicore_posix.go
@@ -3,7 +3,7 @@
 package gosnowflake
 
 /*
-#cgo LDFLAGS: -ldl
+#cgo !openbsd LDFLAGS: -ldl
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Mirror of #1787 by @atanas-vladimirov, re-pushed to a branch on this repo so the secrets-gated CI jobs in `build-test.yml` actually receive `PARAMETERS_SECRET` / `GOLANG_PRIVATE_KEY_SECRET`. Fork PRs get empty values for those, which makes `gpg` fail with "Bad session key" in `ci/scripts/setup_connection_parameters.sh` and blocks every integration test.

Same head commit as #1787 (`b70fc77`). All credit for the change goes to the original author; #1787 will be closed once this lands.

---

### Description (from #1787)

OpenBSD does not provide a separate libdl, so unconditional `-ldl` breaks linking. `dlopen`/`dlsym` are available via libc on OpenBSD, so this keeps POSIX loading portable while preserving behavior on other platforms.

Co-authored-by: Atanas Vladimirov <vladimirov.atanas@gmail.com>