### PR TITLE
SNOW-3449105 add Reset for ArrowStreamBatch method (mirror of #1782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 New features:
 
+- Added `ArrowStreamBatch.Reset()` method that closes any existing stream and clears the cached reader, allowing callers to retry `GetStream` after a mid-stream failure (e.g. TCP RST) without re-executing the entire query. Inline (RowSetBase64) batches are restored from cached bytes on reset.
+
 Bug fixes:
 
 - Fixed stale OCSP cache `.lck` directory permanently blocking cache writes (and forcing an online OCSP validation if OCSP is enabled, as is by default) by using `os.RemoveAll` instead of `os.Remove` for stale lock recovery (snowflakedb/gosnowflake#1793).

--- a/arrow_stream.go
+++ b/arrow_stream.go
@@ -66,10 +66,26 @@ type ArrowStreamBatch struct {
 // be in this stream of record batches.
 func (asb *ArrowStreamBatch) NumRows() int64 { return asb.numrows }
 
+// Reset closes any existing stream and clears the cached reader, allowing
+// GetStream to re-download the chunk on the next call. This enables callers
+// to retry after a mid-stream failure (e.g. TCP RST) without re-executing
+// the entire query.
+func (asb *ArrowStreamBatch) Reset() error {
+	if asb.rr != nil {
+		err := asb.rr.Close()
+		asb.rr = nil
+		return err
+	}
+	return nil
+}
+
 // GetStream downloads the chunk (if not already cached) and returns a
 // stream of bytes. The content may be Arrow IPC or JSON (row fragments)
 // depending on the current QueryResultFormat. Close should be called
 // on the returned stream when done to ensure no leaked memory.
+//
+// If a previous stream failed mid-read, call Reset() first to clear the
+// cached reader and allow re-download.
 func (asb *ArrowStreamBatch) GetStream(ctx context.Context) (io.ReadCloser, error) {
 	if asb.rr == nil {
 		if err := asb.downloadChunkStreamHelper(ctx); err != nil {

--- a/arrow_stream.go
+++ b/arrow_stream.go
@@ -55,11 +55,12 @@ type QueryResultFormatProvider interface {
 // QueryResultFormat: Arrow IPC record batches (use ipc.NewReader) when
 // the format is "arrow", or JSON (row fragments) when it is "json".
 type ArrowStreamBatch struct {
-	idx     int
-	numrows int64
-	scd     *snowflakeArrowStreamChunkDownloader
-	Loc     *time.Location
-	rr      io.ReadCloser
+	idx        int
+	numrows    int64
+	scd        *snowflakeArrowStreamChunkDownloader
+	Loc        *time.Location
+	rr         io.ReadCloser
+	inlineData []byte // non-nil for inline (RowSetBase64) batches
 }
 
 // NumRows returns the total number of rows that the metadata stated should
@@ -74,7 +75,12 @@ func (asb *ArrowStreamBatch) Reset() error {
 	if asb.rr != nil {
 		err := asb.rr.Close()
 		asb.rr = nil
-		return err
+		if err != nil {
+			return err
+		}
+	}
+	if asb.inlineData != nil {
+		asb.rr = io.NopCloser(bytes.NewReader(asb.inlineData))
 	}
 	return nil
 }
@@ -236,9 +242,10 @@ func (scd *snowflakeArrowStreamChunkDownloader) GetBatches() (out []ArrowStreamB
 	if len(rowSetBytes) > 0 {
 		out = out[:chunkMetaLen+1]
 		out[0] = ArrowStreamBatch{
-			scd: scd,
-			Loc: loc,
-			rr:  io.NopCloser(bytes.NewReader(rowSetBytes)),
+			scd:        scd,
+			Loc:        loc,
+			rr:         io.NopCloser(bytes.NewReader(rowSetBytes)),
+			inlineData: rowSetBytes,
 		}
 		toFill = out[1:]
 	}

--- a/arrow_stream.go
+++ b/arrow_stream.go
@@ -72,17 +72,15 @@ func (asb *ArrowStreamBatch) NumRows() int64 { return asb.numrows }
 // to retry after a mid-stream failure (e.g. TCP RST) without re-executing
 // the entire query.
 func (asb *ArrowStreamBatch) Reset() error {
+	var closeErr error
 	if asb.rr != nil {
-		err := asb.rr.Close()
+		closeErr = asb.rr.Close()
 		asb.rr = nil
-		if err != nil {
-			return err
-		}
 	}
 	if asb.inlineData != nil {
 		asb.rr = io.NopCloser(bytes.NewReader(asb.inlineData))
 	}
-	return nil
+	return closeErr
 }
 
 // GetStream downloads the chunk (if not already cached) and returns a

--- a/arrow_stream.go
+++ b/arrow_stream.go
@@ -71,6 +71,14 @@ func (asb *ArrowStreamBatch) NumRows() int64 { return asb.numrows }
 // GetStream to re-download the chunk on the next call. This enables callers
 // to retry after a mid-stream failure (e.g. TCP RST) without re-executing
 // the entire query.
+//
+// For inline batches (those produced from RowSetBase64 in the initial
+// query response), there is no remote chunk to re-download. In that
+// case Reset rewinds the reader by re-wrapping the cached inline bytes
+// so the batch can be read again from the beginning. This is done
+// even when the underlying Close returns an error, so the batch is
+// always left in a usable state for retry; the close error is still
+// returned to the caller.
 func (asb *ArrowStreamBatch) Reset() error {
 	var closeErr error
 	if asb.rr != nil {

--- a/arrow_stream_test.go
+++ b/arrow_stream_test.go
@@ -71,27 +71,6 @@ func (c *closeCountingReadCloser) Close() error {
 	return nil
 }
 
-func newTestArrowStreamBatch(body io.ReadCloser) ArrowStreamBatch {
-	return ArrowStreamBatch{
-		idx: 0,
-		scd: &snowflakeArrowStreamChunkDownloader{
-			sc: &snowflakeConn{
-				rest: &snowflakeRestful{RequestTimeout: time.Second},
-			},
-			ChunkMetas: []query.ExecResponseChunk{{
-				URL:      "https://example.com/chunk",
-				RowCount: 1,
-			}},
-			FuncGet: func(context.Context, *snowflakeConn, string, map[string]string, time.Duration) (*http.Response, error) {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       body,
-				}, nil
-			},
-		},
-	}
-}
-
 func gzipBody(payload []byte) io.ReadCloser {
 	return io.NopCloser(bytes.NewReader(gzipBytes(payload)))
 }
@@ -109,7 +88,7 @@ func TestArrowStreamBatchGetStreamCancellationUnblocksStalledRead(t *testing.T) 
 	defer cancel()
 
 	body := newBlockingReadCloser([]byte("ok"), io.EOF)
-	batch := newTestArrowStreamBatch(body)
+	batch := newTestArrowStreamBatch(static200OK(body))
 
 	stream, err := batch.GetStream(ctx)
 	assertNilF(t, err, "GetStream should succeed")
@@ -157,7 +136,7 @@ func TestArrowStreamBatchGetStreamCancellationNormalizesCloseErrors(t *testing.T
 
 	terminalErr := errors.New("read from closed body")
 	body := newBlockingReadCloser([]byte("ok"), terminalErr)
-	batch := newTestArrowStreamBatch(body)
+	batch := newTestArrowStreamBatch(static200OK(body))
 
 	stream, err := batch.GetStream(ctx)
 	assertNilF(t, err, "GetStream should succeed")
@@ -199,7 +178,7 @@ func TestArrowStreamBatchGetStreamCancellationNormalizesGzipBlockedRead(t *testi
 	terminalErr := errors.New("read from closed body")
 	body := newBlockingReadCloser(gzipBytes([]byte("ok")), terminalErr)
 	body.firstChunkSize = len(body.payload) / 2
-	batch := newTestArrowStreamBatch(body)
+	batch := newTestArrowStreamBatch(static200OK(body))
 
 	stream, err := batch.GetStream(ctx)
 	assertNilF(t, err, "GetStream should succeed")
@@ -336,7 +315,7 @@ func TestArrowStreamBatchGetStreamPreservesCompletedEOF(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			batch := newTestArrowStreamBatch(tc.body)
+			batch := newTestArrowStreamBatch(static200OK(tc.body))
 			stream, err := batch.GetStream(context.Background())
 			assertNilF(t, err, "GetStream should succeed")
 			defer func() {

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -2,9 +2,14 @@ package gosnowflake
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"database/sql/driver"
+	"errors"
 	"fmt"
+	"io"
 	"math/big"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,8 +17,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	ia "github.com/snowflakedb/gosnowflake/v2/internal/arrow"
-
-	"database/sql/driver"
+	"github.com/snowflakedb/gosnowflake/v2/internal/query"
 )
 
 func TestArrowBatchDataProvider(t *testing.T) {
@@ -574,4 +578,314 @@ func TestArrowMemoryCleanedUp(t *testing.T) {
 		assertEqualE(t, v, 2)
 		assertFalseE(t, rows.Next())
 	})
+}
+
+// errReadCloser is a ReadCloser whose Close returns a predetermined error.
+type errReadCloser struct {
+	io.Reader
+	closeErr error
+	closed   bool
+}
+
+func (e *errReadCloser) Close() error {
+	e.closed = true
+	return e.closeErr
+}
+
+func TestArrowStreamBatchResetNilReader(t *testing.T) {
+	// Reset on a batch with no reader should be a no-op and return nil.
+	batch := ArrowStreamBatch{}
+	err := batch.Reset()
+	assertNilF(t, err, "Reset on nil reader should return nil")
+}
+
+func TestArrowStreamBatchResetClosesReader(t *testing.T) {
+	// Reset should close the underlying reader and nil it out.
+	rc := &errReadCloser{Reader: bytes.NewReader([]byte("data"))}
+	batch := ArrowStreamBatch{rr: rc}
+
+	err := batch.Reset()
+	assertNilF(t, err, "Reset should not return error on successful close")
+	assertTrueF(t, rc.closed, "underlying reader should have been closed")
+	assertNilF(t, batch.rr, "rr should be nil after Reset")
+}
+
+func TestArrowStreamBatchResetPropagatesCloseError(t *testing.T) {
+	// Reset should propagate the error from Close.
+	expected := errors.New("close failed")
+	rc := &errReadCloser{Reader: bytes.NewReader(nil), closeErr: expected}
+	batch := ArrowStreamBatch{rr: rc}
+
+	err := batch.Reset()
+	assertTrueF(t, errors.Is(err, expected), "Reset should propagate close error")
+	// rr should still be nilled out even when Close returns an error.
+	assertNilF(t, batch.rr, "rr should be nil after Reset even on error")
+}
+
+func TestArrowStreamBatchResetAllowsRedownload(t *testing.T) {
+	// After Reset, GetStream should re-invoke the download path.
+	// We simulate this by setting rr, resetting, then confirming rr is nil
+	// so GetStream would attempt a fresh download.
+	rc := &errReadCloser{Reader: bytes.NewReader([]byte("stale"))}
+	batch := ArrowStreamBatch{rr: rc}
+
+	// Confirm GetStream returns the cached reader before Reset.
+	stream, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	assertTrueF(t, stream == rc, "GetStream should return cached reader")
+
+	// Reset clears the cache.
+	err = batch.Reset()
+	assertNilF(t, err)
+	assertNilF(t, batch.rr, "rr should be nil after Reset")
+}
+
+func TestArrowStreamBatchDoubleResetIsIdempotent(t *testing.T) {
+	// Calling Reset twice should not error the second time.
+	rc := &errReadCloser{Reader: bytes.NewReader([]byte("data"))}
+	batch := ArrowStreamBatch{rr: rc}
+
+	assertNilF(t, batch.Reset(), "first Reset should succeed")
+	assertNilF(t, batch.Reset(), "second Reset should be a no-op")
+}
+
+// newTestArrowStreamBatch creates an ArrowStreamBatch wired to a mock FuncGet
+// for unit testing without a live Snowflake connection.
+func newTestArrowStreamBatch(funcGet func(context.Context, *snowflakeConn, string, map[string]string, time.Duration) (*http.Response, error)) ArrowStreamBatch {
+	sc := &snowflakeConn{rest: &snowflakeRestful{RequestTimeout: 0}}
+	scd := &snowflakeArrowStreamChunkDownloader{
+		sc:         sc,
+		ChunkMetas: []query.ExecResponseChunk{{URL: "http://fake/chunk0"}},
+		Qrmk:       "testQrmk",
+		FuncGet:    funcGet,
+	}
+	return ArrowStreamBatch{idx: 0, scd: scd}
+}
+
+func TestArrowStreamBatchResetThenGetStreamRedownloads(t *testing.T) {
+	// After Reset, calling GetStream should invoke FuncGet again,
+	// proving the chunk is actually re-downloaded.
+	callCount := 0
+	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
+		callCount++
+		body := []byte(fmt.Sprintf("payload-%d", callCount))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+
+	batch := newTestArrowStreamBatch(mockGet)
+
+	// First download.
+	stream1, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	data1, err := io.ReadAll(stream1)
+	assertNilF(t, err)
+	assertEqualE(t, callCount, 1)
+
+	// Reset clears cached reader.
+	assertNilF(t, batch.Reset())
+
+	// Second download — FuncGet is called again.
+	stream2, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	data2, err := io.ReadAll(stream2)
+	assertNilF(t, err)
+	assertEqualE(t, callCount, 2)
+
+	// Content should differ, proving it was re-downloaded.
+	assertFalseE(t, bytes.Equal(data1, data2), "re-downloaded data should differ from original")
+}
+
+func TestArrowStreamBatchResetAfterPartialRead(t *testing.T) {
+	// Simulates the primary use case: a mid-stream failure followed by
+	// Reset + full re-download.
+	fullPayload := []byte("complete-data-here")
+	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(fullPayload)),
+		}, nil
+	}
+
+	batch := newTestArrowStreamBatch(mockGet)
+
+	// Read only a few bytes (simulate partial/failed read).
+	stream, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	partial := make([]byte, 5)
+	_, err = stream.Read(partial)
+	assertNilF(t, err)
+
+	// Reset and re-download the full payload.
+	assertNilF(t, batch.Reset())
+	stream2, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	full, err := io.ReadAll(stream2)
+	assertNilF(t, err)
+	assertEqualE(t, string(full), string(fullPayload))
+}
+
+func TestArrowStreamBatchGetStreamGzipped(t *testing.T) {
+	// Verify that gzip-compressed responses are transparently decompressed.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write([]byte("decompressed payload"))
+	assertNilF(t, err)
+	assertNilF(t, gw.Close())
+	gzBytes := buf.Bytes()
+
+	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(gzBytes)),
+		}, nil
+	}
+
+	batch := newTestArrowStreamBatch(mockGet)
+	stream, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	data, err := io.ReadAll(stream)
+	assertNilF(t, err)
+	assertEqualE(t, string(data), "decompressed payload")
+}
+
+func TestArrowStreamBatchGetStreamNon200(t *testing.T) {
+	// Non-200 responses should surface as a SnowflakeError.
+	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Body:       io.NopCloser(bytes.NewReader([]byte("error"))),
+		}, nil
+	}
+
+	batch := newTestArrowStreamBatch(mockGet)
+	_, err := batch.GetStream(context.Background())
+	var sfErr *SnowflakeError
+	assertTrueF(t, errors.As(err, &sfErr), "should return SnowflakeError")
+	assertEqualE(t, sfErr.Number, ErrFailedToGetChunk)
+}
+
+func TestArrowStreamBatchGetStreamFuncGetError(t *testing.T) {
+	// Network-level errors from FuncGet should propagate directly.
+	expected := errors.New("network failure")
+	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
+		return nil, expected
+	}
+
+	batch := newTestArrowStreamBatch(mockGet)
+	_, err := batch.GetStream(context.Background())
+	assertTrueF(t, errors.Is(err, expected), "should propagate FuncGet error")
+}
+
+func TestArrowStreamBatchResetThenGetStreamAfterError(t *testing.T) {
+	// If the first GetStream fails, Reset should allow a successful retry.
+	calls := 0
+	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("transient error")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte("ok"))),
+		}, nil
+	}
+
+	batch := newTestArrowStreamBatch(mockGet)
+
+	// First attempt fails.
+	_, err := batch.GetStream(context.Background())
+	assertNotNilE(t, err)
+
+	// Reset (rr is still nil since download failed, but Reset is safe).
+	assertNilF(t, batch.Reset())
+
+	// Retry succeeds.
+	stream, err := batch.GetStream(context.Background())
+	assertNilF(t, err)
+	data, err := io.ReadAll(stream)
+	assertNilF(t, err)
+	assertEqualE(t, string(data), "ok")
+}
+
+func TestStreamWrapReaderCloseClosesInnerAndWrapped(t *testing.T) {
+	// When inner Reader implements io.ReadCloser, both inner and wrapped
+	// should be closed.
+	inner := &errReadCloser{Reader: bytes.NewReader(nil)}
+	wrappedClosed := false
+	wrapped := &errReadCloser{
+		Reader: bytes.NewReader(nil),
+		closed: false,
+	}
+	w := &streamWrapReader{Reader: inner, wrapped: wrapped}
+	err := w.Close()
+	assertNilF(t, err)
+	assertTrueF(t, inner.closed, "inner ReadCloser should be closed")
+	assertTrueF(t, wrapped.closed, "wrapped body should be closed")
+	_ = wrappedClosed
+}
+
+func TestStreamWrapReaderCloseNonClosableInner(t *testing.T) {
+	// When inner Reader is not an io.ReadCloser, only wrapped is closed.
+	wrapped := &errReadCloser{Reader: bytes.NewReader(nil)}
+	w := &streamWrapReader{Reader: bytes.NewReader(nil), wrapped: wrapped}
+	err := w.Close()
+	assertNilF(t, err)
+	assertTrueF(t, wrapped.closed, "wrapped body should be closed")
+}
+
+func TestStreamWrapReaderClosePropagatesInnerError(t *testing.T) {
+	// If the inner ReadCloser's Close fails, the error should propagate.
+	expected := errors.New("inner close fail")
+	inner := &errReadCloser{Reader: bytes.NewReader(nil), closeErr: expected}
+	wrapped := &errReadCloser{Reader: bytes.NewReader(nil)}
+	w := &streamWrapReader{Reader: inner, wrapped: wrapped}
+	err := w.Close()
+	assertTrueF(t, errors.Is(err, expected), "should propagate inner close error")
+	// wrapped should NOT have been closed because inner errored first.
+	assertFalseE(t, wrapped.closed, "wrapped should not close if inner errors")
+}
+
+func TestArrowStreamBatchResetClosesStreamWrapReader(t *testing.T) {
+	// Reset should properly close a streamWrapReader, including the
+	// wrapped HTTP body.
+	wrappedClosed := false
+	body := &fakeResponseBody{
+		body:    []byte("data"),
+		onClose: func() { wrappedClosed = true },
+	}
+	batch := ArrowStreamBatch{
+		rr: &streamWrapReader{
+			Reader:  bytes.NewReader([]byte("inner")),
+			wrapped: body,
+		},
+	}
+	assertNilF(t, batch.Reset())
+	assertNilF(t, batch.rr, "rr should be nil after Reset")
+	assertTrueF(t, wrappedClosed, "wrapped HTTP body should be closed")
+}
+
+func TestArrowStreamBatchResetClosesGzipStreamWrapReader(t *testing.T) {
+	// Verify Reset properly tears down a gzip + streamWrapReader stack.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write([]byte("hello"))
+	assertNilF(t, err)
+	assertNilF(t, gw.Close())
+
+	wrappedClosed := false
+	body := &fakeResponseBody{
+		body:    buf.Bytes(),
+		onClose: func() { wrappedClosed = true },
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(buf.Bytes()))
+	assertNilF(t, err)
+
+	batch := ArrowStreamBatch{
+		rr: &streamWrapReader{Reader: gr, wrapped: body},
+	}
+	assertNilF(t, batch.Reset())
+	assertTrueF(t, wrappedClosed, "wrapped HTTP body should be closed via gzip reader")
 }

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -690,6 +690,7 @@ func TestArrowStreamBatchResetThenGetStreamRedownloads(t *testing.T) {
 	// Second download — FuncGet is called again.
 	stream2, err := batch.GetStream(context.Background())
 	assertNilF(t, err)
+	defer stream2.Close()
 	data2, err := io.ReadAll(stream2)
 	assertNilF(t, err)
 	assertEqualE(t, callCount, 2)
@@ -722,6 +723,7 @@ func TestArrowStreamBatchResetAfterPartialRead(t *testing.T) {
 	assertNilF(t, batch.Reset())
 	stream2, err := batch.GetStream(context.Background())
 	assertNilF(t, err)
+	defer stream2.Close()
 	full, err := io.ReadAll(stream2)
 	assertNilF(t, err)
 	assertEqualE(t, string(full), string(fullPayload))
@@ -814,7 +816,6 @@ func TestStreamWrapReaderCloseClosesInnerAndWrapped(t *testing.T) {
 	// When inner Reader implements io.ReadCloser, both inner and wrapped
 	// should be closed.
 	inner := &errReadCloser{Reader: bytes.NewReader(nil)}
-	wrappedClosed := false
 	wrapped := &errReadCloser{
 		Reader: bytes.NewReader(nil),
 		closed: false,
@@ -824,7 +825,6 @@ func TestStreamWrapReaderCloseClosesInnerAndWrapped(t *testing.T) {
 	assertNilF(t, err)
 	assertTrueF(t, inner.closed, "inner ReadCloser should be closed")
 	assertTrueF(t, wrapped.closed, "wrapped body should be closed")
-	_ = wrappedClosed
 }
 
 func TestStreamWrapReaderCloseNonClosableInner(t *testing.T) {

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -622,10 +622,11 @@ func TestArrowStreamBatchResetPropagatesCloseError(t *testing.T) {
 	assertNilF(t, batch.rr, "rr should be nil after Reset even on error")
 }
 
-func TestArrowStreamBatchResetAllowsRedownload(t *testing.T) {
-	// After Reset, GetStream should re-invoke the download path.
-	// We simulate this by setting rr, resetting, then confirming rr is nil
-	// so GetStream would attempt a fresh download.
+func TestArrowStreamBatchResetClearsCachedReader(t *testing.T) {
+	// Reset should close and nil-out the cached reader so that a
+	// subsequent GetStream (tested separately with a full downloader
+	// in TestArrowStreamBatchResetThenGetStreamRedownloads) would
+	// attempt a fresh download.
 	rc := &errReadCloser{Reader: bytes.NewReader([]byte("stale"))}
 	batch := ArrowStreamBatch{rr: rc}
 
@@ -680,6 +681,7 @@ func TestArrowStreamBatchResetThenGetStreamRedownloads(t *testing.T) {
 	// First download.
 	stream1, err := batch.GetStream(context.Background())
 	assertNilF(t, err)
+	defer stream1.Close()
 	data1, err := io.ReadAll(stream1)
 	assertNilF(t, err)
 	assertEqualE(t, callCount, 1)

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -708,7 +708,7 @@ func TestArrowStreamBatchResetThenGetStreamRedownloads(t *testing.T) {
 	callCount := 0
 	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
 		callCount++
-		body := []byte(fmt.Sprintf("payload-%d", callCount))
+		body := fmt.Appendf(nil, "payload-%d", callCount)
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewReader(body)),

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -630,10 +630,14 @@ func TestArrowStreamBatchResetClearsCachedReader(t *testing.T) {
 	rc := &errReadCloser{Reader: bytes.NewReader([]byte("stale"))}
 	batch := ArrowStreamBatch{rr: rc}
 
-	// Confirm GetStream returns the cached reader before Reset.
+	// Confirm GetStream serves the cached reader's bytes before Reset.
+	// The returned stream is wrapped (e.g. cancelableStream), so we
+	// verify behavior rather than pointer identity.
 	stream, err := batch.GetStream(context.Background())
 	assertNilF(t, err, "GetStream on cached reader should succeed")
-	assertEqualF(t, stream, io.ReadCloser(rc), "GetStream should return cached reader")
+	got, err := io.ReadAll(stream)
+	assertNilF(t, err, "reading cached stream should succeed")
+	assertEqualF(t, string(got), "stale", "GetStream should return cached reader's bytes")
 
 	// Reset clears the cache.
 	err = batch.Reset()

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -617,7 +617,7 @@ func TestArrowStreamBatchResetPropagatesCloseError(t *testing.T) {
 	batch := ArrowStreamBatch{rr: rc}
 
 	err := batch.Reset()
-	assertTrueF(t, errors.Is(err, expected), "Reset should propagate close error")
+	assertErrIsF(t, err, expected, "Reset should propagate close error")
 	// rr should still be nilled out even when Close returns an error.
 	assertNilF(t, batch.rr, "rr should be nil after Reset even on error")
 }
@@ -632,12 +632,12 @@ func TestArrowStreamBatchResetClearsCachedReader(t *testing.T) {
 
 	// Confirm GetStream returns the cached reader before Reset.
 	stream, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
-	assertTrueF(t, stream == rc, "GetStream should return cached reader")
+	assertNilF(t, err, "GetStream on cached reader should succeed")
+	assertEqualF(t, stream, io.ReadCloser(rc), "GetStream should return cached reader")
 
 	// Reset clears the cache.
 	err = batch.Reset()
-	assertNilF(t, err)
+	assertNilF(t, err, "Reset should succeed")
 	assertNilF(t, batch.rr, "rr should be nil after Reset")
 }
 
@@ -653,7 +653,7 @@ func TestArrowStreamBatchResetRestoresInlineReaderOnCloseError(t *testing.T) {
 	batch := ArrowStreamBatch{rr: rc, inlineData: inline}
 
 	err := batch.Reset()
-	assertTrueF(t, errors.Is(err, expected), "Reset should propagate close error")
+	assertErrIsF(t, err, expected, "Reset should propagate close error")
 	assertTrueF(t, rc.closed, "underlying reader should have been closed")
 	assertNotNilF(t, batch.rr, "rr should be restored from inlineData even after close error")
 
@@ -775,8 +775,8 @@ func TestArrowStreamBatchGetStreamGzipped(t *testing.T) {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	_, err := gw.Write([]byte("decompressed payload"))
-	assertNilF(t, err)
-	assertNilF(t, gw.Close())
+	assertNilF(t, err, "gzip Write should succeed")
+	assertNilF(t, gw.Close(), "gzip Close should succeed")
 	gzBytes := buf.Bytes()
 
 	mockGet := func(_ context.Context, _ *snowflakeConn, _ string, _ map[string]string, _ time.Duration) (*http.Response, error) {
@@ -807,7 +807,7 @@ func TestArrowStreamBatchGetStreamNon200(t *testing.T) {
 	batch := newTestArrowStreamBatch(mockGet)
 	_, err := batch.GetStream(context.Background())
 	var sfErr *SnowflakeError
-	assertTrueF(t, errors.As(err, &sfErr), "should return SnowflakeError")
+	assertErrorsAsF(t, err, &sfErr, "should return SnowflakeError")
 	assertEqualF(t, sfErr.Number, ErrFailedToGetChunk, "error number should be ErrFailedToGetChunk")
 }
 
@@ -820,7 +820,7 @@ func TestArrowStreamBatchGetStreamFuncGetError(t *testing.T) {
 
 	batch := newTestArrowStreamBatch(mockGet)
 	_, err := batch.GetStream(context.Background())
-	assertTrueF(t, errors.Is(err, expected), "should propagate FuncGet error")
+	assertErrIsF(t, err, expected, "should propagate FuncGet error")
 }
 
 func TestArrowStreamBatchResetThenGetStreamAfterError(t *testing.T) {
@@ -865,7 +865,7 @@ func TestStreamWrapReaderCloseClosesInnerAndWrapped(t *testing.T) {
 	}
 	w := &streamWrapReader{Reader: inner, wrapped: wrapped}
 	err := w.Close()
-	assertNilF(t, err)
+	assertNilF(t, err, "Close should succeed when neither close errors")
 	assertTrueF(t, inner.closed, "inner ReadCloser should be closed")
 	assertTrueF(t, wrapped.closed, "wrapped body should be closed")
 }
@@ -875,7 +875,7 @@ func TestStreamWrapReaderCloseNonClosableInner(t *testing.T) {
 	wrapped := &errReadCloser{Reader: bytes.NewReader(nil)}
 	w := &streamWrapReader{Reader: bytes.NewReader(nil), wrapped: wrapped}
 	err := w.Close()
-	assertNilF(t, err)
+	assertNilF(t, err, "Close should succeed when only wrapped is closable")
 	assertTrueF(t, wrapped.closed, "wrapped body should be closed")
 }
 
@@ -886,7 +886,7 @@ func TestStreamWrapReaderClosePropagatesInnerError(t *testing.T) {
 	wrapped := &errReadCloser{Reader: bytes.NewReader(nil)}
 	w := &streamWrapReader{Reader: inner, wrapped: wrapped}
 	err := w.Close()
-	assertTrueF(t, errors.Is(err, expected), "should propagate inner close error")
+	assertErrIsF(t, err, expected, "should propagate inner close error")
 	// wrapped should NOT have been closed because inner errored first.
 	assertFalseE(t, wrapped.closed, "wrapped should not close if inner errors")
 }
@@ -905,7 +905,7 @@ func TestArrowStreamBatchResetClosesStreamWrapReader(t *testing.T) {
 			wrapped: body,
 		},
 	}
-	assertNilF(t, batch.Reset())
+	assertNilF(t, batch.Reset(), "Reset should succeed")
 	assertNilF(t, batch.rr, "rr should be nil after Reset")
 	assertTrueF(t, wrappedClosed, "wrapped HTTP body should be closed")
 }
@@ -915,8 +915,8 @@ func TestArrowStreamBatchResetClosesGzipStreamWrapReader(t *testing.T) {
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	_, err := gw.Write([]byte("hello"))
-	assertNilF(t, err)
-	assertNilF(t, gw.Close())
+	assertNilF(t, err, "gzip Write should succeed")
+	assertNilF(t, gw.Close(), "gzip Close should succeed")
 
 	wrappedClosed := false
 	body := &fakeResponseBody{
@@ -924,11 +924,11 @@ func TestArrowStreamBatchResetClosesGzipStreamWrapReader(t *testing.T) {
 		onClose: func() { wrappedClosed = true },
 	}
 	gr, err := gzip.NewReader(bytes.NewReader(buf.Bytes()))
-	assertNilF(t, err)
+	assertNilF(t, err, "gzip.NewReader should succeed")
 
 	batch := ArrowStreamBatch{
 		rr: &streamWrapReader{Reader: gr, wrapped: body},
 	}
-	assertNilF(t, batch.Reset())
+	assertNilF(t, batch.Reset(), "Reset should succeed")
 	assertTrueF(t, wrappedClosed, "wrapped HTTP body should be closed via gzip reader")
 }

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -659,8 +659,8 @@ func TestArrowStreamBatchResetRestoresInlineReaderOnCloseError(t *testing.T) {
 
 	// Verify the restored reader yields the inline payload.
 	got, readErr := io.ReadAll(batch.rr)
-	assertNilF(t, readErr)
-	assertEqualE(t, string(got), string(inline))
+	assertNilF(t, readErr, "reading restored inline reader should succeed")
+	assertEqualE(t, string(got), string(inline), "restored reader should yield inlineData")
 }
 
 func TestArrowStreamBatchResetRestoresInlineReader(t *testing.T) {
@@ -671,13 +671,13 @@ func TestArrowStreamBatchResetRestoresInlineReader(t *testing.T) {
 	batch := ArrowStreamBatch{rr: rc, inlineData: inline}
 
 	err := batch.Reset()
-	assertNilF(t, err)
+	assertNilF(t, err, "Reset should not return error on successful close")
 	assertTrueF(t, rc.closed, "underlying reader should have been closed")
 	assertNotNilF(t, batch.rr, "rr should be restored from inlineData")
 
 	got, readErr := io.ReadAll(batch.rr)
-	assertNilF(t, readErr)
-	assertEqualE(t, string(got), string(inline))
+	assertNilF(t, readErr, "reading restored inline reader should succeed")
+	assertEqualE(t, string(got), string(inline), "restored reader should yield inlineData")
 }
 
 func TestArrowStreamBatchDoubleResetIsIdempotent(t *testing.T) {
@@ -719,22 +719,22 @@ func TestArrowStreamBatchResetThenGetStreamRedownloads(t *testing.T) {
 
 	// First download.
 	stream1, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
+	assertNilF(t, err, "first GetStream should succeed")
 	defer stream1.Close()
 	data1, err := io.ReadAll(stream1)
-	assertNilF(t, err)
-	assertEqualE(t, callCount, 1)
+	assertNilF(t, err, "reading first stream should succeed")
+	assertEqualE(t, callCount, 1, "FuncGet should have been called once")
 
 	// Reset clears cached reader.
-	assertNilF(t, batch.Reset())
+	assertNilF(t, batch.Reset(), "Reset after first read should succeed")
 
 	// Second download — FuncGet is called again.
 	stream2, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
+	assertNilF(t, err, "second GetStream should succeed")
 	defer stream2.Close()
 	data2, err := io.ReadAll(stream2)
-	assertNilF(t, err)
-	assertEqualE(t, callCount, 2)
+	assertNilF(t, err, "reading second stream should succeed")
+	assertEqualE(t, callCount, 2, "FuncGet should have been called twice after Reset")
 
 	// Content should differ, proving it was re-downloaded.
 	assertFalseE(t, bytes.Equal(data1, data2), "re-downloaded data should differ from original")
@@ -755,19 +755,19 @@ func TestArrowStreamBatchResetAfterPartialRead(t *testing.T) {
 
 	// Read only a few bytes (simulate partial/failed read).
 	stream, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
+	assertNilF(t, err, "initial GetStream should succeed")
 	partial := make([]byte, 5)
 	_, err = stream.Read(partial)
-	assertNilF(t, err)
+	assertNilF(t, err, "partial read should succeed")
 
 	// Reset and re-download the full payload.
-	assertNilF(t, batch.Reset())
+	assertNilF(t, batch.Reset(), "Reset after partial read should succeed")
 	stream2, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
+	assertNilF(t, err, "GetStream after Reset should succeed")
 	defer stream2.Close()
 	full, err := io.ReadAll(stream2)
-	assertNilF(t, err)
-	assertEqualE(t, string(full), string(fullPayload))
+	assertNilF(t, err, "reading full payload should succeed")
+	assertEqualE(t, string(full), string(fullPayload), "re-downloaded payload should match original")
 }
 
 func TestArrowStreamBatchGetStreamGzipped(t *testing.T) {
@@ -788,10 +788,11 @@ func TestArrowStreamBatchGetStreamGzipped(t *testing.T) {
 
 	batch := newTestArrowStreamBatch(mockGet)
 	stream, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
+	assertNilF(t, err, "GetStream should succeed")
+	defer stream.Close()
 	data, err := io.ReadAll(stream)
-	assertNilF(t, err)
-	assertEqualE(t, string(data), "decompressed payload")
+	assertNilF(t, err, "reading decompressed stream should succeed")
+	assertEqualE(t, string(data), "decompressed payload", "gzip-decoded payload should match")
 }
 
 func TestArrowStreamBatchGetStreamNon200(t *testing.T) {
@@ -807,7 +808,7 @@ func TestArrowStreamBatchGetStreamNon200(t *testing.T) {
 	_, err := batch.GetStream(context.Background())
 	var sfErr *SnowflakeError
 	assertTrueF(t, errors.As(err, &sfErr), "should return SnowflakeError")
-	assertEqualE(t, sfErr.Number, ErrFailedToGetChunk)
+	assertEqualF(t, sfErr.Number, ErrFailedToGetChunk, "error number should be ErrFailedToGetChunk")
 }
 
 func TestArrowStreamBatchGetStreamFuncGetError(t *testing.T) {
@@ -840,17 +841,18 @@ func TestArrowStreamBatchResetThenGetStreamAfterError(t *testing.T) {
 
 	// First attempt fails.
 	_, err := batch.GetStream(context.Background())
-	assertNotNilE(t, err)
+	assertNotNilE(t, err, "first GetStream should fail with transient error")
 
 	// Reset (rr is still nil since download failed, but Reset is safe).
-	assertNilF(t, batch.Reset())
+	assertNilF(t, batch.Reset(), "Reset after failed download should succeed")
 
 	// Retry succeeds.
 	stream, err := batch.GetStream(context.Background())
-	assertNilF(t, err)
+	assertNilF(t, err, "retry GetStream should succeed")
+	defer stream.Close()
 	data, err := io.ReadAll(stream)
-	assertNilF(t, err)
-	assertEqualE(t, string(data), "ok")
+	assertNilF(t, err, "reading retried stream should succeed")
+	assertEqualE(t, string(data), "ok", "retried payload should match")
 }
 
 func TestStreamWrapReaderCloseClosesInnerAndWrapped(t *testing.T) {

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -702,6 +702,15 @@ func newTestArrowStreamBatch(funcGet func(context.Context, *snowflakeConn, strin
 	return ArrowStreamBatch{idx: 0, scd: scd}
 }
 
+// static200OK adapts a fixed response body into a FuncGet that always returns
+// HTTP 200. Use it when a test only cares about the bytes the chunk downloader
+// reads, not request semantics.
+func static200OK(body io.ReadCloser) func(context.Context, *snowflakeConn, string, map[string]string, time.Duration) (*http.Response, error) {
+	return func(context.Context, *snowflakeConn, string, map[string]string, time.Duration) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	}
+}
+
 func TestArrowStreamBatchResetThenGetStreamRedownloads(t *testing.T) {
 	// After Reset, calling GetStream should invoke FuncGet again,
 	// proving the chunk is actually re-downloaded.

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -641,6 +641,45 @@ func TestArrowStreamBatchResetClearsCachedReader(t *testing.T) {
 	assertNilF(t, batch.rr, "rr should be nil after Reset")
 }
 
+func TestArrowStreamBatchResetRestoresInlineReaderOnCloseError(t *testing.T) {
+	// For inline (RowSetBase64) batches, Reset must restore rr from
+	// inlineData even when the underlying Close returns an error, so
+	// that the batch remains usable for retry. Otherwise GetStream
+	// would fall through to downloadChunkStreamHelper, which has no
+	// chunk URL for inline batches.
+	expected := errors.New("close failed")
+	rc := &errReadCloser{Reader: bytes.NewReader(nil), closeErr: expected}
+	inline := []byte("inline payload")
+	batch := ArrowStreamBatch{rr: rc, inlineData: inline}
+
+	err := batch.Reset()
+	assertTrueF(t, errors.Is(err, expected), "Reset should propagate close error")
+	assertTrueF(t, rc.closed, "underlying reader should have been closed")
+	assertNotNilF(t, batch.rr, "rr should be restored from inlineData even after close error")
+
+	// Verify the restored reader yields the inline payload.
+	got, readErr := io.ReadAll(batch.rr)
+	assertNilF(t, readErr)
+	assertEqualE(t, string(got), string(inline))
+}
+
+func TestArrowStreamBatchResetRestoresInlineReader(t *testing.T) {
+	// Reset on an inline batch should leave rr pointing at a fresh
+	// reader over inlineData (successful Close path).
+	rc := &errReadCloser{Reader: bytes.NewReader([]byte("consumed"))}
+	inline := []byte("inline payload")
+	batch := ArrowStreamBatch{rr: rc, inlineData: inline}
+
+	err := batch.Reset()
+	assertNilF(t, err)
+	assertTrueF(t, rc.closed, "underlying reader should have been closed")
+	assertNotNilF(t, batch.rr, "rr should be restored from inlineData")
+
+	got, readErr := io.ReadAll(batch.rr)
+	assertNilF(t, readErr)
+	assertEqualE(t, string(got), string(inline))
+}
+
 func TestArrowStreamBatchDoubleResetIsIdempotent(t *testing.T) {
 	// Calling Reset twice should not error the second time.
 	rc := &errReadCloser{Reader: bytes.NewReader([]byte("data"))}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -674,6 +674,7 @@ func TestQueryArrowStreamResetAndRereadBatch(t *testing.T) {
 		// First read.
 		stream1, err := batches[idx].GetStream(sct.sc.ctx)
 		assertNilF(t, err)
+		defer stream1.Close()
 		data1, err := io.ReadAll(stream1)
 		assertNilF(t, err)
 		assertTrueF(t, len(data1) > 0, "first read should return data")

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -653,3 +653,42 @@ func TestQueryArrowStreamArrowResponseExposesFormat(t *testing.T) {
 		assertTrueF(t, len(batches) > 0, "should have Arrow batches")
 	})
 }
+
+func TestQueryArrowStreamResetAndRereadBatch(t *testing.T) {
+	runSnowflakeConnTest(t, func(sct *SCTest) {
+		numrows := 50000
+		query := fmt.Sprintf(selectRandomGenerator, numrows)
+		loader, err := sct.sc.QueryArrowStream(sct.sc.ctx, query)
+		assertNilF(t, err)
+
+		batches, err := loader.GetBatches()
+		assertNilF(t, err)
+		assertTrueF(t, len(batches) > 0, "should have at least one batch")
+
+		// Pick a batch that requires a download (skip index 0 which may be inline).
+		idx := 0
+		if len(batches) > 1 {
+			idx = 1
+		}
+
+		// First read.
+		stream1, err := batches[idx].GetStream(sct.sc.ctx)
+		assertNilF(t, err)
+		data1, err := io.ReadAll(stream1)
+		assertNilF(t, err)
+		assertTrueF(t, len(data1) > 0, "first read should return data")
+
+		// Reset the batch.
+		assertNilF(t, batches[idx].Reset())
+
+		// Re-read the same batch.
+		stream2, err := batches[idx].GetStream(sct.sc.ctx)
+		assertNilF(t, err)
+		data2, err := io.ReadAll(stream2)
+		assertNilF(t, err)
+		assertTrueF(t, len(data2) > 0, "re-read after Reset should return data")
+
+		// Both reads should return the same content.
+		assertTrueF(t, bytes.Equal(data1, data2), "data should match after Reset + re-download")
+	})
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -684,6 +684,7 @@ func TestQueryArrowStreamResetAndRereadBatch(t *testing.T) {
 		// Re-read the same batch.
 		stream2, err := batches[idx].GetStream(sct.sc.ctx)
 		assertNilF(t, err)
+		defer stream2.Close()
 		data2, err := io.ReadAll(stream2)
 		assertNilF(t, err)
 		assertTrueF(t, len(data2) > 0, "re-read after Reset should return data")

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -659,10 +659,10 @@ func TestQueryArrowStreamResetAndRereadBatch(t *testing.T) {
 		numrows := 50000
 		query := fmt.Sprintf(selectRandomGenerator, numrows)
 		loader, err := sct.sc.QueryArrowStream(sct.sc.ctx, query)
-		assertNilF(t, err)
+		assertNilF(t, err, "QueryArrowStream should succeed")
 
 		batches, err := loader.GetBatches()
-		assertNilF(t, err)
+		assertNilF(t, err, "GetBatches should succeed")
 		assertTrueF(t, len(batches) > 0, "should have at least one batch")
 
 		// Pick a batch that requires a download (skip index 0 which may be inline).
@@ -673,24 +673,24 @@ func TestQueryArrowStreamResetAndRereadBatch(t *testing.T) {
 
 		// First read.
 		stream1, err := batches[idx].GetStream(sct.sc.ctx)
-		assertNilF(t, err)
+		assertNilF(t, err, "first GetStream should succeed")
 		defer stream1.Close()
 		data1, err := io.ReadAll(stream1)
-		assertNilF(t, err)
+		assertNilF(t, err, "reading first stream should succeed")
 		assertTrueF(t, len(data1) > 0, "first read should return data")
 
 		// Reset the batch.
-		assertNilF(t, batches[idx].Reset())
+		assertNilF(t, batches[idx].Reset(), "Reset should succeed")
 
 		// Re-read the same batch.
 		stream2, err := batches[idx].GetStream(sct.sc.ctx)
-		assertNilF(t, err)
+		assertNilF(t, err, "second GetStream should succeed")
 		defer stream2.Close()
 		data2, err := io.ReadAll(stream2)
-		assertNilF(t, err)
+		assertNilF(t, err, "reading second stream should succeed")
 		assertTrueF(t, len(data2) > 0, "re-read after Reset should return data")
 
 		// Both reads should return the same content.
-		assertTrueF(t, bytes.Equal(data1, data2), "data should match after Reset + re-download")
+		assertBytesEqualE(t, data1, data2, "data should match after Reset + re-download")
 	})
 }


### PR DESCRIPTION
## Description

Adds `ArrowStreamBatch.Reset()` so callers can retry a chunk download after a mid-stream failure (e.g. a TCP RST from cloud storage) without re-executing the whole query.

Addresses #1781: customers using ADBC → goSnowflake from Power BI hit `arrow/ipc: could not read message body: ... An existing connection was forcibly closed by the remote host.` mid-stream during long Arrow reads. The TCP reset happens on the chunk download connection to S3/Azure Blob, so `ClientSessionKeepAlive` doesn't help — it keeps the Snowflake control-plane session alive, not the chunk transfer. Without a way to clear the cached reader, the only recovery path was re-executing the query.

`Reset()` closes the in-flight reader and nils out the cached `rr`, so the next `GetStream()` triggers a fresh chunk download (or, for inline `RowSetBase64` batches, restores the inline reader from `inlineData`). The mid-read failure becomes a recoverable retry instead of a query-level redo.

### Checklist
- [ ] Added proper logging (if possible)
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

---

Mirror of #1782 by @davidhcoe.

Co-authored-by: davidhcoe <13318837+davidhcoe@users.noreply.github.com>