### PR TITLE
SNOW-3438406: `os.RemoveAll()` in OCSP cache lockdir initialization to prevent issues which are more frequent on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 
 Bug fixes:
 
+- Fixed stale OCSP cache `.lck` directory permanently blocking cache writes (and forcing an online OCSP validation if OCSP is enabled, as is by default) on Windows by using `os.RemoveAll` instead of `os.Remove` for stale lock recovery (snowflakedb/gosnowflake#XXXX).
 - Fixed `baseName` silently dropping files whose name ends with a dot (e.g. `myfile.txt.`), which caused PUT uploads to discard such files without error (snowflakedb/gosnowflake#1788).
 - Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#1784).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features:
 
 Bug fixes:
 
-- Fixed stale OCSP cache `.lck` directory permanently blocking cache writes (and forcing an online OCSP validation if OCSP is enabled, as is by default) on Windows by using `os.RemoveAll` instead of `os.Remove` for stale lock recovery (snowflakedb/gosnowflake#XXXX).
+- Fixed stale OCSP cache `.lck` directory permanently blocking cache writes (and forcing an online OCSP validation if OCSP is enabled, as is by default) by using `os.RemoveAll` instead of `os.Remove` for stale lock recovery (snowflakedb/gosnowflake#1793).
 - Fixed `baseName` silently dropping files whose name ends with a dot (e.g. `myfile.txt.`), which caused PUT uploads to discard such files without error (snowflakedb/gosnowflake#1788).
 - Improved error message when `Host` is incorrectly configured with a URL scheme (e.g. `https://myorg-myaccount.snowflakecomputing.com`), previously this produced a cryptic `260004: failed to parse a port number` error (snowflakedb/gosnowflake#1784).
 

--- a/ocsp.go
+++ b/ocsp.go
@@ -1008,7 +1008,7 @@ func (ov *ocspValidator) writeOCSPCacheFile() {
 			logger.Debugf("other process locks the cache file. %v. ignored.\n", cacheLockFileName)
 			return
 		}
-		if err = os.Remove(cacheLockFileName); err != nil {
+		if err = os.RemoveAll(cacheLockFileName); err != nil {
 			logger.Debugf("failed to delete lock file. file: %v, err: %v. ignored.\n", cacheLockFileName, err)
 			return
 		}


### PR DESCRIPTION
### Preamble to reviewers
It is not in scope for this PR to do a bigger refactor on the locking mechanism to rebase it e.g. to a OS-level file locking mechanism which would be more robust

The scope of this PR is to keep the current approach we had in place and yet address the problem. 

A manual reproducer is available in the jira. 

### Description
We already had multiple customer complaints due to this issue which is more prominent on Windows; the troublecalls coming specifically from PowerBI -> ADBC which uses gosnowflake here. 

Some customers intermittently got weird
```
tls: received record with version 301 when expecting version 303
```

errors on intermittent occassions, coming from a privatelink environment (issue is not limited to privatelink, but since it's more restricted, it's also more likely to happen there)

After investigation on multiple sides, it looks like the issue has nothing to do with `crypto/tls` where it is coming from, but rather OCSP, which is unfortunately enabled by default whether it's needed or not. Suspected sequence of events:
1. OCSP `.lck` dir is created during [OCSP cache file write](https://github.com/snowflakedb/gosnowflake/blob/v1.19.1/ocsp.go#L998-L999)
  * note that there's a [proper cleanup](https://github.com/snowflakedb/gosnowflake/blob/v1.19.1/ocsp.go#L1025-L1028) for this dir after function executes, already `os.RemoveAll()` which works, if the process doesn't crash / killed and can actually get to the point where the `defer` is executed..
2. somehow, the parent process (which runs ADBC -> gosnowflake) exits in a way (e.g. crash) where the `defer` cannot apply
3. the process is started up again outside of the [15 minutes](https://github.com/snowflakedb/gosnowflake/blob/v1.19.1/ocsp.go#L1007-L1009) of 'safety' period and [tries to remove](https://github.com/snowflakedb/gosnowflake/blob/v1.19.1/ocsp.go#L1011-L1013) `os.Remove()` the stale lockdir
4. this could potentially fail on non-Windows too, but it's more expressed on Windows, due to some OS-specific factors where a directory might be very briefly and transiently considered as 'non empty' or a file lock held over on it for a brief period (e.g. Windows Defender, searchindexer, enterprise AV agents hooked into directory creation, etc.) - for whatever the reason is for 'non empty' directory, `os.Remove()` will fail and gives up (empty `return`)
5. OCSP local cache file never gets written , thus the driver is forced to do an online OCSP check with a OCSP Responder only reachable over the public internet, since the response is not available cached locally
6. the particular OCSP Responder -which always sits at `host:80`, thus plain http- is unreachable which is very often the case for port 80 connections and especially over the privatelink with any publicly exposed hosts
7. Connection is attempted multiple times, and enough time passes for S3 to drop the connection which sits idle for several seconds now , waiting for OCSP to happen..
8. TLS error is displayed.

### Fix
The fix in this setup is simply use `os.RemoveAll()` which should recursively delete the dir and everything inside it. For the current setup, it should be hopefully enough, since the stale `.lck` doesn't even attempted to be cleaned up with modify date < 15 minutes. It should be more than enough for those temporal locks to disappear, which were mentioned above. 

It would however address the situation where the directory permanently exist with content inside of it, and this won't go away by its own. And this is what we facing here.
(also as mentioned we're already using `os.RemoveAll()` in the `defer`red cleanup [here](https://github.com/snowflakedb/gosnowflake/blob/v1.19.1/ocsp.go#L1025-L1028))

This also doesn't change today's behaviour regarding multiple concurrent processes, since we have th 15m safety window. 