### PR TITLE
SNOW-3351450: emit client_connection_identifier_shape in-band telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 New features:
 
 - Added `ArrowStreamBatch.Reset()` method that closes any existing stream and clears the cached reader, allowing callers to retry `GetStream` after a mid-stream failure (e.g. TCP RST) without re-executing the entire query. Inline (RowSetBase64) batches are restored from cached bytes on reset.
+- Added one in-band telemetry record per successful login describing which connection-identifier fields the user supplied (`account_provided`, `account_with_region`, `account_org_provided`, `region_provided`, `host_provided`). No hostname or account value is included. This is gated by the existing server-side `CLIENT_TELEMETRY_ENABLED` parameter and can additionally be disabled locally by setting `SF_TELEMETRY_DISABLE_CONNECTION_SHAPE=true`. The telemetry collection is time-boxed and will be removed in a future release.
 
 Bug fixes:
 

--- a/connection_identifier_shape_telemetry_test.go
+++ b/connection_identifier_shape_telemetry_test.go
@@ -1,0 +1,114 @@
+package gosnowflake
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	sfconfig "github.com/snowflakedb/gosnowflake/v2/internal/config"
+)
+
+// newTestShapeConn returns a snowflakeConn with an enabled in-memory telemetry
+// client suitable for unit-testing connectionIdentifierShapeTelemetry without
+// requiring a real Snowflake account or HTTP plumbing. The returned conn's
+// telemetry.sr is nil, which is safe because the tests only exercise addLog
+// (which appends to st.logs without touching st.sr).
+func newTestShapeConn() *snowflakeConn {
+	return &snowflakeConn{
+		ctx: context.Background(),
+		telemetry: &snowflakeTelemetry{
+			mutex:     &sync.Mutex{},
+			enabled:   true,
+			flushSize: defaultFlushSize,
+		},
+	}
+}
+
+func TestConnectionIdentifierShapeTelemetryEmitsExpectedPayload(t *testing.T) {
+	t.Setenv(disableConnectionShapeEnv, "")
+	cfg := &Config{}
+	sfconfig.SetInputShape(cfg, &sfconfig.ConnectionIdentifierShape{
+		AccountProvided:    true,
+		AccountWithRegion:  true,
+		AccountOrgProvided: true,
+		RegionProvided:     false,
+		HostProvided:       false,
+	})
+	sc := newTestShapeConn()
+	sc.connectionIdentifierShapeTelemetry(cfg)
+
+	assertEqualF(t, len(sc.telemetry.logs), 1, "expected exactly one telemetry record")
+	msg := sc.telemetry.logs[0].Message
+	assertEqualE(t, msg[typeKey], connectionIdentifierShape)
+	assertEqualE(t, msg[sourceKey], telemetrySource)
+	assertEqualE(t, msg[driverTypeKey], "Go")
+	assertEqualE(t, msg[accountProvidedKey], "true")
+	assertEqualE(t, msg[accountWithRegionKey], "true")
+	assertEqualE(t, msg[accountOrgProvidedKey], "true")
+	assertEqualE(t, msg[regionProvidedKey], "false")
+	assertEqualE(t, msg[hostProvidedKey], "false")
+	assertNotEqualE(t, msg[driverVersionKey], "",
+		"driver version field should carry SnowflakeGoDriverVersion")
+	assertNotEqualE(t, msg[golangVersionKey], "",
+		"golang version field should carry runtime.Version()")
+}
+
+func TestConnectionIdentifierShapeTelemetrySkipsWhenInputShapeNil(t *testing.T) {
+	t.Setenv(disableConnectionShapeEnv, "")
+	sc := newTestShapeConn()
+	// A freshly-constructed Config has no shape set (SetInputShape not called).
+	sc.connectionIdentifierShapeTelemetry(&Config{})
+	assertEmptyE(t, sc.telemetry.logs,
+		"expected no telemetry record when shape is nil")
+}
+
+func TestConnectionIdentifierShapeTelemetrySkipsWhenCfgNil(t *testing.T) {
+	t.Setenv(disableConnectionShapeEnv, "")
+	sc := newTestShapeConn()
+	sc.connectionIdentifierShapeTelemetry(nil)
+	assertEmptyE(t, sc.telemetry.logs,
+		"expected no telemetry record when cfg is nil")
+}
+
+func TestConnectionIdentifierShapeTelemetryHonorsEnvKillSwitch(t *testing.T) {
+	// Only case-insensitive "true" disables, matching SF_DISABLE_MINICORE
+	// and the CHANGELOG documentation.
+	for _, v := range []string{"true", "True", "TRUE"} {
+		t.Run("disabled_by_"+v, func(t *testing.T) {
+			t.Setenv(disableConnectionShapeEnv, v)
+			cfg := &Config{}
+			sfconfig.SetInputShape(cfg, &sfconfig.ConnectionIdentifierShape{AccountProvided: true})
+			sc := newTestShapeConn()
+			sc.connectionIdentifierShapeTelemetry(cfg)
+			assertEmptyE(t, sc.telemetry.logs,
+				"expected no telemetry record when "+disableConnectionShapeEnv+"="+v)
+		})
+	}
+}
+
+func TestConnectionIdentifierShapeTelemetryEnvVarOffByDefault(t *testing.T) {
+	// Anything other than case-insensitive "true" (including former truthy
+	// aliases like "1" / "yes") must leave emission enabled.
+	for _, v := range []string{"", "0", "1", "yes", "Yes", "false", "no", "anything-else"} {
+		t.Run("not_disabled_by_"+v, func(t *testing.T) {
+			t.Setenv(disableConnectionShapeEnv, v)
+			cfg := &Config{}
+			sfconfig.SetInputShape(cfg, &sfconfig.ConnectionIdentifierShape{AccountProvided: true})
+			sc := newTestShapeConn()
+			sc.connectionIdentifierShapeTelemetry(cfg)
+			assertEqualF(t, len(sc.telemetry.logs), 1,
+				"expected exactly one telemetry record when "+disableConnectionShapeEnv+"="+v)
+		})
+	}
+}
+
+func TestConnectionIdentifierShapeTelemetryRespectsTelemetryDisabled(t *testing.T) {
+	t.Setenv(disableConnectionShapeEnv, "")
+	cfg := &Config{}
+	sfconfig.SetInputShape(cfg, &sfconfig.ConnectionIdentifierShape{AccountProvided: true})
+	sc := newTestShapeConn()
+	sc.telemetry.enabled = false // server said CLIENT_TELEMETRY_ENABLED=false
+	sc.connectionIdentifierShapeTelemetry(cfg)
+	assertEmptyE(t, sc.telemetry.logs,
+		"expected no telemetry record when sc.telemetry.enabled=false")
+}

--- a/connection_util.go
+++ b/connection_util.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	sfconfig "github.com/snowflakedb/gosnowflake/v2/internal/config"
 )
 
 func (sc *snowflakeConn) isClientSessionKeepAliveEnabled() bool {
@@ -93,6 +96,51 @@ func (sc *snowflakeConn) connectionTelemetry(cfg *Config) {
 	if err := sc.telemetry.sendBatch(); err != nil {
 		logger.WithContext(sc.ctx).Warnf("cannot send telemetry batch: %v", err)
 	}
+}
+
+// connectionIdentifierShapeTelemetry queues a single in-band telemetry record
+// describing the shape of the connection-identifier input the user supplied.
+// It does not send a batch on its own; the caller is expected to flush
+// telemetry shortly after (see OpenWithConfig). When shape capture has not
+// run, or the env-var kill switch is set, this is a no-op.
+//
+// TODO(SNOW-3548350): remove this method and its call site after the
+// connection-identifier-shape data collection wraps up (target: 2026-11-30).
+func (sc *snowflakeConn) connectionIdentifierShapeTelemetry(cfg *Config) {
+	if connectionShapeTelemetryDisabledByEnv() {
+		logger.WithContext(sc.ctx).Debug("connection-identifier-shape telemetry disabled via " + disableConnectionShapeEnv)
+		return
+	}
+	shape := sfconfig.InputShapeOf(cfg)
+	if shape == nil {
+		logger.WithContext(sc.ctx).Debug("connection-identifier-shape telemetry skipped: shape not captured")
+		return
+	}
+	data := &telemetryData{
+		Message: map[string]string{
+			typeKey:               connectionIdentifierShape,
+			sourceKey:             telemetrySource,
+			driverTypeKey:         "Go",
+			driverVersionKey:      SnowflakeGoDriverVersion,
+			golangVersionKey:      runtime.Version(),
+			accountProvidedKey:    strconv.FormatBool(shape.AccountProvided),
+			accountWithRegionKey:  strconv.FormatBool(shape.AccountWithRegion),
+			accountOrgProvidedKey: strconv.FormatBool(shape.AccountOrgProvided),
+			regionProvidedKey:     strconv.FormatBool(shape.RegionProvided),
+			hostProvidedKey:       strconv.FormatBool(shape.HostProvided),
+		},
+		Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+	}
+	if err := sc.telemetry.addLog(data); err != nil {
+		logger.WithContext(sc.ctx).Warnf("cannot add connection-identifier-shape telemetry log: %v", err)
+	}
+}
+
+func connectionShapeTelemetryDisabledByEnv() bool {
+	// CHANGELOG documents the value as exactly "true". Match minicore's
+	// SF_DISABLE_MINICORE convention by accepting case-insensitive "true"
+	// only — no truthy aliases.
+	return strings.EqualFold(os.Getenv(disableConnectionShapeEnv), "true")
 }
 
 // processFileTransfer creates a snowflakeFileTransferAgent object to process

--- a/driver.go
+++ b/driver.go
@@ -52,6 +52,12 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
+	// Shape capture for the post-login client_connection_identifier_shape
+	// telemetry happens inside FillMissingConfigParameters; callers that
+	// reach OpenWithConfig via ParseDSN / LoadConnectionConfig /
+	// Connector.Connect have already invoked it. Direct OpenWithConfig
+	// callers that skip FillMissingConfigParameters will simply emit no
+	// shape record (the telemetry hook is a no-op when shape is unset).
 	if config.Params == nil {
 		config.Params = make(map[string]*string)
 	}
@@ -86,6 +92,10 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 		logger.WithContext(ctx).Errorf("Failed to authenticate. Connection failed after %v milliseconds", time.Since(timer).String())
 		return nil, err
 	}
+	// Queue the connection-identifier-shape record first so it is flushed in
+	// the same batch as connectionTelemetry's sendBatch call (one HTTP request,
+	// not two).
+	sc.connectionIdentifierShapeTelemetry(&config)
 	sc.connectionTelemetry(&config)
 
 	sc.startHeartBeat()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,66 @@ type Config struct {
 	ProxyPassword string // Proxy password
 	ProxyProtocol string // Proxy protocol (http or https)
 	NoProxy       string // No proxy for this host list
+
+	// inputShape records which connection-identifier fields the user supplied
+	// (vs. which were inferred by the driver) and whether the account string the
+	// user supplied carried region/org information. It is populated by ParseDSN,
+	// LoadConnectionConfig, and by FillMissingConfigParameters for programmatic
+	// configs (which captures shape before any field is normalized), then
+	// consumed by post-login telemetry. May be nil if shape capture has not
+	// run yet; downstream code must nil-check via InputShapeOf.
+	//
+	// Unexported so it does not appear on the gosnowflake.Config type-alias's
+	// public surface; cross-package access goes through InputShapeOf and
+	// SetInputShape.
+	//
+	// TODO(SNOW-3548350): remove this field, its accessors, and the telemetry
+	// emission that uses it after the connection-identifier-shape data
+	// collection wraps up (target: 2026-11-30).
+	inputShape *ConnectionIdentifierShape
+}
+
+// ConnectionIdentifierShape captures the *shape* of the connection identifier
+// the user supplied: which of {account, region, host} they actually set, and
+// whether the raw account string they typed contained the substrings that
+// signal an "account.region" form (dot) or an "org-account" form (dash).
+//
+// Fields reflect user intent at the moment of input, not the final
+// post-normalization state of Config. For example, if a user supplies only
+// "myorg-myacct" as the account, the driver will later synthesize a Host —
+// AccountProvided will be true and HostProvided will remain false.
+type ConnectionIdentifierShape struct {
+	AccountProvided    bool
+	AccountWithRegion  bool // raw account string contains '.'
+	AccountOrgProvided bool // raw account string contains '-'
+	RegionProvided     bool
+	HostProvided       bool
+}
+
+// InputShapeOf returns the connection-identifier shape captured during DSN
+// parsing, TOML loading, or programmatic Config setup. Returns nil when shape
+// capture has not run; callers must nil-check.
+//
+// This is the only external read path for Config's unexported shape field;
+// the gosnowflake driver package uses it at post-login telemetry-emit time.
+func InputShapeOf(c *Config) *ConnectionIdentifierShape {
+	if c == nil {
+		return nil
+	}
+	return c.inputShape
+}
+
+// SetInputShape overwrites the connection-identifier shape on Config. It is
+// the external write path for the unexported shape field and exists so that
+// tests in the gosnowflake driver package can build Configs with a known
+// shape without going through DSN parsing. Production code paths populate
+// the shape via ParseDSN, LoadConnectionConfig, or
+// FillMissingConfigParameters and should not call this.
+func SetInputShape(c *Config, s *ConnectionIdentifierShape) {
+	if c == nil {
+		return
+	}
+	c.inputShape = s
 }
 
 var errTokenConfigConflict = errors.New("token and tokenFilePath cannot be specified at the same time")

--- a/internal/config/connection_configuration.go
+++ b/internal/config/connection_configuration.go
@@ -36,6 +36,7 @@ func LoadConnectionConfig() (*Config, error) {
 	cfg := &Config{
 		Params:        make(map[string]*string),
 		Authenticator: AuthTypeSnowflake, // Default to snowflake
+		inputShape:    &ConnectionIdentifierShape{},
 	}
 	dsn := getConnectionDSN(os.Getenv(snowflakeConnectionName))
 	snowflakeConfigDir, err := GetTomlFilePath(os.Getenv(snowflakeHome))
@@ -105,8 +106,14 @@ func HandleSingleParam(cfg *Config, key string, value any) error {
 		cfg.Password, err = parseString(value)
 	case "host":
 		cfg.Host, err = parseString(value)
+		if err == nil && cfg.Host != "" && cfg.inputShape != nil {
+			cfg.inputShape.HostProvided = true
+		}
 	case "account":
 		cfg.Account, err = parseString(value)
+		if err == nil {
+			recordAccountShape(cfg.inputShape, cfg.Account)
+		}
 	case "warehouse":
 		cfg.Warehouse, err = parseString(value)
 	case "database":
@@ -117,6 +124,9 @@ func HandleSingleParam(cfg *Config, key string, value any) error {
 		cfg.Role, err = parseString(value)
 	case "region":
 		cfg.Region, err = parseString(value)
+		if err == nil && cfg.Region != "" && cfg.inputShape != nil {
+			cfg.inputShape.RegionProvided = true
+		}
 	case "protocol":
 		cfg.Protocol, err = parseString(value)
 	case "passcode":

--- a/internal/config/connection_identifier_shape_test.go
+++ b/internal/config/connection_identifier_shape_test.go
@@ -1,0 +1,226 @@
+package config
+
+import (
+	"testing"
+)
+
+// TestConnectionIdentifierShapeCapture exercises the user-vs-inferred
+// provenance recorded on Config's unexported inputShape field across the
+// three entry points (DSN, programmatic Config, TOML). The actual telemetry
+// emission lives in the gosnowflake package and is exercised separately.
+func TestConnectionIdentifierShapeCapture(t *testing.T) {
+	t.Run("ParseDSN", testShapeFromParseDSN)
+	t.Run("ProgrammaticConfig", testShapeFromProgrammaticConfig)
+	t.Run("ParseToml", testShapeFromToml)
+	t.Run("Idempotent", testInferIsIdempotent)
+}
+
+func testShapeFromParseDSN(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want ConnectionIdentifierShape
+	}{
+		{
+			name: "account_only_locator",
+			// Authority is a bare account locator. Region/host are inferred.
+			dsn: "u:p@myacct/db",
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+			},
+		},
+		{
+			name: "account_with_region_via_authority",
+			// "myacct.us-east-1" is account-form; dot signals region embedded.
+			dsn: "u:p@myacct.us-east-1/db",
+			want: ConnectionIdentifierShape{
+				AccountProvided:   true,
+				AccountWithRegion: true,
+			},
+		},
+		{
+			name: "org_account_via_authority_global",
+			// Dash signals org-prefixed account; ".global" host triggers
+			// the org-id strip in FillMissingConfigParameters.
+			dsn: "u:p@myorg-myacct.global/db",
+			want: ConnectionIdentifierShape{
+				AccountProvided:    true,
+				AccountWithRegion:  true, // also has '.' before normalization
+				AccountOrgProvided: true,
+			},
+		},
+		{
+			name: "host_explicit_in_authority",
+			// Full hostname; account inferred from first DNS label later.
+			dsn: "u:p@myacct.us-east-1.aws.snowflakecomputing.com:443/db",
+			want: ConnectionIdentifierShape{
+				HostProvided: true,
+			},
+		},
+		{
+			name: "account_query_param",
+			// Bare host less form; account supplied via ?account=.
+			dsn: "u:p@/db?account=myacct",
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+			},
+		},
+		{
+			name: "account_and_region_query_params",
+			dsn:  "u:p@/db?account=myacct&region=us-east-1",
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+				RegionProvided:  true,
+			},
+		},
+		{
+			name: "host_authority_account_query_param",
+			dsn:  "u:p@myacct.us-east-1.aws.snowflakecomputing.com:443/db?account=myacct",
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+				HostProvided:    true,
+			},
+		},
+		{
+			name: "non_snowflake_host_with_port",
+			// Localhost / proxy / private-DNS targets do not carry the
+			// Snowflake TLD, but an explicit port disables the account-form
+			// rewrite in transformAccountToHost — so the user did supply a
+			// host and must be recorded as such.
+			dsn: "u:p@localhost:8080/db?account=myacct",
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+				HostProvided:    true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseDSN(tc.dsn)
+			assertNilF(t, err, "ParseDSN("+tc.dsn+")")
+			assertNotNilF(t, cfg.inputShape, "ParseDSN("+tc.dsn+") left inputShape nil")
+			assertEqualE(t, *cfg.inputShape, tc.want)
+		})
+	}
+}
+
+func testShapeFromProgrammaticConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want ConnectionIdentifierShape
+	}{
+		{
+			name: "bare_account",
+			cfg:  Config{Account: "myacct"},
+			want: ConnectionIdentifierShape{AccountProvided: true},
+		},
+		{
+			name: "account_with_dot_and_dash",
+			cfg:  Config{Account: "myorg-myacct.us-east-1"},
+			want: ConnectionIdentifierShape{
+				AccountProvided:    true,
+				AccountWithRegion:  true,
+				AccountOrgProvided: true,
+			},
+		},
+		{
+			name: "host_only",
+			cfg:  Config{Host: "myacct.snowflakecomputing.com"},
+			want: ConnectionIdentifierShape{HostProvided: true},
+		},
+		{
+			name: "all_three",
+			cfg: Config{
+				Account: "myacct",
+				Region:  "us-east-1",
+				Host:    "myacct.us-east-1.aws.snowflakecomputing.com",
+			},
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+				RegionProvided:  true,
+				HostProvided:    true,
+			},
+		},
+		{
+			name: "empty",
+			cfg:  Config{},
+			want: ConnectionIdentifierShape{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			inferInputShapeIfMissing(&cfg)
+			assertNotNilF(t, cfg.inputShape, "inferInputShapeIfMissing left inputShape nil")
+			assertEqualE(t, *cfg.inputShape, tc.want)
+		})
+	}
+}
+
+func testShapeFromToml(t *testing.T) {
+	cases := []struct {
+		name string
+		toml map[string]any
+		want ConnectionIdentifierShape
+	}{
+		{
+			name: "account_and_region",
+			toml: map[string]any{
+				"account": "myacct",
+				"region":  "us-east-1",
+				"user":    "u",
+			},
+			want: ConnectionIdentifierShape{
+				AccountProvided: true,
+				RegionProvided:  true,
+			},
+		},
+		{
+			name: "host_only",
+			toml: map[string]any{
+				"host": "myacct.snowflakecomputing.com",
+				"user": "u",
+			},
+			want: ConnectionIdentifierShape{HostProvided: true},
+		},
+		{
+			name: "org_account_only",
+			toml: map[string]any{
+				"account": "myorg-myacct",
+				"user":    "u",
+			},
+			want: ConnectionIdentifierShape{
+				AccountProvided:    true,
+				AccountOrgProvided: true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Params:     make(map[string]*string),
+				inputShape: &ConnectionIdentifierShape{},
+			}
+			assertNilF(t, ParseToml(cfg, tc.toml), "ParseToml")
+			assertNotNilF(t, cfg.inputShape, "ParseToml left inputShape nil")
+			assertEqualE(t, *cfg.inputShape, tc.want)
+		})
+	}
+}
+
+func testInferIsIdempotent(t *testing.T) {
+	preset := &ConnectionIdentifierShape{AccountProvided: true}
+	cfg := Config{
+		Account:    "myacct",
+		Host:       "myacct.snowflakecomputing.com",
+		inputShape: preset,
+	}
+	inferInputShapeIfMissing(&cfg)
+	assertEqualF(t, cfg.inputShape, preset,
+		"inferInputShapeIfMissing overwrote existing inputShape pointer")
+	// HostProvided was *not* set on the preset and must remain false because
+	// shape capture must not run twice on the same Config.
+	assertFalseE(t, cfg.inputShape.HostProvided,
+		"inferInputShapeIfMissing mutated an already-populated inputShape")
+}

--- a/internal/config/dsn.go
+++ b/internal/config/dsn.go
@@ -304,12 +304,63 @@ func DSN(cfg *Config) (dsn string, err error) {
 	return
 }
 
+// recordAccountShape marks AccountProvided on shape and records whether the
+// raw account string carries a dot (region embedded) or a dash in its
+// account portion (org-prefixed). shape may be nil. rawAccount is the
+// user-supplied string before any normalization (truncation at the first
+// dot, dash stripping for .global, etc.).
+//
+// The org-account dash heuristic intentionally looks only at the substring
+// before the first dot, because a dash in the region portion (e.g.
+// "myacct.us-east-1") is not an org separator and would otherwise be
+// misclassified.
+func recordAccountShape(shape *ConnectionIdentifierShape, rawAccount string) {
+	if shape == nil || rawAccount == "" {
+		return
+	}
+	shape.AccountProvided = true
+	accountPortion := rawAccount
+	if i := strings.Index(rawAccount, "."); i > 0 {
+		shape.AccountWithRegion = true
+		accountPortion = rawAccount[:i]
+	}
+	if strings.Contains(accountPortion, "-") {
+		shape.AccountOrgProvided = true
+	}
+}
+
+// inferInputShapeIfMissing populates cfg.inputShape from the current Config
+// fields when shape capture has not already run (i.e. cfg was constructed
+// programmatically rather than via ParseDSN or LoadConnectionConfig). It is
+// a no-op when the shape is already non-nil.
+//
+// FillMissingConfigParameters runs this as its first step, before any field
+// mutation, so callers do not need to invoke it explicitly. The function
+// stays unexported because shape capture is an internal telemetry concern.
+func inferInputShapeIfMissing(cfg *Config) {
+	if cfg == nil || cfg.inputShape != nil {
+		return
+	}
+	shape := &ConnectionIdentifierShape{}
+	if cfg.Account != "" {
+		recordAccountShape(shape, cfg.Account)
+	}
+	if cfg.Region != "" {
+		shape.RegionProvided = true
+	}
+	if cfg.Host != "" {
+		shape.HostProvided = true
+	}
+	cfg.inputShape = shape
+}
+
 // ParseDSN parses the DSN string to a Config.
 func ParseDSN(dsn string) (cfg *Config, err error) {
 	// New config with some default values
 	cfg = &Config{
 		Params:        make(map[string]*string),
 		Authenticator: AuthTypeSnowflake, // Default to snowflake
+		inputShape:    &ConnectionIdentifierShape{},
 	}
 
 	// user[:password]@account/database/schema[?param1=value1&paramN=valueN]
@@ -464,6 +515,12 @@ func applyAccountFromHostIfMissing(cfg *Config) {
 
 // FillMissingConfigParameters fills in default values for missing config parameters.
 func FillMissingConfigParameters(cfg *Config) error {
+	// Capture user-supplied provenance before any field below normalizes the
+	// Config. Idempotent: ParseDSN and LoadConnectionConfig have already set
+	// cfg.inputShape, so this only matters for programmatic Configs handed
+	// to FillMissingConfigParameters directly (e.g. via database/sql
+	// Connector or driver.OpenWithConfig).
+	inferInputShapeIfMissing(cfg)
 	applyAccountFromHostIfMissing(cfg)
 
 	if cfg.Host != "" {
@@ -657,6 +714,10 @@ func transformAccountToHost(cfg *Config) (err error) {
 	if cfg.Port == 0 && cfg.Host != "" && !hostIncludesTopLevelDomain(cfg.Host) {
 		// account name is specified instead of host:port
 		cfg.Account = cfg.Host
+		// Capture the user-supplied account shape before normalization
+		// truncates/rewrites it. A dot signals "account.region" form; a dash
+		// signals "org-account" form.
+		recordAccountShape(cfg.inputShape, cfg.Account)
 		region, posDot := extractRegionFromAccount(cfg.Account)
 		if strings.ToLower(region) == "us-west-2" {
 			region = ""
@@ -694,6 +755,20 @@ func parseAccountHostPort(cfg *Config, posAt, posSlash int, dsn string) (err err
 		}
 	}
 	cfg.Host = dsn[posAt+1 : k]
+	// The DSN carries a real host (not an account-form authority that
+	// transformAccountToHost will rewrite) when cfg.Host is non-empty AND
+	// either of:
+	//   1) the authority contains the Snowflake TLD, e.g. "myacct.snowflakecomputing.com", or
+	//   2) the authority carries an explicit port, e.g. "localhost:443" — the
+	//      transformAccountToHost guard only fires when Port == 0, so any
+	//      explicit port means we never rewrite Host out from under the user.
+	// The Host-non-empty check guards against degenerate forms like
+	// "u:p@:8080/db" where the port is set but the host slice is empty.
+	// Capture HostProvided in both real cases so non-Snowflake-TLD targets
+	// (localhost, IP, private DNS) aren't silently misclassified as host-not-provided.
+	if cfg.inputShape != nil && cfg.Host != "" && (hostIncludesTopLevelDomain(cfg.Host) || cfg.Port != 0) {
+		cfg.inputShape.HostProvided = true
+	}
 	return transformAccountToHost(cfg)
 }
 
@@ -741,6 +816,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		// Disable INFILE whitelist / enable all files
 		case "account":
 			cfg.Account = value
+			recordAccountShape(cfg.inputShape, value)
 		case "warehouse":
 			cfg.Warehouse = value
 		case "database":
@@ -751,6 +827,9 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.Role = value
 		case "region":
 			cfg.Region = value
+			if cfg.inputShape != nil {
+				cfg.inputShape.RegionProvided = true
+			}
 		case "protocol":
 			cfg.Protocol = value
 		case "singleAuthenticationPrompt":

--- a/telemetry.go
+++ b/telemetry.go
@@ -30,9 +30,44 @@ const (
 )
 
 const (
-	telemetrySource      = "golang_driver"
-	sqlException         = "client_sql_exception"
-	connectionParameters = "client_connection_parameters"
+	telemetrySource           = "golang_driver"
+	sqlException              = "client_sql_exception"
+	connectionParameters      = "client_connection_parameters"
+	connectionIdentifierShape = "client_connection_identifier_shape"
+	disableConnectionShapeEnv = "SF_TELEMETRY_DISABLE_CONNECTION_SHAPE"
+)
+
+// Wire-format keys for the client_connection_identifier_shape telemetry
+// event. Values are stringified booleans ("true" / "false") to match the
+// existing client_connection_parameters telemetry style. All fields describe
+// what the user supplied at the moment of input — they reflect intent, not
+// the final post-normalization state of Config.
+//
+//   - account_provided:     the user explicitly set Account (via DSN authority,
+//     "?account=", TOML, or programmatic Config).
+//   - account_with_region:  the raw account string the user typed contained a
+//     dot (e.g. "myacct.us-east-1"), signaling the deprecated
+//     "account.region" embedded form. Set only on the raw input.
+//   - account_org_provided: the raw account string carried a dash in its
+//     account portion (e.g. "myorg-myacct"), signaling the org-prefixed form.
+//     Region-portion dashes (e.g. the "-east-" in "myacct.us-east-1") are
+//     intentionally not counted; see recordAccountShape.
+//   - region_provided:      the user explicitly set Region as a distinct field
+//     (via "?region=", TOML, or programmatic Config). Note: a region embedded
+//     inside a dotted account string is NOT region_provided; that's
+//     account_with_region.
+//   - host_provided:        the user explicitly set Host. True when the DSN
+//     authority is a full hostname (Snowflake TLD) or carries an explicit
+//     port, when TOML sets host=, or when a programmatic Config sets Host.
+//
+// TODO(SNOW-3548350): remove these keys with the telemetry emission
+// (target: 2026-11-30).
+const (
+	accountProvidedKey    = "account_provided"
+	accountWithRegionKey  = "account_with_region"
+	accountOrgProvidedKey = "account_org_provided"
+	regionProvidedKey     = "region_provided"
+	hostProvidedKey       = "host_provided"
 )
 
 type telemetryData struct {


### PR DESCRIPTION
The Traffic team needs to understand how customers actually
supply connection-identifier inputs (`Account`, `Region`, `Host`) ahead of
the Northstar migration. This PR adds a single in-band telemetry event,
`client_connection_identifier_shape`, that captures which of those three
fields the user explicitly set and whether the raw account string carried
the dot ("account.region") or dash ("org-account") markers. The shape is
captured at the earliest parsing stage across DSN (`ParseDSN`), TOML
(`LoadConnectionConfig`), and programmatic `Config` (via
`InferInputShapeIfMissing` called from `Connector.Connect` and
`OpenWithConfig`), then emitted once at post-login time alongside the
existing `connectionTelemetry` hook. Provenance is recorded before
`FillMissingConfigParameters` mutates the `Config` so inferred values are
never misclassified as user-supplied.

The implementation mirrors how `snowflake-connector-python`
(`_log_minicore_import`) and `snowflake-jdbc` (`sendMinicoreTelemetry`)
route their analogous "minicore usage" telemetry: through
`sc.telemetry.addLog` to `/telemetry/send`, gated by the server-supplied
`CLIENT_TELEMETRY_ENABLED` session parameter that arrives in the login
response. A local `SF_TELEMETRY_DISABLE_CONNECTION_SHAPE` env-var kill
switch is wired in addition. The `Config.inputShape` field is unexported
and accessed across packages via `internal/config.InputShapeOf` (read)
and `internal/config.SetInputShape` (test setup), so the public
`gosnowflake.Config` API surface is unchanged.

This is the reference implementation; equivalents for
`snowflake-connector-python`, `snowflake-connector-nodejs`, and
`snowflake-jdbc` will land separately. The data collection is
time-boxed — removal is tracked in SNOW-3548350 with a target date of
2026-11-30.

### Checklist
- [x] Added proper logging (if possible)
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary