### PR TITLE
NO-SNOW Bumped minor version 2.0.2 -> 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 New features:
 
+Bug fixes:
+
+Internal changes:
+
+## 2.1.0
+
+New features:
+
 - Added `SF_DISABLE_OCSP_CHECKS` environment variable as an additional option to override OCSP checks' default behaviour besides the existing `DisableOCSPChecks` config. (snowflakedb/gosnowflake#1798).
   - Note: the env var is explicitly refused when OCSP fail-closed mode is active.
 - Added `ArrowStreamBatch.Reset()` method that closes any existing stream and clears the cached reader, allowing callers to retry `GetStream` after a mid-stream failure (e.g. TCP RST) without re-executing the entire query. Inline (RowSetBase64) batches are restored from cached bytes on reset.

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package gosnowflake
 
 // SnowflakeGoDriverVersion is the version of Go Snowflake Driver.
-const SnowflakeGoDriverVersion = "2.0.2"
+const SnowflakeGoDriverVersion = "2.1.0"


### PR DESCRIPTION
## Summary
- Bump driver version `2.0.2` -> `2.1.0` in `version.go`.
- Roll the `## Upcoming release` section of `CHANGELOG.md` into a dated `## 2.1.0` entry and reset a fresh empty `## Upcoming release` template.

## Context
Minor version bump (per semver): this release adds backward-compatible features (new exported `ArrowStreamBatch.Reset()` method, `SF_DISABLE_OCSP_CHECKS` env var, opt-out connection-identifier shape telemetry) with no breaking API changes.

### Included in 2.1.0
New features:
- `SF_DISABLE_OCSP_CHECKS` env var (#1798)
- `ArrowStreamBatch.Reset()` method (#1792)
- Connection-identifier shape in-band telemetry, opt-out via `SF_TELEMETRY_DISABLE_CONNECTION_SHAPE` (#1797)

Bug fixes:
- Stale OCSP cache `.lck` directory blocking cache writes (#1793)
- Canceled regular chunk downloader reads now interrupt instead of hanging (#1789)
- Canceled `QueryArrowStream` chunk reads now interrupt instead of hanging (#1789)
- PUT no longer drops files whose names end in a trailing dot (#1788)
- Clearer error when `Host` is misconfigured with a URL scheme (#1784)
- minicore build on OpenBSD by skipping `-ldl` (#1791)

Internal changes (kept in CHANGELOG per repo convention):
- `SKIP_FILE_PERMISSIONS_VERIFICATION` env var (#1780)
- `SPCS_TOKEN` login support (#1783)
- Signed minicore binaries for Windows/Mac (#1790)

## Test plan
- `gofmt -l version.go` reports no formatting issues.
- Note: full `go build ./...` was not run locally because go.mod requires Go >= 1.24 and the local toolchain is 1.22/1.23; the change is a version-string constant plus a CHANGELOG edit. CI will compile against the supported toolchain.

Made with [Cursor](https://cursor.com)