### PR TITLE
SNOW-3637978: Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 New features:
 
 Bug fixes:
-- Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#XXXX).
+- Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 
 Internal changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 New features:
 
 Bug fixes:
-- Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
+- Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 
 Internal changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 New features:
 
 Bug fixes:
+- Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#XXXX).
 
 Internal changes:
 

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -667,12 +667,16 @@ func (sfa *snowflakeFileTransferAgent) transferAccelerateConfigWithUtil(s3Util s
 			Message:  errors2.ErrMsgFailedToConvertToS3Client,
 		}, sfa.sc)
 	}
+	logger.WithContext(sfa.sc.ctx).Debugf("Getting accelerate endpoint for bucket %v.", s3Loc.bucketName)
 	ret, err := withCloudStorageTimeout(sfa.ctx, sfa.sc.cfg, func(ctx context.Context) (*s3.GetBucketAccelerateConfigurationOutput, error) {
 		return client.GetBucketAccelerateConfiguration(ctx, &s3.GetBucketAccelerateConfigurationInput{
 			Bucket: &s3Loc.bucketName,
 		})
 	})
 	sfa.useAccelerateEndpoint = ret != nil && ret.Status == "Enabled"
+	if sfa.useAccelerateEndpoint {
+		logger.WithContext(sfa.sc.ctx).Debugf("Transfer acceleration enabled for bucket %v.", s3Loc.bucketName)
+	}
 	if err != nil {
 		logger.WithContext(sfa.sc.ctx).Warnf("An error occurred when getting accelerate config: %v", err)
 	}

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -650,6 +650,8 @@ func (sfa *snowflakeFileTransferAgent) transferAccelerateConfigWithUtil(s3Util s
 	if err != nil {
 		return err
 	}
+	// role used in Snowflake stage (bucket sfc-*) operations doesn't have s3:GetAccelerateConfiguration
+	// thus get-bucket-accelerate-configuration API calls will surely fail with HTTP 403
 	if strings.HasPrefix(strings.ToLower(s3Loc.bucketName), "sfc-") {
 		logger.WithContext(sfa.sc.ctx).Debugf("Not attempting to get bucket transfer accelerate endpoint for internal stage.")
 		return nil

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -650,6 +650,10 @@ func (sfa *snowflakeFileTransferAgent) transferAccelerateConfigWithUtil(s3Util s
 	if err != nil {
 		return err
 	}
+	if strings.HasPrefix(strings.ToLower(s3Loc.bucketName), "sfc-") {
+		logger.WithContext(sfa.sc.ctx).Debugf("Not attempting to get bucket transfer accelerate endpoint for internal stage.")
+		return nil
+	}
 	s3Cli, err := s3Util.createClientWithConfig(sfa.stageInfo, false, sfa.sc.cfg, sfa.sc.telemetry)
 	if err != nil {
 		return err

--- a/file_transfer_agent_test.go
+++ b/file_transfer_agent_test.go
@@ -180,6 +180,34 @@ func TestGetBucketAccelerateConfigurationInvalidClient(t *testing.T) {
 	})
 }
 
+func TestGetBucketAccelerateConfigurationSkippedForInternalStage(t *testing.T) {
+	runSnowflakeConnTest(t, func(sct *SCTest) {
+		sfa := &snowflakeFileTransferAgent{
+			ctx:         context.Background(),
+			sc:          sct.sc,
+			commandType: uploadCommand,
+			srcFiles:    make([]string, 0),
+			data: &execResponseData{
+				SrcLocations: make([]string, 0),
+			},
+			stageInfo: &execResponseStageInfo{
+				Location: "sfc-test-bucket-customer-stage.s3.amazonaws.com",
+			},
+		}
+		err := sfa.transferAccelerateConfigWithUtil(&s3ClientCreatorMock{
+			extract: func(s string) (*s3Location, error) {
+				return &s3Location{bucketName: "sfc-test-bucket-customer-stage.s3.amazonaws.com", s3Path: ""}, nil
+			},
+			create: func(info *execResponseStageInfo, useAccelerateEndpoint bool, cfg *Config, _ *snowflakeTelemetry) (cloudClient, error) {
+				t.Fatal("S3 client must not be created for internal stage bucket")
+				return nil, nil
+			},
+		})
+		assertNilF(t, err)
+		assertFalseF(t, sfa.useAccelerateEndpoint, "useAccelerateEndpoint should be false for internal stage bucket")
+	})
+}
+
 func TestUnitDownloadWithInvalidLocalPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "data")
 	if err != nil {


### PR DESCRIPTION
### Description

Similar to https://github.com/snowflakedb/snowflake-connector-python/pull/2556. Since `s3:GetAccelerateConfiguration` permission is not granted on purpose, and won't be granted on Snowflake-internal buckets, 100% of the s3 client `GetBucketAccelerateConfiguration` calls are failing. This wastes resources as TLS still needs to be performed for something which we know not gonna work and apparently starts to cause operational issues as well in certain tools.

### Fix
Similarly to the Python driver; do not perform `GetBucketAccelerateConfiguration` call for Snowflake-internal buckets. For anything else, proceed as before.

Added unit test. Also confirmed against a live test account that accelerate probe was not launched when performing a real `PUT`. 
