### PR TITLE
SNOW-3561155: load minicore lazily on driver use instead of package init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 
 Bug fixes:
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
+- Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
 
 Internal changes:
 

--- a/connector.go
+++ b/connector.go
@@ -21,6 +21,12 @@ type Connector struct {
 
 // NewConnector creates a new connector with the given SnowflakeDriver and Config.
 func NewConnector(driver InternalSnowflakeDriver, config Config) driver.Connector {
+	// Begin loading minicore asynchronously as soon as the application
+	// references the driver. database/sql.Open() invokes OpenConnector ->
+	// NewConnector synchronously, so this gives the version a head start to be
+	// warm by first login, without loading at package-import time when
+	// gosnowflake is merely a transitive dependency (SNOW-3561155 / #1800).
+	_ = getMiniCore()
 	return Connector{driver, config}
 }
 

--- a/driver.go
+++ b/driver.go
@@ -52,6 +52,10 @@ func (d SnowflakeDriver) OpenWithConfig(ctx context.Context, config Config) (dri
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
+	// Catch-all minicore kickoff for connection paths that bypass
+	// NewConnector (e.g. SnowflakeDriver.Open(dsn) or a direct OpenWithConfig
+	// caller). Idempotent via sync.Once (SNOW-3561155 / #1800).
+	_ = getMiniCore()
 	// Shape capture for the post-login client_connection_identifier_shape
 	// telemetry happens inside FillMissingConfigParameters; callers that
 	// reach OpenWithConfig via ParseDSN / LoadConnectionConfig /

--- a/minicore.go
+++ b/minicore.go
@@ -330,12 +330,6 @@ func getMiniCore() miniCore {
 	return miniCoreInstance
 }
 
-func init() {
-	// Start async minicore loading but don't block initialization.
-	// This allows the application to start quickly while minicore loads in the background.
-	getMiniCore()
-}
-
 func minicoreDebugf(format string, args ...any) {
 	minicoreLoadLogs.mu.Lock()
 	defer minicoreLoadLogs.mu.Unlock()

--- a/minicore_test.go
+++ b/minicore_test.go
@@ -144,6 +144,11 @@ func TestIsDynamicallyLinked(t *testing.T) {
 
 func TestMiniCoreLoadedE2E(t *testing.T) {
 	logger.SetLogLevel("debug")
+	// init() no longer pre-warms minicore; loading now starts when the driver
+	// is first referenced (NewConnector below). Wait for it to finish so the
+	// login request deterministically carries CORE_VERSION and no
+	// CORE_LOAD_ERROR, as required by the wiremock mapping.
+	awaitMinicoreLoaded(t)
 	mappingFile := "minicore/auth/successful_flow.json"
 	if runtime.GOOS == "linux" {
 		mappingFile = "minicore/auth/successful_flow_linux.json"
@@ -153,4 +158,21 @@ func TestMiniCoreLoadedE2E(t *testing.T) {
 	connector := NewConnector(SnowflakeDriver{}, *cfg)
 	db := sql.OpenDB(connector)
 	runSmokeQuery(t, db)
+}
+
+// awaitMinicoreLoaded triggers asynchronous minicore loading (if not already
+// started) and blocks until the version is available or the deadline elapses.
+func awaitMinicoreLoaded(t *testing.T) {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if mc := getMiniCore(); mc != nil {
+			if _, err := mc.FullVersion(); err == nil {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("minicore did not finish loading within 5s")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## Overview

`gosnowflake` writes a temp folder (`/tmp/gosnowflake-cgo*`) during package `init()` even when the driver is never used — e.g. when it's only a transitive dependency of a binary that doesn't talk to Snowflake (reported in #1800 by the otel-collector-contrib maintainers).

The `init()` eagerly started minicore loading, which writes the embedded native library to disk and `dlopen`s it (to report the core version in login telemetry). This side effect fired on import alone.

## Change

- Remove the package `init()` in `minicore.go`.
- Kick off the same async load lazily, when the app first references the driver:
  - `NewConnector` — `database/sql.Open()` calls this synchronously via `OpenConnector`, so the common path keeps the same head start.
  - `OpenWithConfig` — catch-all for `SnowflakeDriver.Open(dsn)` and direct callers.
- Both calls are idempotent (`sync.Once`); loading remains fully async, so nothing is added to the connection critical path.

Net effect: no filesystem work when the driver is never used, while real users keep minicore warm by first login.

## Relationship to #1801

#1801 also removes `init()` but does not re-trigger loading, so the first login of every process reports `CORE_VERSION` empty / `"Minicore is still loading"`. This PR re-triggers at driver-reference time, preserving first-login telemetry for real usage. Suggest closing #1801 in favor of this.

## Behavior note (intentional, not a regression)

Minicore loading is async and non-blocking by design (it must never impact customers). A process that references the driver and connects with no gap in between can still report `"still loading"` on its very first login — the same best-effort behavior `init()` had. We deliberately did not add a synchronous/blocking load.

## Testing

- `go build ./...` and `go build -tags minicore_disabled ./...`
- `go vet ./...`
- Minicore loader unit tests (real `dlopen`)
- `TestMiniCoreLoadedE2E` updated: since `init()` no longer pre-warms, it now waits for the load (`awaitMinicoreLoaded`) before connecting, so the login request deterministically carries `CORE_VERSION` with no `CORE_LOAD_ERROR`.
- Manual #1800 repro: an import-only program creates no `gosnowflake-cgo` temp activity; a program that calls `NewConnector` (without connecting) does trigger the load.

Fixes #1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
