### PR TITLE
Add WithFileGetStreamForExactFile to fix get-stream prefix-sibling corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming release
 
 New features:
+- Added `WithFileGetStreamForExactFile(ctx, writer, fileName)`, an opt-in variant of `WithFileGetStream` for streaming a single named file when a `GET` prefix-matches more than one (e.g. `foo` alongside `foobar` or a nested `foo/foo`). In that case plain `WithFileGetStream` streams every matched file into one shared buffer and can return corrupt or wrong-file bytes; the new variant selects the requested file before any download goroutine is spawned - matching by leaf and preferring the shallowest path when a name also appears deeper - and returns `ErrFileNotExists` (no match) or the new `ErrGetStreamMultipleFiles` (multiple equally-specific matches) instead of streaming the wrong file. Plain `WithFileGetStream` behavior is unchanged (snowflakedb/gosnowflake#1808).
 
 Bug fixes:
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).

--- a/connection_util.go
+++ b/connection_util.go
@@ -212,6 +212,15 @@ func isFileGetStream(ctx context.Context) bool {
 	return v != nil
 }
 
+// getFileGetStreamExactFile returns the file name set by WithFileGetStreamForExactFile and
+// whether it was set. The boolean distinguishes "no target" (plain WithFileGetStream, where
+// ok is false) from "an explicit empty target" (a caller misuse, where ok is true and the
+// value is "").
+func getFileGetStreamExactFile(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(fileGetStreamExactFile).(string)
+	return v, ok
+}
+
 func getFileTransferOptions(ctx context.Context) *SnowflakeFileTransferOptions {
 	v := ctx.Value(fileTransferOptions)
 	if v == nil {

--- a/doc.go
+++ b/doc.go
@@ -1465,6 +1465,23 @@ To download a file into an in-memory stream (rather than a file) use code simila
 	// streamBuf is now filled with the stream. Use bytes.NewReader(streamBuf.Bytes()) to read uncompressed stream or
 	// use gzip.NewReader(&streamBuf) for to read compressed stream.
 
+A GET resolves its stage path by prefix matching, so it can match more than one file (for
+example "foo" alongside "foobar"). Because a get-stream has a single io.Writer, plain
+WithFileGetStream streams every matched file into one shared buffer in that case and can return
+corrupt or wrong-file bytes. To stream exactly one named file, use WithFileGetStreamForExactFile,
+which selects the requested file before downloading and returns an error instead of streaming the
+wrong bytes:
+
+	var streamBuf bytes.Buffer
+	ctx := WithFileGetStreamForExactFile(context.Background(), &streamBuf, "data1.txt.gz")
+
+	sql := "get @~/data1.txt.gz file:///tmp/testData"
+	if _, err := db.ExecContext(ctx, sql); err != nil {
+		// ErrFileNotExists if data1.txt.gz is not in the result,
+		// ErrGetStreamMultipleFiles if the name is ambiguous.
+	}
+	// streamBuf now holds exactly data1.txt.gz.
+
 Note: GET statements are not supported for multi-statement queries.
 
 Specifying temporary directory for encryption and compression:

--- a/errors.go
+++ b/errors.go
@@ -195,6 +195,9 @@ const (
 	ErrNotImplemented = sferrors.ErrNotImplemented
 	// ErrInvalidPadding is an error code denoting the invalid padding of decryption key
 	ErrInvalidPadding = sferrors.ErrInvalidPadding
+	// ErrGetStreamMultipleFiles is an error code denoting a streaming GET that resolved to
+	// more than one file when exactly one was requested.
+	ErrGetStreamMultipleFiles = sferrors.ErrGetStreamMultipleFiles
 
 	/* binding */
 

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -257,6 +257,15 @@ func (sfa *snowflakeFileTransferAgent) parseCommand() error {
 			}, sfa.sc)
 		}
 
+		// Narrow a get-stream GET to the single exact file requested. Must run after the
+		// encryption-material map above is built over the full result set (it is keyed
+		// by source file name), so the selected file keeps its correct material.
+		if isFileGetStream(sfa.ctx) {
+			if err = sfa.selectGetStreamExactFile(); err != nil {
+				return err
+			}
+		}
+
 		sfa.localLocation, err = expandUser(sfa.data.LocalLocation)
 		if err != nil {
 			return err
@@ -293,6 +302,89 @@ func (sfa *snowflakeFileTransferAgent) parseCommand() error {
 			MessageArgs: []any{sfa.stageLocationType},
 		}, sfa.sc)
 	}
+	return nil
+}
+
+// selectGetStreamExactFile narrows sfa.srcFiles to the one file named via
+// WithFileGetStreamForExactFile. A GET prefix-matches on the server, so requesting "foo" can
+// return "foo", "foobar", a nested "foo/foo", ...; a get-stream has a single io.Writer, so we
+// pick one file here - before any download goroutine touches the shared stream buffer.
+//
+// Matching is case-sensitive and by leaf (the identity dir-mode download also uses):
+//
+//   - matches when the path equals name or ends with "/"+name (so "foo" or "dir/foo");
+//   - on multiple leaf matches the shallowest path wins (the exact "foo", not a deeper "foo/foo");
+//   - equally-shallow matches ("a/foo", "b/foo") are ambiguous -> ErrGetStreamMultipleFiles;
+//   - no match -> ErrFileNotExists.
+//
+// Depth is compared across candidates, not absolute, so no physical/logical boundary is needed:
+// every result in one GET shares the same prefix depth (versions/<entity>/<versionId>/<logical>,
+// versionId one segment), so fewer segments == shallower logical path.
+//
+// Known limitation: a lone deeper namesake is accepted - request "foo" with only "foo/foo" in
+// the result (no top-level "foo") returns "foo/foo", since one path gives no boundary and the
+// tiebreak needs >=2 candidates. A wrong-file outcome; full correctness needs an exact
+// server-side GET. See TestSelectGetStreamExactFileLoneDeeperNamesake.
+//
+// No-op for plain WithFileGetStream (no name set); an explicit empty name is rejected.
+func (sfa *snowflakeFileTransferAgent) selectGetStreamExactFile() error {
+	requestedExactFile, ok := getFileGetStreamExactFile(sfa.ctx)
+	if !ok {
+		return nil // plain WithFileGetStream: no exact file, behavior unchanged
+	}
+	if requestedExactFile == "" {
+		// Opted into exact-file streaming but named no file: fail loud rather than
+		// silently falling back to the racy multi-file path (an empty name can never
+		// denote a streamable file).
+		return exceptionTelemetry(&SnowflakeError{
+			Number:   ErrFileNotExists,
+			SQLState: sfa.data.SQLState,
+			QueryID:  sfa.data.QueryID,
+			Message:  errors2.ErrMsgGetStreamExactFileEmpty,
+		}, sfa.sc)
+	}
+
+	matched := make([]string, 0, 1)
+	for _, srcFile := range sfa.srcFiles {
+		if srcFile == requestedExactFile || strings.HasSuffix(srcFile, "/"+requestedExactFile) {
+			matched = append(matched, srcFile)
+		}
+	}
+	if len(matched) == 0 {
+		return exceptionTelemetry(&SnowflakeError{
+			Number:      ErrFileNotExists,
+			SQLState:    sfa.data.SQLState,
+			QueryID:     sfa.data.QueryID,
+			Message:     errors2.ErrMsgFileNotExists,
+			MessageArgs: []any{requestedExactFile},
+		}, sfa.sc)
+	}
+
+	// Prefer the shallowest match (fewest path segments): the file named exactly the
+	// request rather than a deeper namesake. Take it when unique; only equally-shallow
+	// namesakes remain ambiguous.
+	minDepth := strings.Count(matched[0], "/")
+	for _, m := range matched[1:] {
+		if d := strings.Count(m, "/"); d < minDepth {
+			minDepth = d
+		}
+	}
+	shallowest := make([]string, 0, 1)
+	for _, m := range matched {
+		if strings.Count(m, "/") == minDepth {
+			shallowest = append(shallowest, m)
+		}
+	}
+	if len(shallowest) > 1 {
+		return exceptionTelemetry(&SnowflakeError{
+			Number:      ErrGetStreamMultipleFiles,
+			SQLState:    sfa.data.SQLState,
+			QueryID:     sfa.data.QueryID,
+			Message:     errors2.ErrMsgGetStreamMultipleFiles,
+			MessageArgs: []any{requestedExactFile, len(shallowest)},
+		}, sfa.sc)
+	}
+	sfa.srcFiles = shallowest
 	return nil
 }
 

--- a/getstream_select_test.go
+++ b/getstream_select_test.go
@@ -1,0 +1,302 @@
+package gosnowflake
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// TestGetFileGetStreamExactFile verifies the opt-in API sets a retrievable target,
+// that the plain get-stream constructor reports no target, and that an explicit empty
+// name is reported as present-but-empty (a misuse the selector rejects).
+func TestGetFileGetStreamExactFile(t *testing.T) {
+	var buf bytes.Buffer
+
+	if v, ok := getFileGetStreamExactFile(WithFileGetStream(context.Background(), &buf)); ok {
+		t.Fatalf("plain WithFileGetStream should report no target, got %q ok=true", v)
+	}
+	if v, ok := getFileGetStreamExactFile(WithFileGetStreamForExactFile(context.Background(), &buf, "dir/foo")); !ok || v != "dir/foo" {
+		t.Fatalf("target = %q ok=%v, want %q true", v, ok, "dir/foo")
+	}
+	if v, ok := getFileGetStreamExactFile(WithFileGetStreamForExactFile(context.Background(), &buf, "")); !ok || v != "" {
+		t.Fatalf("explicit empty target should be present with empty value, got %q ok=%v", v, ok)
+	}
+	if !isFileGetStream(WithFileGetStreamForExactFile(context.Background(), &buf, "foo")) {
+		t.Fatal("WithFileGetStreamForExactFile must also mark the context as a get-stream")
+	}
+}
+
+// TestSelectGetStreamExactFile exercises the single-file selection that protects
+// the get-stream primitive from the N>1 prefix-match case. No live connection is needed:
+// the method only reads ctx/srcFiles/data, and exceptionTelemetry tolerates a nil conn.
+func TestSelectGetStreamExactFile(t *testing.T) {
+	// Realistic workspace (FBE) physical paths look like versions/<entity>/<versionId>/<logical>.
+	// The <versionId> segment differs per file (it is a per-file timestamp), so selection
+	// compares depth *relative* to the other candidates and never needs to locate where the
+	// physical prefix ends.
+	ws := "versions/29_559629944250378"
+	v1 := ws + "/1782146627271"
+	v2 := ws + "/1782164111378"
+	v3 := ws + "/1782146628397"
+
+	tests := []struct {
+		name       string
+		target     string // "" means plain WithFileGetStream (no opt-in)
+		srcFiles   []string
+		wantFiles  []string // expected srcFiles on success (nil when an error is expected)
+		wantErrNum int      // 0 when no error expected
+	}{
+		{
+			name:      "plain get-stream is untouched even with multiple matches",
+			target:    "",
+			srcFiles:  []string{v1 + "/foo", v2 + "/foobar"},
+			wantFiles: []string{v1 + "/foo", v2 + "/foobar"},
+		},
+		{
+			name:      "single result unchanged",
+			target:    "report.csv",
+			srcFiles:  []string{v1 + "/report.csv"},
+			wantFiles: []string{v1 + "/report.csv"},
+		},
+		{
+			name:      "shared prefix selects the exact leaf (foo not foobar)",
+			target:    "foo",
+			srcFiles:  []string{v1 + "/foo", v2 + "/foobar"},
+			wantFiles: []string{v1 + "/foo"},
+		},
+		{
+			name:      "selects the longer sibling when it is the one requested",
+			target:    "foobar",
+			srcFiles:  []string{v1 + "/foo", v2 + "/foobar"},
+			wantFiles: []string{v2 + "/foobar"},
+		},
+		{
+			name:      "dotted suffix sibling (profiles.yml vs profiles.yml.template)",
+			target:    "profiles.yml",
+			srcFiles:  []string{v1 + "/profiles.yml", v2 + "/profiles.yml.template"},
+			wantFiles: []string{v1 + "/profiles.yml"},
+		},
+		{
+			// The key relative-depth case: a top-level "foo" and a nested "foo/foo" both
+			// end in leaf "foo", but "foo" is shallower (different version ids, same prefix
+			// depth), so it is the exact file and wins - no error.
+			name:      "top-level file wins over a deeper same-leaf namesake",
+			target:    "foo",
+			srcFiles:  []string{v1 + "/foo", v2 + "/foo/foo"},
+			wantFiles: []string{v1 + "/foo"},
+		},
+		{
+			name:      "shallowest wins across three depths",
+			target:    "foo",
+			srcFiles:  []string{v1 + "/foo", v2 + "/foo/foo", v3 + "/foo/bar/foo"},
+			wantFiles: []string{v1 + "/foo"},
+		},
+		{
+			// No top-level namesake exists; the unique shallowest is still returned rather
+			// than erroring (shortest-wins is a better outcome than throwing).
+			name:      "unique shallowest namesake wins when none is top-level",
+			target:    "config.yml",
+			srcFiles:  []string{v1 + "/envs/config.yml", v2 + "/envs/staging/config.yml"},
+			wantFiles: []string{v1 + "/envs/config.yml"},
+		},
+		{
+			name:      "nested path explicitly selects the file inside the same-named dir",
+			target:    "foo/foo",
+			srcFiles:  []string{v1 + "/foo", v2 + "/foo/foo"},
+			wantFiles: []string{v2 + "/foo/foo"},
+		},
+		{
+			// The core fail-loud case: requested file does not exist, but a single
+			// prefix-sibling does. Must NOT silently stream the sibling.
+			name:       "no exact match returns ErrFileNotExists (single sibling present)",
+			target:     "foo",
+			srcFiles:   []string{v1 + "/foobar"},
+			wantErrNum: ErrFileNotExists,
+		},
+		{
+			name:       "no exact match returns ErrFileNotExists (multiple siblings)",
+			target:     "foo",
+			srcFiles:   []string{v1 + "/foobar", v2 + "/foobaz"},
+			wantErrNum: ErrFileNotExists,
+		},
+		{
+			// Equally-shallow same-leaf files in different directories: genuinely ambiguous,
+			// no shallower exact candidate exists.
+			name:       "equally-shallow namesakes are ambiguous",
+			target:     "config.yml",
+			srcFiles:   []string{v1 + "/dev/config.yml", v2 + "/prod/config.yml"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+		{
+			name:      "fuller path disambiguates equally-shallow namesakes",
+			target:    "dev/config.yml",
+			srcFiles:  []string{v1 + "/dev/config.yml", v2 + "/prod/config.yml"},
+			wantFiles: []string{v1 + "/dev/config.yml"},
+		},
+		{
+			// Two files tie at the shallowest depth while a third is deeper: still ambiguous
+			// (the deeper one does not break the tie).
+			name:       "tie at the shallowest depth is ambiguous even with a deeper match",
+			target:     "config.yml",
+			srcFiles:   []string{v1 + "/dev/config.yml", v2 + "/prod/config.yml", v3 + "/dev/old/config.yml"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+		{
+			name:       "matching is case-sensitive",
+			target:     "Foo",
+			srcFiles:   []string{v1 + "/foo"},
+			wantErrNum: ErrFileNotExists,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ctx := WithFileGetStream(context.Background(), &buf)
+			if tt.target != "" {
+				ctx = WithFileGetStreamForExactFile(context.Background(), &buf, tt.target)
+			}
+			sfa := &snowflakeFileTransferAgent{
+				ctx:         ctx,
+				commandType: downloadCommand,
+				srcFiles:    tt.srcFiles,
+				data:        &execResponseData{},
+			}
+
+			err := sfa.selectGetStreamExactFile()
+
+			if tt.wantErrNum != 0 {
+				if err == nil {
+					t.Fatalf("expected error %d, got nil", tt.wantErrNum)
+				}
+				sfErr, ok := err.(*SnowflakeError)
+				if !ok {
+					t.Fatalf("expected *SnowflakeError, got %T: %v", err, err)
+				}
+				if sfErr.Number != tt.wantErrNum {
+					t.Fatalf("error number = %d, want %d", sfErr.Number, tt.wantErrNum)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalStringSlice(sfa.srcFiles, tt.wantFiles) {
+				t.Fatalf("srcFiles = %v, want %v", sfa.srcFiles, tt.wantFiles)
+			}
+		})
+	}
+}
+
+// TestSelectGetStreamExactFileEmptyName verifies that opting into exact-file
+// streaming with an empty name fails loud rather than silently falling back to the
+// multi-file path.
+func TestSelectGetStreamExactFileEmptyName(t *testing.T) {
+	var buf bytes.Buffer
+	sfa := &snowflakeFileTransferAgent{
+		ctx:         WithFileGetStreamForExactFile(context.Background(), &buf, ""),
+		commandType: downloadCommand,
+		srcFiles:    []string{"versions/29_559629944250378/1782146627271/foo", "versions/29_559629944250378/1782164111378/foobar"},
+		data:        &execResponseData{},
+	}
+
+	err := sfa.selectGetStreamExactFile()
+	sfErr, ok := err.(*SnowflakeError)
+	if !ok {
+		t.Fatalf("expected *SnowflakeError, got %T: %v", err, err)
+	}
+	if sfErr.Number != ErrFileNotExists {
+		t.Fatalf("error number = %d, want %d", sfErr.Number, ErrFileNotExists)
+	}
+	if !equalStringSlice(sfa.srcFiles, []string{"versions/29_559629944250378/1782146627271/foo", "versions/29_559629944250378/1782164111378/foobar"}) {
+		t.Fatalf("srcFiles must be untouched on error, got %v", sfa.srcFiles)
+	}
+}
+
+// TestSelectGetStreamExactFileLoneDeeperNamesake documents a KNOWN, UNDESIRED limitation.
+//
+// When the GET resolves to a single deeper namesake - request "foo", but the result contains
+// only ".../foo/foo" with no top-level "foo" - the driver returns that file instead of erroring.
+// From one physical path it cannot tell the logical name is "foo/foo" rather than "foo" (the
+// per-file version-id prefix has no fixed boundary), and the relative-depth tiebreak needs >=2
+// candidates to detect over-depth. The *correct* outcome would be ErrFileNotExists; full
+// correctness requires the GET to resolve to the exact object server-side (the driver selection
+// is a backstop for the multi-file race, not a logical-identity oracle).
+//
+// This test pins the current limited behavior so that any change to it is a conscious decision.
+func TestSelectGetStreamExactFileLoneDeeperNamesake(t *testing.T) {
+	const loneNested = "versions/29_559629944250378/1782146627271/foo/foo"
+	var buf bytes.Buffer
+	sfa := &snowflakeFileTransferAgent{
+		ctx:         WithFileGetStreamForExactFile(context.Background(), &buf, "foo"),
+		commandType: downloadCommand,
+		srcFiles:    []string{loneNested},
+		data:        &execResponseData{},
+	}
+
+	if err := sfa.selectGetStreamExactFile(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// LIMITATION: ideally this would error with ErrFileNotExists (no top-level "foo" exists);
+	// instead the deeper namesake "foo/foo" is wrongly accepted for a request of "foo".
+	if !equalStringSlice(sfa.srcFiles, []string{loneNested}) {
+		t.Fatalf("srcFiles = %v, want [%s] (documenting current limited behavior)", sfa.srcFiles, loneNested)
+	}
+}
+
+// TestSelectGetStreamExactFileEncryptionMaterialAlignment guards the ordering bug:
+// selection must run AFTER the source-file -> encryption-material map is built, so a
+// selected file at index > 0 keeps its own material rather than the first file's.
+func TestSelectGetStreamExactFileEncryptionMaterialAlignment(t *testing.T) {
+	m0 := &snowflakeFileEncryption{SMKID: 100, QueryID: "q0"}
+	m1 := &snowflakeFileEncryption{SMKID: 101, QueryID: "q1"}
+	m2 := &snowflakeFileEncryption{SMKID: 102, QueryID: "q2"}
+	ws := "versions/29_559629944250378"
+	// Different version ids per file, just like the real GET response.
+	srcFiles := []string{ws + "/1782146627271/alpha", ws + "/1782164111378/bravo", ws + "/1782146628397/charlie"}
+
+	var buf bytes.Buffer
+	sfa := &snowflakeFileTransferAgent{
+		ctx:                WithFileGetStreamForExactFile(context.Background(), &buf, "bravo"),
+		commandType:        downloadCommand,
+		srcFiles:           srcFiles,
+		encryptionMaterial: []*snowflakeFileEncryption{m0, m1, m2},
+		data:               &execResponseData{SrcLocations: srcFiles},
+	}
+
+	// Mirror parseCommand: build the material map over the FULL result set first...
+	sfa.srcFileToEncryptionMaterial = make(map[string]*snowflakeFileEncryption)
+	for i, f := range sfa.srcFiles {
+		sfa.srcFileToEncryptionMaterial[f] = sfa.encryptionMaterial[i]
+	}
+	// ...then narrow to the requested file.
+	if err := sfa.selectGetStreamExactFile(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sfa.srcFiles) != 1 || sfa.srcFiles[0] != ws+"/1782164111378/bravo" {
+		t.Fatalf("srcFiles = %v, want [%s/1782164111378/bravo]", sfa.srcFiles, ws)
+	}
+
+	if err := sfa.initFileMetadata(); err != nil {
+		t.Fatalf("initFileMetadata: %v", err)
+	}
+	if len(sfa.fileMetadata) != 1 {
+		t.Fatalf("fileMetadata count = %d, want 1", len(sfa.fileMetadata))
+	}
+	if got := sfa.fileMetadata[0].encryptionMaterial; got != m1 {
+		t.Fatalf("selected file got material %+v, want m1 (SMKID 101) - index alignment broke", got)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -158,6 +158,9 @@ const (
 	ErrNotImplemented = 264011
 	// ErrInvalidPadding is an error code denoting the invalid padding of decryption key
 	ErrInvalidPadding = 264012
+	// ErrGetStreamMultipleFiles is an error code denoting a streaming GET that resolved to
+	// more than one file when exactly one was requested (and none could be uniquely selected).
+	ErrGetStreamMultipleFiles = 264013
 
 	/* binding */
 
@@ -265,6 +268,8 @@ const (
 	ErrMsgNoResultIDs                        = "no result IDs returned with the multi-statement query"
 	ErrMsgQueryStatus                        = "server ErrorCode=%s, ErrorMessage=%s"
 	ErrMsgInvalidPadding                     = "invalid padding on input"
+	ErrMsgGetStreamMultipleFiles             = "streaming GET for %q matched %v equally-specific files; WithFileGetStreamForExactFile streams a single file - provide a more specific path to disambiguate"
+	ErrMsgGetStreamExactFileEmpty            = "WithFileGetStreamForExactFile requires a non-empty file name"
 	ErrMsgClientConfigFailed                 = "client configuration failed: %v"
 	ErrMsgNullValueInArray                   = "for handling null values in arrays use WithArrayValuesNullable(ctx)"
 	ErrMsgNullValueInMap                     = "for handling null values in maps use WithMapValuesNullable(ctx)"

--- a/util.go
+++ b/util.go
@@ -29,6 +29,7 @@ const (
 	fetchResultByID        ContextKey = "SF_FETCH_RESULT_BY_ID"
 	filePutStream          ContextKey = "STREAMING_PUT_FILE"
 	fileGetStream          ContextKey = "STREAMING_GET_FILE"
+	fileGetStreamExactFile ContextKey = "STREAMING_GET_EXACT_FILE"
 	fileTransferOptions    ContextKey = "FILE_TRANSFER_OPTIONS"
 	enableDecfloat         ContextKey = "ENABLE_DECFLOAT"
 	arrowAlloc             ContextKey = "ARROW_ALLOC"
@@ -80,6 +81,27 @@ func WithFilePutStream(ctx context.Context, reader io.Reader) context.Context {
 // WithFileGetStream returns a context that contains the address of the file stream to be GET
 func WithFileGetStream(ctx context.Context, writer io.Writer) context.Context {
 	return context.WithValue(ctx, fileGetStream, writer)
+}
+
+// WithFileGetStreamForExactFile is like WithFileGetStream but names the single file to stream.
+//
+// A GET resolves its stage path by server-side prefix matching, so a request for "foo" can
+// come back as several files (e.g. "foo", "foobar", a nested "foo/foo"). A get-stream has
+// exactly one io.Writer and cannot represent more than one file. This variant selects the file
+// matching fileName - by leaf, or by a trailing path such as "dir/foo" - before any download
+// begins, so callers avoid the corrupt/wrong-file output that plain WithFileGetStream produces
+// when several matched files share one buffer. When several matches share the leaf the
+// shallowest path wins; it returns ErrFileNotExists if nothing matches and
+// ErrGetStreamMultipleFiles if several equally-specific files match.
+//
+// Known limitation: matching is by leaf, so if the GET resolves to ONLY a deeper namesake -
+// you request "foo" but the result contains just "foo/foo" and no top-level "foo" - that file
+// is returned. From a single physical path the driver cannot tell its logical name is "foo/foo"
+// rather than "foo". To be fully exact, ensure the GET resolves to the precise object on the
+// server side; the driver selection is a backstop for the multi-file race, not a substitute for
+// an exact GET.
+func WithFileGetStreamForExactFile(ctx context.Context, writer io.Writer, fileName string) context.Context {
+	return context.WithValue(WithFileGetStream(ctx, writer), fileGetStreamExactFile, fileName)
 }
 
 // WithFileTransferOptions returns a context that contains the address of file transfer options


### PR DESCRIPTION
## Problem

A `GET` resolves its stage path by **server-side prefix matching**, so a request for a single
file (e.g. `foo`) can come back as several files (`foo` **and** `foobar`, a nested `foo/foo`, …).

The get-stream primitive (`WithFileGetStream`) has exactly one `io.Writer` and one shared
`streamBuffer`, but `download()` still fans out **one goroutine per matched file**, all writing
that *same* buffer (`storage_client.go`):

- **encrypted:** each goroutine `Truncate`s the shared buffer to *its own* file size → a
  nondeterministic concat/truncation of the siblings;
- **unencrypted:** each goroutine reassigns the shared buffer pointer (last-writer-wins),
  silently dropping the others.

Either way the caller can receive corrupt bytes, or an arbitrary sibling's content, **with no
error** — including when the requested file does not exist but a prefix-sibling does.

This continues the file-transfer hardening from #1687 (SNOW-3049473): that made a panicking
download goroutine non-fatal and added a single-file `totalFileSize` bound check, but neither
addresses the *cross-file* shared-buffer contention when a get-stream resolves to N > 1 files.

## Fix

Add an opt-in API:

```go
func WithFileGetStreamForExactFile(ctx context.Context, writer io.Writer, fileName string) context.Context
```

`parseCommand` selects the requested file and narrows `srcFiles` to it **before any download
goroutine is spawned**, structurally eliminating the shared-buffer hazard for that path (exactly
one goroutine ever touches `streamBuffer`). Selection runs *after* the source-file →
encryption-material map is built (the map is keyed by source file name), so a selected file at
index > 0 keeps its own encryption material.

Matching is **case-sensitive, by leaf** — the same identity the driver uses when downloading to a
directory (`baseName(dstFileName)`):

- a file matches when its path equals `fileName` or ends with `"/" + fileName` (so a leaf `foo`
  or a trailing path `dir/foo`);
- when several matches share the leaf, the **shallowest** path wins (the exact `foo`, not a
  deeper `foo/foo`) — compared *relative* to the other candidates, so no physical/logical
  boundary guessing is needed;
- equally-shallow matches (`a/foo`, `b/foo`) → `ErrGetStreamMultipleFiles` (new, 264013);
- no match → `ErrFileNotExists`; an explicit empty name → error.

**Known limitation (documented in godoc + a marked test):** a *lone* deeper namesake can't be
detected — requesting `foo` when the result is only `foo/foo` returns `foo/foo`, since one
physical path gives no boundary and the depth tiebreak needs ≥2 candidates. Full correctness
requires the GET to resolve to the exact object server-side; the driver selection is the backstop
for the multi-file race, not a logical-identity oracle.

## Consumer migration

The GET SQL, `ExecContext`, and buffer read are identical — only the context constructor changes.

**Before** (silent corruption when the path matched >1 file):
```go
var buf bytes.Buffer
ctx := gosnowflake.WithFileGetStream(ctx, &buf)
_, err := db.ExecContext(ctx, "GET 'snow://…/minimap_status' 'file:///tmp/x'")
// buf may hold corrupt/wrong/nondeterministic bytes; err is nil.
```

**After** (opt-in; one line changes):
```go
var buf bytes.Buffer
ctx := gosnowflake.WithFileGetStreamForExactFile(ctx, &buf, "minimap_status") // ← only difference
_, err := db.ExecContext(ctx, "GET 'snow://…/minimap_status' 'file:///tmp/x'")
if err != nil {
    var se *gosnowflake.SnowflakeError
    if errors.As(err, &se) && se.Number == gosnowflake.ErrFileNotExists { /* not there */ }
    if errors.As(err, &se) && se.Number == gosnowflake.ErrGetStreamMultipleFiles { /* ambiguous */ }
    return err
}
data := buf.Bytes() // exactly minimap_status's bytes
```

**Plain `WithFileGetStream` is byte-for-byte unchanged** — selection is a no-op without an
explicit name, so nothing is forced on existing callers. This is a safe opt-in that consumers
adopt explicitly; a follow-up can make single-file selection the default once it is validated in
the field. No public API is removed or changed; this adds one helper and one error constant.

## Tests

Offline unit tests (no live connection — `exceptionTelemetry` tolerates a nil conn), using
realistic `versions/<entity>/<versionId>/<logical>` paths with **differing version ids**:

- leaf match (`foo` not `foobar`), dotted suffixes (`profiles.yml` vs `.template`);
- shallowest-wins across 2 and 3 depths; unique-shallowest when none is top-level;
- equally-shallow tie (and tie-with-a-deeper-also-present) → `ErrGetStreamMultipleFiles`;
- fuller-path disambiguation; case-sensitivity; no-match → `ErrFileNotExists`;
- empty-name guard; **encryption-material alignment** regression;
- a clearly-marked characterization test for the lone-deeper-namesake limitation.

Validated end-to-end against a real internal workspace stage where a GET prefix-matches sibling
files:
- **before:** requesting `foo` returned correct content **0 / 5** runs (nondeterministic
  corruption);
- **after:** `WithFileGetStreamForExactFile("foo")` returned the byte-for-byte correct file every
  run (incl. `foo` alongside a nested `foo/foo`); a nonexistent name → `ErrFileNotExists`; and
  plain `WithFileGetStream` still reproduced the old behavior (confirming it is unchanged).

## Notes for reviewers

- cc the file-transfer / #1687 area owner.
- Complementary server-side narrowing (anchored/exact GET) would close the lone-namesake
  limitation at the source.
