### PR TITLE
SNOW-3637888: Error on multi-file streaming GET instead of returning corrupt bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New features:
 
 Bug fixes:
 - Fixed nil pointer dereference panic when a corrupt or malformed OCSP cache key is encountered, either from the remote OCSP cache server or the local cache file (snowflakedb/gosnowflake#1819).
+- Fixed `WithFileGetStream` returning corrupt or wrong-file bytes when a `GET` prefix-matched more than one file; a get-stream can return only one file, so a multi-file match now returns the new `ErrGetStreamMultipleFiles` (pointing to the GET `PATTERN` argument) instead of a nondeterministic mix (snowflakedb/gosnowflake#1809).
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 - Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
 - Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (snowflakedb/gosnowflake#1810).

--- a/doc.go
+++ b/doc.go
@@ -1480,6 +1480,14 @@ To download a file into an in-memory stream (rather than a file) use code simila
 	// streamBuf is now filled with the stream. Use bytes.NewReader(streamBuf.Bytes()) to read uncompressed stream or
 	// use gzip.NewReader(&streamBuf) for to read compressed stream.
 
+A GET resolves its stage path by prefix matching, so it can match more than one file (for
+example "foo" alongside "foobar"). Because a get-stream has a single io.Writer, it can return
+only one file: if the GET matches more than one, it returns ErrGetStreamMultipleFiles instead of
+streaming a corrupt mix of them. Use the GET command's PATTERN argument to narrow the match to a
+single file, for example:
+
+	sql := `get @~ file:///tmp/testData pattern='.*data1.txt.gz'`
+
 Note: GET statements are not supported for multi-statement queries.
 
 Specifying temporary directory for encryption and compression:

--- a/errors.go
+++ b/errors.go
@@ -195,6 +195,10 @@ const (
 	ErrNotImplemented = sferrors.ErrNotImplemented
 	// ErrInvalidPadding is an error code denoting the invalid padding of decryption key
 	ErrInvalidPadding = sferrors.ErrInvalidPadding
+	// ErrGetStreamMultipleFiles is an error code denoting a streaming GET whose stage path
+	// matched more than one file, so it cannot be streamed into a single writer. Narrow the
+	// GET with its PATTERN argument so it matches exactly one file.
+	ErrGetStreamMultipleFiles = sferrors.ErrGetStreamMultipleFiles
 
 	/* binding */
 

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -261,6 +261,15 @@ func (sfa *snowflakeFileTransferAgent) parseCommand() error {
 			}, sfa.sc)
 		}
 
+		// A get-stream has a single io.Writer, so a GET matching more than one file would
+		// stream a corrupt mix. Fail deterministically instead of guessing which file the
+		// caller meant, pointing them at the GET PATTERN argument to narrow the match.
+		if isFileGetStream(sfa.ctx) {
+			if err = sfa.ensureSingleGetStreamFile(); err != nil {
+				return err
+			}
+		}
+
 		sfa.localLocation, err = expandUser(sfa.data.LocalLocation)
 		if err != nil {
 			return err
@@ -295,6 +304,22 @@ func (sfa *snowflakeFileTransferAgent) parseCommand() error {
 			QueryID:     sfa.data.QueryID,
 			Message:     errors2.ErrMsgInvalidStageFs,
 			MessageArgs: []any{sfa.stageLocationType},
+		}, sfa.sc)
+	}
+	return nil
+}
+
+// ensureSingleGetStreamFile fails a get-stream that matched more than one file. A GET resolves its
+// stage path by prefix, so it can match several files, but a get-stream has a single io.Writer and
+// streaming them all into it yields a corrupt mix. Rather than guess which file the caller meant,
+// return ErrGetStreamMultipleFiles so the caller narrows the GET with its PATTERN argument.
+func (sfa *snowflakeFileTransferAgent) ensureSingleGetStreamFile() error {
+	if len(sfa.srcFiles) > 1 {
+		return exceptionTelemetry(&SnowflakeError{
+			Number:   ErrGetStreamMultipleFiles,
+			SQLState: sfa.data.SQLState,
+			QueryID:  sfa.data.QueryID,
+			Message:  errors2.ErrMsgGetStreamMultipleFiles,
 		}, sfa.sc)
 	}
 	return nil

--- a/getstream_select_test.go
+++ b/getstream_select_test.go
@@ -1,0 +1,105 @@
+package gosnowflake
+
+import "testing"
+
+// TestEnsureSingleGetStreamFile checks that a get-stream returns its sole matched file unchanged
+// and errors deterministically when the GET matched more than one. No live connection needed: it
+// only reads srcFiles/data. Physical paths follow versions/<entity>/<versionId>/<logical>, with a
+// per-file <versionId>.
+func TestEnsureSingleGetStreamFile(t *testing.T) {
+	ws := "versions/29_559629944250378"
+	v1 := ws + "/1782146627271"
+	v2 := ws + "/1782164111378"
+	v3 := ws + "/1782146628397"
+
+	tests := []struct {
+		name       string
+		srcFiles   []string
+		wantFiles  []string // expected srcFiles on success (nil when an error is expected)
+		wantErrNum int      // 0 when no error expected
+	}{
+		{
+			name:      "single result is streamed",
+			srcFiles:  []string{v1 + "/report.csv"},
+			wantFiles: []string{v1 + "/report.csv"},
+		},
+		{
+			name:      "single prefix-sibling is streamed",
+			srcFiles:  []string{v1 + "/foobar"},
+			wantFiles: []string{v1 + "/foobar"},
+		},
+		{
+			name:       "prefix-sibling match is ambiguous (foo alongside foobar)",
+			srcFiles:   []string{v1 + "/foo", v2 + "/foobar"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+		{
+			name:       "file and same-named subdir are ambiguous",
+			srcFiles:   []string{v1 + "/foo", v2 + "/foo/foo"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+		{
+			name:       "same leaf in different directories is ambiguous",
+			srcFiles:   []string{v1 + "/a/foo", v2 + "/b/foo"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+		{
+			name:       "whole-stage GET with multiple files is ambiguous",
+			srcFiles:   []string{v1 + "/a.csv.gz", v2 + "/b.csv.gz"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+		{
+			name:       "three prefix-matched files are ambiguous",
+			srcFiles:   []string{v1 + "/foo", v2 + "/foobar", v3 + "/foobaz"},
+			wantErrNum: ErrGetStreamMultipleFiles,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sfa := &snowflakeFileTransferAgent{
+				commandType: downloadCommand,
+				srcFiles:    tt.srcFiles,
+				data:        &execResponseData{},
+			}
+
+			err := sfa.ensureSingleGetStreamFile()
+
+			if tt.wantErrNum != 0 {
+				var sfErr *SnowflakeError
+				assertErrorsAsF(t, err, &sfErr)
+				assertEqualE(t, sfErr.Number, tt.wantErrNum)
+				return
+			}
+			assertNilF(t, err)
+			assertDeepEqualE(t, sfa.srcFiles, tt.wantFiles)
+		})
+	}
+}
+
+// TestEnsureSingleGetStreamFileKeepsEncryptionMaterial guards that the single retained file keeps
+// its own encryption material: the check runs after the source-file -> encryption-material map is
+// built in parseCommand and, on the single-file path, does not disturb srcFiles ordering.
+func TestEnsureSingleGetStreamFileKeepsEncryptionMaterial(t *testing.T) {
+	m0 := &snowflakeFileEncryption{SMKID: 100, QueryID: "q0"}
+	ws := "versions/29_559629944250378"
+	srcFiles := []string{ws + "/1782146627271/alpha"}
+
+	sfa := &snowflakeFileTransferAgent{
+		commandType:        downloadCommand,
+		srcFiles:           srcFiles,
+		encryptionMaterial: []*snowflakeFileEncryption{m0},
+		data:               &execResponseData{SrcLocations: srcFiles},
+	}
+
+	// Mirror parseCommand: build the material map, then run the single-file guard.
+	sfa.srcFileToEncryptionMaterial = make(map[string]*snowflakeFileEncryption)
+	for i, f := range sfa.srcFiles {
+		sfa.srcFileToEncryptionMaterial[f] = sfa.encryptionMaterial[i]
+	}
+	assertNilF(t, sfa.ensureSingleGetStreamFile())
+
+	assertNilF(t, sfa.initFileMetadata())
+	assertEqualE(t, len(sfa.fileMetadata), 1)
+	assertEqualE(t, sfa.fileMetadata[0].encryptionMaterial, m0)
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -158,6 +158,9 @@ const (
 	ErrNotImplemented = 264011
 	// ErrInvalidPadding is an error code denoting the invalid padding of decryption key
 	ErrInvalidPadding = 264012
+	// ErrGetStreamMultipleFiles is an error code denoting a streaming GET whose stage path
+	// matched more than one file, so it cannot be streamed into a single writer.
+	ErrGetStreamMultipleFiles = 264013
 
 	/* binding */
 
@@ -265,6 +268,7 @@ const (
 	ErrMsgNoResultIDs                        = "no result IDs returned with the multi-statement query"
 	ErrMsgQueryStatus                        = "server ErrorCode=%s, ErrorMessage=%s"
 	ErrMsgInvalidPadding                     = "invalid padding on input"
+	ErrMsgGetStreamMultipleFiles             = "get stream can only return one file, please use the GET PATTERN argument"
 	ErrMsgClientConfigFailed                 = "client configuration failed: %v"
 	ErrMsgNullValueInArray                   = "for handling null values in arrays use WithArrayValuesNullable(ctx)"
 	ErrMsgNullValueInMap                     = "for handling null values in maps use WithMapValuesNullable(ctx)"


### PR DESCRIPTION
## Problem

[SNOW-3637888] A streaming `GET` (`WithFileGetStream`) corrupts its output when the GET path
prefix-matches more than one file. A GET resolves its stage path by prefix, so `GET @stage/foo`
also matches `foobar`, a nested `foo/foo`, etc. Because a get-stream has a single `io.Writer`,
every matched file's download goroutine writes that one shared buffer, so the caller silently gets
a nondeterministic concat/truncation (encrypted stages) or one arbitrary file (unencrypted) — with
no error.

Continues the file-transfer hardening from #1687, which made a panicking download goroutine
non-fatal but didn't address the cross-file shared-buffer contention.

## Fix

A get-stream can return only one file. When a `GET` matches more than one, the driver now returns
the new `ErrGetStreamMultipleFiles` (error code `264013`) **before any download goroutine is
spawned**, instead of streaming a corrupt mix.

Per review, the driver does **not** parse the SQL or guess which file the caller meant — that
selection logic would be specific to this one driver and can't be preserved under the upcoming
unified-driver work. Instead the error is meaningful and points the caller at the supported,
server-side way to narrow a GET to a single file: the **`PATTERN`** argument, e.g.

```sql
GET @~ file:///tmp/testData PATTERN='.*data1.txt.gz'
```

This adds one exported error constant (`ErrGetStreamMultipleFiles`) and changes no existing
signature. The check runs only for get-stream and after the encryption-material map is built, so a
single streamed file keeps its material.

## Behavior (before → after)

| # | Case | `GET` → server prefix-match | Before | After |
|---|------|------------------------------|--------|-------|
| 1 | Single result | `foo` → `[foo]` | streams `foo` | streams `foo` — unchanged |
| 2 | Whole-stage / folder GET, one file | `@%table` / `@stage` / `@stage/dir` → `[onefile]` | streams `onefile` | streams `onefile` — unchanged |
| 3 | Single result, not the exact name | `foo` → `[foobar]` | streams `foobar` | streams `foobar` — unchanged¹ |
| 4 | Exact file + prefix-sibling | `foo` → `[foo, foobar]` | **corrupt**, no error | `ErrGetStreamMultipleFiles` |
| 5 | Same leaf, different dirs | `foo` → `[a/foo, b/foo]` | **corrupt**, no error | `ErrGetStreamMultipleFiles` |
| 6 | File + same-named subdir | `foo` → `[foo, foo/foo]` | **corrupt**, no error | `ErrGetStreamMultipleFiles` |
| 7 | Whole-stage / folder GET, many files | `@%table` → `[a, b]` | **corrupt**, no error | `ErrGetStreamMultipleFiles` |
| 8 | Server returns nothing | `nope` → `[]` | `ErrInvalidStageLocation` | same — unchanged |
| 9 | Non-stream dir GET (not get-stream) | `@stage/dir` → `[a, b]` → local dir | downloads both | unchanged |
| 10 | PUT / streaming PUT | — | unchanged | unchanged |

"Corrupt" = all matched files share one buffer (encrypted: per-file `Truncate` ⇒ concat/truncation;
unencrypted: last-writer-wins). The multi-file check runs only for get-stream (rows 9–10 and
non-stream GETs are untouched).

**¹ Single-result note (row 3):** a lone result is streamed as-is. The N>1 corruption — the actual
bug — is fully fixed; the caller uses `PATTERN` when they need to guarantee the GET resolves to a
specific single object.

## Tests

Offline unit tests (`getstream_select_test.go`, run with `SKIP_SETUP=1`) cover the single-file
pass-through and every multi-file case erroring with `ErrGetStreamMultipleFiles`, plus a guard that
the single streamed file keeps its own encryption material (the check runs after the
source-file → material map is built). The full `put_get` integration suite (covering
whole-stage/folder get-stream) passes across the matrix.

cc the file-transfer / #1687 area owner.


[SNOW-3637888]: https://snowflakecomputing.atlassian.net/browse/SNOW-3637888
