### PR TITLE
SNOW-2294562: Fix GET from a LOCAL_FS stage downloading 0 files (download ignored smallFileMetas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New features:
 Bug fixes:
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 - Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
-- Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (SNOW-2294562, snowflakedb/gosnowflake#1810).
+- Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (snowflakedb/gosnowflake#1810).
 
 Internal changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features:
 Bug fixes:
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 - Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
+- Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (SNOW-2294562, snowflakedb/gosnowflake#1810).
 
 Internal changes:
 

--- a/file_transfer_agent.go
+++ b/file_transfer_agent.go
@@ -202,7 +202,11 @@ func (sfa *snowflakeFileTransferAgent) execute() error {
 			return err
 		}
 	} else {
-		if err = sfa.download(largeFileMetas); err != nil {
+		// Local-stage downloads place their file metadata in smallFileMetas (see the
+		// stageLocationType == local branch above); cloud downloads use largeFileMetas.
+		// Passing only largeFileMetas drops every file for a LOCAL_FS stage, so download()
+		// reports "downloading 0 files" and result() returns ErrNotImplemented (264011).
+		if err = sfa.download(append(largeFileMetas, smallFileMetas...)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Jira: SNOW-2294562

# Fix: GET from a LOCAL_FS stage downloads 0 files → `264011: not implemented`

## Problem
`GET @<stage>/<file> file://<dir>` against a **LOCAL_FS** stage fails with
`264011 (ErrNotImplemented)`. The driver logs `"downloading 0 files"` even though the
server returns a valid response (`command=DOWNLOAD`, non-empty `src_locations`,
`stageInfo.locationType=LOCAL_FS`).

## Root cause
In `snowflakeFileTransferAgent.execute()`, the per-file metadata distribution loop puts
**local-stage** files into `smallFileMetas`:
```go
} else { // sfa.stageLocationType == local
    meta.parallel = 1
    smallFileMetas = append(smallFileMetas, meta)
}
```
but the download dispatch passes only the large slice:
```go
} else {
    if err = sfa.download(largeFileMetas); err != nil { // largeFileMetas is empty for local
```
For a LOCAL_FS download, `largeFileMetas` is empty → `download()` processes 0 files →
`result()` finds 0 results → returns `ErrNotImplemented`. Cloud downloads put their metas in
`largeFileMetas`, so they are unaffected (this only breaks local-filesystem stages).

Introduced by the "enable multi-part download for all files" change, which routes cloud
downloads through `largeFileMetas` but did not account for the local-stage path that still
uses `smallFileMetas`.

## Fix
Pass both slices to `download()`:
```go
if err = sfa.download(append(largeFileMetas, smallFileMetas...)); err != nil {
```

## Verification
Reproduced against a local-filesystem stage with `tracing=trace`:
- before: `downloading 0 files` → `264011: not implemented`
- after:  `downloading 1 files` → file downloaded successfully, GET returns 1 result row.

A regression test should `GET` from a LOCAL_FS stage and assert the file is downloaded
(the existing local-stage tests only cover PUT/upload).