### PR TITLE
NO-SNOW Remove no longer existing max LOB parameters

### DIFF
--- a/bindings_test.go
+++ b/bindings_test.go
@@ -38,8 +38,6 @@ const (
 	insertSQLBulkArrayDateTimeTimestamp      = "insert into test_bulk_array_DateTimeTimestamp values(?, ?, ?, ?, ?)"
 	selectAllSQLBulkArrayDateTimeTimestamp   = "select * from test_bulk_array_DateTimeTimestamp ORDER BY 1"
 
-	enableFeatureMaxLOBSize      = "ALTER SESSION SET FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY='ENABLED'"
-	unsetFeatureMaxLOBSize       = "ALTER SESSION UNSET FEATURE_INCREASED_MAX_LOB_SIZE_IN_MEMORY"
 	enableLargeVarcharAndBinary  = "ALTER SESSION SET ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT=TRUE"
 	disableLargeVarcharAndBinary = "ALTER SESSION SET ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT=FALSE"
 	unsetLargeVarcharAndBinary   = "ALTER SESSION UNSET ENABLE_LARGE_VARCHAR_AND_BINARY_IN_RESULT"
@@ -1460,7 +1458,6 @@ func testLOBRetrieval(t *testing.T, useArrowFormat bool) {
 func TestMaxLobSize(t *testing.T) {
 	skipMaxLobSizeTestOnGithubActions(t)
 	runDBTest(t, func(dbt *DBTest) {
-		dbt.mustExec(enableFeatureMaxLOBSize)
 		defer dbt.mustExec(unsetLargeVarcharAndBinary)
 		t.Run("Max Lob Size disabled", func(t *testing.T) {
 			dbt.mustExec(disableLargeVarcharAndBinary)
@@ -1529,7 +1526,6 @@ func testInsertLOBData(t *testing.T, useArrowFormat bool, isLiteral bool) {
 		var c2 string
 		var c3 int
 
-		dbt.mustExec(enableFeatureMaxLOBSize)
 		if useArrowFormat {
 			dbt.mustExec(forceARROW)
 		} else {
@@ -1593,7 +1589,6 @@ func testInsertLOBData(t *testing.T, useArrowFormat bool, isLiteral bool) {
 			})
 			dbt.mustExec("DROP TABLE IF EXISTS lob_test_table")
 		}
-		dbt.mustExec(unsetFeatureMaxLOBSize)
 	})
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -309,6 +309,7 @@ func (dbt *DBTest) prepare(query string) (*sql.Stmt, error) {
 }
 
 func (dbt *DBTest) fail(method, query string, err error) {
+	dbt.Helper()
 	if !debugMode && len(query) > 1000 {
 		query = "[query too large to print]"
 	}
@@ -316,22 +317,26 @@ func (dbt *DBTest) fail(method, query string, err error) {
 }
 
 func (dbt *DBTest) mustExec(query string, args ...any) (res sql.Result) {
+	dbt.Helper()
 	return dbt.mustExecContext(context.Background(), query, args...)
 }
 
 func (dbt *DBTest) mustExecT(t *testing.T, query string, args ...any) (res sql.Result) {
+	dbt.Helper()
 	return dbt.mustExecContextT(context.Background(), t, query, args...)
 }
 
 func (dbt *DBTest) mustExecContext(ctx context.Context, query string, args ...any) (res sql.Result) {
 	res, err := dbt.conn.ExecContext(ctx, query, args...)
 	if err != nil {
+		dbt.Helper()
 		dbt.fail("exec context", query, err)
 	}
 	return res
 }
 
 func (dbt *DBTest) mustExecContextT(ctx context.Context, t *testing.T, query string, args ...any) (res sql.Result) {
+	dbt.Helper()
 	res, err := dbt.conn.ExecContext(ctx, query, args...)
 	if err != nil {
 		t.Fatalf("exec context: query=%v, err=%v", query, err)


### PR DESCRIPTION
### Description

Removes the explicit `enableFeatureMaxLOBSize` and `unsetFeatureMaxLOBSize` calls from LOB-related tests, as this feature is now enabled by default and no longer needs to be toggled manually. Additionally, removes the Jenkins skip conditions from `TestInsertLobData*` tests that were previously blocked on SNOW-1264687, indicating that issue has been resolved.

Adds `dbt.T.Helper()` calls to test helper methods to improve test failure output by correctly attributing failures to the calling test rather than the helper function itself.