### PR TITLE
SNOW-3651566 Add cleanupTimeout config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming release
 
 New features:
+- Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 
 Bug fixes:
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).

--- a/connection.go
+++ b/connection.go
@@ -1,6 +1,7 @@
 package gosnowflake
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"database/sql/driver"
@@ -302,8 +303,18 @@ func (sc *snowflakeConn) Close() (err error) {
 
 	if sc.cfg != nil && !sc.cfg.ServerSessionKeepAlive {
 		logger.WithContext(sc.ctx).Debug("Closing session since ServerSessionKeepAlive is false")
-		// we have to replace context with background, otherwise we can use a one that is cancelled or timed out
-		if err = sc.rest.FuncCloseSession(context.Background(), sc.rest, sc.rest.RequestTimeout); err != nil {
+		// we have to strip cancellation, otherwise we can use a ctx that is cancelled or timed out
+		// We reset the request ID so the abort gets its own fresh one instead of reusing the aborted query's
+		// ID (which WithRequestID would otherwise leak into the abort request URL).
+		closeCtx := context.WithValue(context.WithoutCancel(cmp.Or(sc.ctx, context.Background())), snowflakeRequestIDKey, nilUUID)
+		if sc.cfg.CleanupTimeout > 0 {
+			// Bound the logout so Close does not block past CleanupTimeout. Stays
+			// synchronous to honor the io.Closer expectation of blocking on close.
+			var cancelClose context.CancelFunc
+			closeCtx, cancelClose = context.WithTimeout(closeCtx, sc.cfg.CleanupTimeout)
+			defer cancelClose()
+		}
+		if err = sc.rest.FuncCloseSession(closeCtx, sc.rest, sc.rest.RequestTimeout); err != nil {
 			logger.WithContext(sc.ctx).Errorf("error while closing session: %v", err)
 		}
 	} else {

--- a/doc.go
+++ b/doc.go
@@ -98,6 +98,21 @@ The following connection parameters are supported:
     0 (zero) specifies that the driver should wait indefinitely. The default is 0 seconds.
     The query request gives up after the timeout length if the HTTP response is success.
 
+  - cleanupTimeout: Specifies the timeout, in seconds, that bounds post-cancellation
+    cleanup — the best-effort query abort sent after a QueryContext/PingContext/ExecContext
+    is canceled or times out, and the session logout sent by Close. 0 (zero, the default)
+    preserves the pre-existing behavior: cleanup runs synchronously on the caller's
+    goroutine using a background context and is unbounded, so a canceled query can block
+    the caller minutes-to-hours past its own deadline. When positive, the query abort is
+    detached onto its own goroutine bounded by this timeout so the caller regains control
+    at its own deadline, and Close bounds the logout to this timeout (Close stays
+    synchronous to honor the io.Closer contract). Because the abort then runs concurrently
+    with any reuse of the same connection, keep this value small (5 seconds is a reasonable
+    starting point) to bound the overlap window.
+
+    Note: this field was added to bypass a Behavior Change Release (BCR) and may be subject
+    to change in the next breaking change release.
+
   - authenticator: Specifies the authenticator to use for authenticating user credentials.
     See "Authenticator Values" section below for supported values.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	ExternalBrowserTimeout time.Duration // Timeout for external browser login
 	// Deprecated: timeouts may be reorganized in a future release.
 	CloudStorageTimeout time.Duration // Timeout for a single call to a cloud storage provider
+	CleanupTimeout      time.Duration // Bounds post-cancellation cleanup (query abort and session logout); 0 keeps the legacy unbounded behavior
 	MaxRetryCount       int           // Specifies how many times non-periodic HTTP request can be retried
 
 	Application       string           // application name.

--- a/internal/config/dsn.go
+++ b/internal/config/dsn.go
@@ -181,6 +181,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	if cfg.CloudStorageTimeout != defaultCloudStorageTimeout {
 		params.Add("cloudStorageTimeout", strconv.FormatInt(int64(cfg.CloudStorageTimeout/time.Second), 10))
 	}
+	if cfg.CleanupTimeout != 0 {
+		params.Add("cleanupTimeout", strconv.FormatInt(int64(cfg.CleanupTimeout/time.Second), 10))
+	}
 	if cfg.MaxRetryCount != defaultMaxRetryCount {
 		params.Add("maxRetryCount", strconv.Itoa(cfg.MaxRetryCount))
 	}
@@ -917,6 +920,11 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			}
 		case "cloudStorageTimeout":
 			cfg.CloudStorageTimeout, err = parseTimeout(value)
+			if err != nil {
+				return err
+			}
+		case "cleanupTimeout":
+			cfg.CleanupTimeout, err = parseTimeout(value)
 			if err != nil {
 				return err
 			}

--- a/internal/config/dsn_test.go
+++ b/internal/config/dsn_test.go
@@ -2122,6 +2122,15 @@ func TestDSN(t *testing.T) {
 			},
 			dsn: "u:p@a.b.c.snowflakecomputing.com:443?ocspFailOpen=true&region=b.c&singleAuthenticationPrompt=false&validateDefaultParameters=true",
 		},
+		{
+			cfg: &Config{
+				User:           "u",
+				Password:       "p",
+				Account:        "a.b.c",
+				CleanupTimeout: 5 * time.Second,
+			},
+			dsn: "u:p@a.b.c.snowflakecomputing.com:443?cleanupTimeout=5&ocspFailOpen=true&region=b.c&validateDefaultParameters=true",
+		},
 	}
 	for _, test := range testcases {
 		t.Run(maskSecrets(test.dsn), func(t *testing.T) {

--- a/restful.go
+++ b/restful.go
@@ -206,9 +206,28 @@ func postRestfulQuery(
 
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		// For context cancel/timeout cases, a special cancel request needs to be sent.
-		if cancelErr := sr.FuncCancelQuery(context.Background(), sr, requestID, timeout); cancelErr != nil {
-			// Wrap the original error with the cancel error.
-			err = fmt.Errorf("failed to cancel query. cancelErr: %w, queryErr: %w", cancelErr, err)
+		if cfg.CleanupTimeout > 0 {
+			// Bounded cleanup: detach the abort onto its own goroutine with a hard
+			// deadline so the caller regains control at its own deadline instead of
+			// blocking until the abort (and its internal retries) finish.
+			// WithoutCancel keeps the caller ctx's values (logging/trace correlation)
+			// while dropping its cancellation and deadline. We reset the request ID so
+			// the abort gets its own fresh one instead of reusing the aborted query's
+			// ID (which WithRequestID would otherwise leak into the abort request URL).
+			detachedCtx := context.WithValue(context.WithoutCancel(ctx), snowflakeRequestIDKey, nilUUID)
+			cleanupCtx, cancel := context.WithTimeout(detachedCtx, cfg.CleanupTimeout)
+			go func() {
+				defer cancel()
+				if cancelErr := sr.FuncCancelQuery(cleanupCtx, sr, requestID, timeout); cancelErr != nil {
+					logger.Warnf("failed to cancel query (async cleanup): %v", cancelErr)
+				}
+			}()
+		} else {
+			// Legacy behavior: synchronous, unbounded cleanup on the caller's goroutine.
+			if cancelErr := sr.FuncCancelQuery(context.Background(), sr, requestID, timeout); cancelErr != nil {
+				// Wrap the original error with the cancel error.
+				err = fmt.Errorf("failed to cancel query. cancelErr: %w, queryErr: %w", cancelErr, err)
+			}
 		}
 	}
 

--- a/restful_test.go
+++ b/restful_test.go
@@ -660,7 +660,7 @@ func TestPostRestfulQueryContextErrors(t *testing.T) {
 		}
 	}
 	runPostRestfulQuery := func(sr *snowflakeRestful) (data *execResponse, err error) {
-		return postRestfulQuery(context.Background(), sr, &url.Values{}, nil, nil, 0, NewUUID(), nil)
+		return postRestfulQuery(context.Background(), sr, &url.Values{}, nil, nil, 0, NewUUID(), &Config{})
 	}
 
 	t.Run("postRestfulQuery error does not trigger cancel", func(t *testing.T) {
@@ -697,6 +697,60 @@ func TestPostRestfulQueryContextErrors(t *testing.T) {
 		assertErrIsE(t, err, context.Canceled)
 		assertErrIsE(t, err, fatalCancelErr)
 		assertEqualE(t, "failed to cancel query. cancelErr: fatal failure, queryErr: context canceled", err.Error())
+	})
+
+	t.Run("positive CleanupTimeout detaches abort and returns unwrapped error", func(t *testing.T) {
+		type cleanupCtxKey struct{}
+		type abortCapture struct {
+			err         error
+			keptValue   any
+			hasDeadline bool
+			reqID       UUID
+		}
+		captured := make(chan abortCapture, 1)
+
+		callerReqID := NewUUID()
+		sr := newRestfulWithError(context.Canceled)
+		sr.FuncCancelQuery = func(ctx context.Context, _ *snowflakeRestful, _ UUID, _ time.Duration) error {
+			// Snapshot the detached context while it is still live (before the
+			// goroutine's deferred cancel fires) so assertions don't race.
+			_, hasDeadline := ctx.Deadline()
+			captured <- abortCapture{
+				err:         ctx.Err(),
+				keptValue:   ctx.Value(cleanupCtxKey{}),
+				hasDeadline: hasDeadline,
+				reqID:       getOrGenerateRequestIDFromContext(ctx),
+			}
+			return fmt.Errorf("cancel error that must not surface to the caller")
+		}
+
+		// Caller ctx carries a value and a request ID, and is already canceled -
+		// mirroring the state postRestfulQuery sees on the cancel path.
+		callerCtx := WithRequestID(context.WithValue(context.Background(), cleanupCtxKey{}, "keep-me"), callerReqID)
+		callerCtx, cancelCaller := context.WithCancel(callerCtx)
+		cancelCaller()
+
+		_, err := postRestfulQuery(callerCtx, sr, &url.Values{}, nil, nil, 0, NewUUID(), &Config{CleanupTimeout: 5 * time.Second})
+
+		// Caller-visible error is the original one, not wrapped with the cancel error.
+		assertErrIsE(t, err, context.Canceled)
+		assertEqualE(t, context.Canceled.Error(), err.Error())
+
+		select {
+		case c := <-captured:
+			// Detached: not canceled even though the caller ctx was canceled.
+			assertNilE(t, c.err)
+			// WithoutCancel retained the caller ctx values.
+			assertEqualE(t, c.keptValue, "keep-me")
+			// Bounded by CleanupTimeout.
+			assertTrueE(t, c.hasDeadline)
+			// Request ID reset: the abort must not reuse the aborted query's ID,
+			// and must be a freshly generated UUID rather than the all-zeros sentinel.
+			assertNotEqualE(t, c.reqID, callerReqID)
+			assertNotEqualE(t, c.reqID, nilUUID)
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected async abort to be sent")
+		}
 	})
 }
 


### PR DESCRIPTION
### Description

Adds a `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup operations — specifically the query abort sent after a `QueryContext`/`PingContext`/`ExecContext` cancellation or timeout, and the session logout sent by `Close`.

Previously, cleanup ran synchronously on the caller's goroutine using an unbounded background context, meaning a canceled query could block the caller for minutes or hours past its own deadline. With `CleanupTimeout` set to a positive value, the query abort is detached onto its own goroutine bounded by the specified timeout, allowing the caller to regain control at its own deadline. The session logout in `Close` is also bounded by this timeout while remaining synchronous to honor the `io.Closer` contract.

The default value of `0` preserves the existing unbounded behavior to avoid a breaking change. A value of 5 seconds is recommended as a starting point. Because the abort runs concurrently with potential connection reuse when a positive value is set, keeping this value small limits the overlap window.

Note: this field was added to bypass a Behavior Change Release (BCR) and may be subject to change in the next breaking change release.