### PR TITLE
SNOW-3801358 fix nil pointer dereference panic upon encountering corrupt OCSP cache entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features:
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 
 Bug fixes:
-- Fixed nil pointer dereference panic in OCSP cache loading when a corrupt or malformed cache key is encountered, either from the remote OCSP cache server or the on-disk cache file. Corrupt entries are now skipped and the driver falls back to the live OCSP Responder for the affected certificate (snowflakedb/gosnowflake#XXXX).
+- Fixed nil pointer dereference panic in OCSP cache loading when a corrupt or malformed cache key is encountered, either from the remote OCSP cache server or the on-disk cache file. Corrupt entries are now skipped and the driver falls back to the live OCSP Responder for the affected certificate (snowflakedb/gosnowflake#1819).
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 - Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
 - Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (snowflakedb/gosnowflake#1810).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features:
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 
 Bug fixes:
-- Fixed nil pointer dereference panic in OCSP cache loading when a corrupt or malformed cache key is encountered, either from the remote OCSP cache server or the on-disk cache file. Corrupt entries are now skipped and the driver falls back to the live OCSP Responder for the affected certificate (snowflakedb/gosnowflake#1819).
+- Fixed nil pointer dereference panic when a corrupt or malformed OCSP cache key is encountered, either from the remote OCSP cache server or the local cache file (snowflakedb/gosnowflake#1819).
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 - Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
 - Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (snowflakedb/gosnowflake#1810).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 
 Bug fixes:
+- Fixed nil pointer dereference panic in OCSP cache loading when a corrupt or malformed cache key is encountered, either from the remote OCSP cache server or the on-disk cache file. Corrupt entries are now skipped and the driver falls back to the live OCSP Responder for the affected certificate (snowflakedb/gosnowflake#XXXX).
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).
 - Fixed gosnowflake writing a `gosnowflake-cgo` directory under the system temp dir at package import time even when the driver was never used (e.g. when imported only as a transitive dependency). Minicore now loads lazily when the driver is first referenced (`NewConnector`/`OpenWithConfig`) instead of in `init()` (snowflakedb/gosnowflake#1807).
 - Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (snowflakedb/gosnowflake#1810).

--- a/ocsp.go
+++ b/ocsp.go
@@ -267,27 +267,25 @@ func extractCertIDKeyFromRequest(ocspReq []byte) (*certIDKey, *ocspStatus) {
 	}
 }
 
-func decodeCertIDKey(certIDKeyBase64 string) *certIDKey {
+func decodeCertIDKey(certIDKeyBase64 string) (*certIDKey, error) {
 	r, err := base64.StdEncoding.DecodeString(certIDKeyBase64)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	var c certID
 	rest, err := asn1.Unmarshal(r, &c)
 	if err != nil {
-		// error in parsing
-		return nil
+		return nil, err
 	}
 	if len(rest) > 0 {
-		// extra bytes to the end
-		return nil
+		return nil, fmt.Errorf("extra bytes after ASN.1 certID structure")
 	}
 	return &certIDKey{
 		getHashAlgorithmFromOID(c.HashAlgorithm),
 		base64.StdEncoding.EncodeToString(c.NameHash),
 		base64.StdEncoding.EncodeToString(c.IssuerKeyHash),
 		c.SerialNumber.String(),
-	}
+	}, nil
 }
 
 func encodeCertIDKey(k *certIDKey) string {
@@ -811,9 +809,9 @@ func (ov *ocspValidator) downloadOCSPCacheServer() {
 
 	ocspResponseCacheLock.Lock()
 	for k, cacheValue := range *ret {
-		cacheKey := decodeCertIDKey(k)
-		if cacheKey == nil {
-			logger.Debugf("OCSP cache server returned a corrupt or unrecognised cache key, skipping entry")
+		cacheKey, err := decodeCertIDKey(k)
+		if err != nil {
+			logger.Debugf("OCSP cache server returned a corrupt or unrecognised cache key, skipping entry: %v", err)
 			continue
 		}
 		status := extractOCSPCacheResponseValueWithoutSubject(cacheKey, cacheValue)
@@ -909,9 +907,9 @@ func initOCSPCache() {
 			continue
 		}
 		certValue := &certCacheValue{ts, ocspRespBase64}
-		cacheKey := decodeCertIDKey(k)
-		if cacheKey == nil {
-			logger.Debugf("OCSP cache file contains a corrupt or unrecognised cache key, skipping entry")
+		cacheKey, err := decodeCertIDKey(k)
+		if err != nil {
+			logger.Debugf("OCSP cache file contains a corrupt or unrecognised cache key, skipping entry: %v", err)
 			continue
 		}
 		status := extractOCSPCacheResponseValueWithoutSubject(cacheKey, certValue)

--- a/ocsp.go
+++ b/ocsp.go
@@ -812,6 +812,10 @@ func (ov *ocspValidator) downloadOCSPCacheServer() {
 	ocspResponseCacheLock.Lock()
 	for k, cacheValue := range *ret {
 		cacheKey := decodeCertIDKey(k)
+		if cacheKey == nil {
+			logger.Debugf("OCSP cache server returned a corrupt or unrecognised cache key, skipping entry")
+			continue
+		}
 		status := extractOCSPCacheResponseValueWithoutSubject(cacheKey, cacheValue)
 		if !isValidOCSPStatus(status.code) {
 			continue
@@ -906,6 +910,10 @@ func initOCSPCache() {
 		}
 		certValue := &certCacheValue{ts, ocspRespBase64}
 		cacheKey := decodeCertIDKey(k)
+		if cacheKey == nil {
+			logger.Debugf("OCSP cache file contains a corrupt or unrecognised cache key, skipping entry")
+			continue
+		}
 		status := extractOCSPCacheResponseValueWithoutSubject(cacheKey, certValue)
 		if !isValidOCSPStatus(status.code) {
 			continue

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -7,11 +7,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -627,4 +629,81 @@ func syncUpdateOcspResponseCache(f func()) {
 	ocspResponseCacheLock.Lock()
 	defer ocspResponseCacheLock.Unlock()
 	f()
+}
+
+// issue#1818 - corrupt/mangled OCSP entries must be skipped both in the on-filesystem, pre-existing
+// OCSP cache file, and in the one which is freshly downloaded from OCSP_CACHE_SERVER, and
+// must not cause a panic on nil pointer dereference.
+// After skipping the corrupt entry, the driver continues to validate online with OCSP Responder.
+
+// Corrupt entry in file downloaded from OCSP_CACHE_SERVER
+func TestUnitDownloadOCSPCacheServerCorruptKey(t *testing.T) {
+	ocspCacheServerEnabled = true
+
+	// Build a JSON payload whose key is not valid base64 (so decodeCertIDKey
+	// returns nil) but whose value is a well-formed [ts, ocspRespBase64] pair.
+	payload, err := json.Marshal(map[string]any{
+		"not!valid!base64==": []any{
+			float64(time.Now().UTC().Unix()),
+			base64.StdEncoding.EncodeToString([]byte("junk-not-ocsp")),
+		},
+	})
+	assertNilF(t, err, "marshalling test payload")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(payload)
+	}))
+	defer ts.Close()
+
+	ov := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenTrue})
+	ov.cacheServerURL = ts.URL
+
+	syncUpdateOcspResponseCache(func() {
+		ocspResponseCache = make(map[certIDKey]*certCacheValue)
+	})
+
+	// Must not panic.
+	ov.downloadOCSPCacheServer()
+
+	func() {
+		ocspResponseCacheLock.RLock()
+		defer ocspResponseCacheLock.RUnlock()
+		assertEqualF(t, len(ocspResponseCache), 0, "corrupt key must not be stored in cache")
+	}()
+}
+
+// Corrupt entry in the on-disk OCSP cache file
+func TestUnitInitOCSPCacheCorruptKey(t *testing.T) {
+	ocspCacheServerEnabled = true
+
+	// Build a JSON payload with a key that is valid base64 but does not decode
+	// to a valid ASN.1 certID structure.
+	corruptKey := base64.StdEncoding.EncodeToString([]byte("this-is-not-asn1"))
+	payload, err := json.Marshal(map[string]any{
+		corruptKey: []any{
+			float64(time.Now().UTC().Unix()),
+			base64.StdEncoding.EncodeToString([]byte("junk-not-ocsp")),
+		},
+	})
+	assertNilF(t, err, "marshalling test payload")
+
+	f, err := os.CreateTemp(t.TempDir(), "ocsp_cache_corrupt_*.json")
+	assertNilF(t, err, "creating temp cache file")
+	_, err = f.Write(payload)
+	assertNilF(t, err, "writing temp cache file")
+	assertNilF(t, f.Close(), "closing temp cache file")
+
+	origCacheFileName := cacheFileName
+	cacheFileName = f.Name()
+	defer func() { cacheFileName = origCacheFileName }()
+
+	// Must not panic.
+	initOCSPCache()
+
+	func() {
+		ocspResponseCacheLock.RLock()
+		defer ocspResponseCacheLock.RUnlock()
+		assertEqualF(t, len(ocspResponseCache), 0, "corrupt key from file must not be stored in cache")
+	}()
 }

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -640,24 +639,10 @@ func syncUpdateOcspResponseCache(f func()) {
 func TestUnitDownloadOCSPCacheServerCorruptKey(t *testing.T) {
 	ocspCacheServerEnabled = true
 
-	// Build a JSON payload whose key is not valid base64 (so decodeCertIDKey
-	// returns nil) but whose value is a well-formed [ts, ocspRespBase64] pair.
-	payload, err := json.Marshal(map[string]any{
-		"not!valid!base64==": []any{
-			float64(time.Now().UTC().Unix()),
-			base64.StdEncoding.EncodeToString([]byte("junk-not-ocsp")),
-		},
-	})
-	assertNilF(t, err, "marshalling test payload")
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(payload)
-	}))
-	defer ts.Close()
+	wiremock.registerMappings(t, newWiremockMapping("ocsp/corrupt_cache_key.json"))
 
 	ov := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenTrue})
-	ov.cacheServerURL = ts.URL
+	ov.cacheServerURL = fmt.Sprintf("%v/ocsp_response_cache.json", wiremock.baseURL())
 
 	syncUpdateOcspResponseCache(func() {
 		ocspResponseCache = make(map[certIDKey]*certCacheValue)

--- a/test_data/wiremock/mappings/ocsp/corrupt_cache_key.json
+++ b/test_data/wiremock/mappings/ocsp/corrupt_cache_key.json
@@ -1,0 +1,19 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPathPattern": "/ocsp_response_cache.json",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "not!valid!base64==": [9999999999.0, "anVuay1ub3Qtb2NzcA=="]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Problem

When the OCSP cache server (`ocsp.snowflakecomputing.com`) or the local on-disk cache file contained an entry with a corrupt or malformed cache key (invalid base64, or valid base64 but not a valid ASN.1 `certID` structure), the driver panicked with a nil pointer dereference. 

`decodeCertIDKey()` correctly returns `nil` for such keys, but neither `downloadOCSPCacheServer` nor `initOCSPCache` checked for nil before dereferencing the result when writing to `ocspResponseCache`. 

Because `extractOCSPCacheResponseValueWithoutSubject` handles a nil key gracefully and can return a valid OCSP status (when the response value itself is well-formed), the `isValidOCSPStatus` guard did not protect against the subsequent `ocspResponseCache[*cacheKey]` dereference.

### Fix

Added a nil check on the result of `decodeCertIDKey()` in both `downloadOCSPCacheServer` and `initOCSPCache`, immediately after the call and before any further use. Corrupt entries are skipped with a debug log message. Because the entry is never loaded into the in-memory cache, the driver naturally falls back to a live OCSP Responder request for the affected certificate, and `writeOCSPCacheFile` will subsequently persist only the fresh, valid response — effectively overwriting the corrupt entry.

### Tests

* Added `TestUnitDownloadOCSPCacheServerCorruptKey`, which spins up a local HTTP test server serving a JSON payload with an invalid base64 cache key and verifies that `downloadOCSPCacheServer` does not panic and does not store the entry. 
* Added `TestUnitInitOCSPCacheCorruptKey`, which writes a temp cache file containing a valid-base64-but-not-ASN.1 key (simulating a file mangled by an external tool between driver reads) and verifies that `initOCSPCache` does not panic and does not load the entry.