### PR TITLE
NO-SNOW Increased CRL disk cache removal delay to 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 New features:
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
+- Increased CRL disk cache removal delay to 7 days (snowflakedb/gosnowflake#1820).
 
 Bug fixes:
 - Fixed nil pointer dereference panic when a corrupt or malformed OCSP cache key is encountered, either from the remote OCSP cache server or the local cache file (snowflakedb/gosnowflake#1819).

--- a/crl.go
+++ b/crl.go
@@ -156,7 +156,7 @@ const (
 const (
 	defaultCrlHTTPClientTimeout       = 10 * time.Second
 	defaultCrlCacheValidityTime       = 24 * time.Hour
-	defaultCrlOnDiskCacheRemovalDelay = 7 * time.Hour
+	defaultCrlOnDiskCacheRemovalDelay = 7 * 24 * time.Hour
 	defaultCrlDownloadMaxSize         = 20 * 1024 * 1024 // 20 MB
 )
 


### PR DESCRIPTION
### Description

SNOW-1820 The CRL disk cache removal delay has been corrected from 7 hours to 7 days, ensuring cached CRL entries are retained on disk for the intended duration before being eligible for removal.