### PR TITLE
SNOW-3784429 token cache key v2 fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ New features:
 - Added option to load private key from `connections.toml` file (snowflakedb/gosnowflake#1822).
 
 Bug fixes:
-- Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key applied uniformly across keyring (macOS/Windows) and file (Linux) backends (snowflakedb/gosnowflake#1817).
+- Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the token type in the key prefix, applied uniformly across keyring (macOS/Windows) and file (Linux) backends (snowflakedb/gosnowflake#1821).
 - Fixed nil pointer dereference panic when a corrupt or malformed OCSP cache key is encountered, either from the remote OCSP cache server or the local cache file (snowflakedb/gosnowflake#1819).
 - Fixed `WithFileGetStream` returning corrupt or wrong-file bytes when a `GET` prefix-matched more than one file; a get-stream can return only one file, so a multi-file match now returns the new `ErrGetStreamMultipleFiles` (pointing to the GET `PATTERN` argument) instead of a nondeterministic mix (snowflakedb/gosnowflake#1809).
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ New features:
 - Added option to load private key from `connections.toml` file (snowflakedb/gosnowflake#1822).
 
 Bug fixes:
-- Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the token type in the key prefix, applied uniformly across keyring (macOS/Windows) and file (Linux) backends (snowflakedb/gosnowflake#1821).
+- Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the token type in the key prefix, applied uniformly across keyring (macOS/Windows) and file (Linux) backends; also replaced the bag-of-fields spec struct with typed token-spec types (`hostUserTokenSpec` for MFA/ID flows, `oauthTokenSpec` for OAuth flows) so each spec validates and serializes only its own fields (snowflakedb/gosnowflake#1817, snowflakedb/gosnowflake#1821).
 - Fixed nil pointer dereference panic when a corrupt or malformed OCSP cache key is encountered, either from the remote OCSP cache server or the local cache file (snowflakedb/gosnowflake#1819).
 - Fixed `WithFileGetStream` returning corrupt or wrong-file bytes when a `GET` prefix-matched more than one file; a get-stream can return only one file, so a multi-file match now returns the new `ErrGetStreamMultipleFiles` (pointing to the GET `PATTERN` argument) instead of a nondeterministic mix (snowflakedb/gosnowflake#1809).
 - Do not attempt to get S3 bucket accelerate config for Snowflake-internal stages (matched by bucket name `sfc-*`) since s3:GetAccelerateConfiguration not granted anyways (snowflakedb/gosnowflake#1805).

--- a/auth.go
+++ b/auth.go
@@ -338,13 +338,13 @@ func authenticate(
 		logger.WithContext(ctx).Error("Authentication FAILED")
 		sc.rest.TokenAccessor.SetTokens("", "", -1)
 		if sessionParameters[clientRequestMfaToken] == true {
-			credentialsStorage.deleteCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
+			credentialsStorage.deleteCredential(newMfaTokenSpec(sc.cfg))
 		}
 		if sessionParameters[clientStoreTemporaryCredential] == true && sc.cfg.Authenticator == AuthTypeExternalBrowser {
-			credentialsStorage.deleteCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
+			credentialsStorage.deleteCredential(newIDTokenSpec(sc.cfg))
 		}
 		if sessionParameters[clientStoreTemporaryCredential] == true && isOauthNativeFlow(sc.cfg.Authenticator) {
-			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(sc.cfg))
 		}
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
@@ -360,11 +360,11 @@ func authenticate(
 	sc.rest.TokenAccessor.SetTokens(respd.Data.Token, respd.Data.MasterToken, respd.Data.SessionID)
 	if sessionParameters[clientRequestMfaToken] == true {
 		token := respd.Data.MfaToken
-		credentialsStorage.setCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User), token)
+		credentialsStorage.setCredential(newMfaTokenSpec(sc.cfg), token)
 	}
 	if sessionParameters[clientStoreTemporaryCredential] == true {
 		token := respd.Data.IDToken
-		credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User), token)
+		credentialsStorage.setCredential(newIDTokenSpec(sc.cfg), token)
 	}
 	return &respd.Data, nil
 }
@@ -584,8 +584,9 @@ func (o *oauthLockKey) lockID() string {
 	return o.idp + "|" + o.snowflake + "|" + o.user + "|" + o.role + "|" + o.flowType
 }
 
-// oauthTokenRequestURL returns the full token endpoint URL for OAuth, using the
-// same fallback logic as oauthClient.tokenURL() so that eviction keys match write keys.
+// oauthTokenRequestURL returns the full token endpoint URL for OAuth.
+// oauthClient.tokenURL() delegates to this function so that all cache key
+// construction and eviction paths use one canonical URL formula.
 func oauthTokenRequestURL(cfg *Config) string {
 	return cmp.Or(cfg.OauthTokenRequestURL, fmt.Sprintf("%v://%v:%v/oauth/token-request", cfg.Protocol, cfg.Host, cfg.Port))
 }
@@ -599,11 +600,11 @@ func authenticateByAuthorizationCode(sc *snowflakeConn) (string, error) {
 		return oauthClient.authenticateByOAuthAuthorizationCode()
 	}
 
-	lockKey := newOAuthAuthorizationCodeLockKey(oauthClient.tokenURL(), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
+	lockKey := newOAuthAuthorizationCodeLockKey(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
 	valueAwaiter := valueAwaitHolder.get(lockKey)
 	defer valueAwaiter.resumeOne()
 	token, err := awaitValue(valueAwaiter, func() (string, error) {
-		return credentialsStorage.getCredential(newOAuthAccessTokenSpec(oauthClient.tokenURL(), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)), nil
+		return credentialsStorage.getCredential(newOAuthAccessTokenSpec(sc.cfg)), nil
 	}, func(s string, err error) bool {
 		return s != ""
 	}, func() string {
@@ -699,7 +700,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 				valueAwaiter := valueAwaitHolder.get(idTokenLockKey)
 				defer valueAwaiter.resumeOne()
 				sc.idToken, _ = awaitValue(valueAwaiter, func() (string, error) {
-					credential := credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
+					credential := credentialsStorage.getCredential(newIDTokenSpec(sc.cfg))
 					return credential, nil
 				}, func(s string, err error) bool {
 					return s != ""
@@ -707,7 +708,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 					return ""
 				})
 			} else if sc.cfg.ClientStoreTemporaryCredential == ConfigBoolTrue {
-				sc.idToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
+				sc.idToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg))
 			}
 		}
 		// Disable console login by default
@@ -724,7 +725,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 			valueAwaiter := valueAwaitHolder.get(mfaTokenLockKey)
 			defer valueAwaiter.resumeOne()
 			sc.mfaToken, _ = awaitValue(valueAwaiter, func() (string, error) {
-				credential := credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
+				credential := credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg))
 				return credential, nil
 			}, func(s string, err error) bool {
 				return s != ""
@@ -732,7 +733,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 				return ""
 			})
 		} else if sc.cfg.ClientRequestMfaToken == ConfigBoolTrue {
-			sc.mfaToken = credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
+			sc.mfaToken = credentialsStorage.getCredential(newMfaTokenSpec(sc.cfg))
 		}
 	}
 
@@ -763,7 +764,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 	if err != nil {
 		var se *SnowflakeError
 		if errors.As(err, &se) && slices.Contains(refreshOAuthTokenErrorCodes, strconv.Itoa(se.Number)) {
-			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(sc.cfg))
 
 			if sc.cfg.Authenticator == AuthTypeOAuthAuthorizationCode {
 				doRefreshTokenWithLock(sc)
@@ -796,11 +797,11 @@ func doRefreshTokenWithLock(sc *snowflakeConn) {
 	if oauthClient, err := newOauthClient(sc.ctx, sc.cfg, sc); err != nil {
 		logger.Warnf("failed to create oauth client. %v", err)
 	} else {
-		lockKey := newRefreshTokenLockKey(oauthClient.tokenURL(), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
+		lockKey := newRefreshTokenLockKey(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
 		if _, err = getValueWithLock(chooseLockerForAuth(sc.cfg), lockKey, func() (string, error) {
 			if err = oauthClient.refreshToken(); err != nil {
 				logger.Warnf("cannot refresh token. %v", err)
-				credentialsStorage.deleteCredential(newOAuthRefreshTokenSpec(oauthClient.tokenURL(), sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+				credentialsStorage.deleteCredential(newOAuthRefreshTokenSpec(sc.cfg))
 				return "", err
 			}
 			return "", nil

--- a/auth.go
+++ b/auth.go
@@ -1,7 +1,6 @@
 package gosnowflake
 
 import (
-	"cmp"
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
@@ -552,45 +551,6 @@ func createRequestBody(sc *snowflakeConn, sessionParameters map[string]any,
 	return jsonBody, nil
 }
 
-type oauthLockKey struct {
-	idp       string
-	snowflake string
-	user      string
-	role      string
-	flowType  string
-}
-
-func newOAuthAuthorizationCodeLockKey(idpURL, snowflakeHost, user, role string) *oauthLockKey {
-	return &oauthLockKey{
-		idp:       idpURL,
-		snowflake: snowflakeHost,
-		user:      user,
-		role:      role,
-		flowType:  "authorization_code",
-	}
-}
-
-func newRefreshTokenLockKey(idpURL, snowflakeHost, user, role string) *oauthLockKey {
-	return &oauthLockKey{
-		idp:       idpURL,
-		snowflake: snowflakeHost,
-		user:      user,
-		role:      role,
-		flowType:  "refresh_token",
-	}
-}
-
-func (o *oauthLockKey) lockID() string {
-	return o.idp + "|" + o.snowflake + "|" + o.user + "|" + o.role + "|" + o.flowType
-}
-
-// oauthTokenRequestURL returns the full token endpoint URL for OAuth.
-// oauthClient.tokenURL() delegates to this function so that all cache key
-// construction and eviction paths use one canonical URL formula.
-func oauthTokenRequestURL(cfg *Config) string {
-	return cmp.Or(cfg.OauthTokenRequestURL, fmt.Sprintf("%v://%v:%v/oauth/token-request", cfg.Protocol, cfg.Host, cfg.Port))
-}
-
 func authenticateByAuthorizationCode(sc *snowflakeConn) (string, error) {
 	oauthClient, err := newOauthClient(sc.ctx, sc.cfg, sc)
 	if err != nil {
@@ -600,7 +560,7 @@ func authenticateByAuthorizationCode(sc *snowflakeConn) (string, error) {
 		return oauthClient.authenticateByOAuthAuthorizationCode()
 	}
 
-	lockKey := newOAuthAuthorizationCodeLockKey(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
+	lockKey := newOAuthAccessTokenSpec(sc.cfg)
 	valueAwaiter := valueAwaitHolder.get(lockKey)
 	defer valueAwaiter.resumeOne()
 	token, err := awaitValue(valueAwaiter, func() (string, error) {
@@ -656,40 +616,14 @@ func prepareJWTToken(config *Config) (string, error) {
 	return tokenString, err
 }
 
-type tokenLockKey struct {
-	snowflake string
-	user      string
-	tokenType string
-}
-
-func newMfaTokenLockKey(snowflakeHost, user string) *tokenLockKey {
-	return &tokenLockKey{
-		snowflake: snowflakeHost,
-		user:      user,
-		tokenType: "MFA",
-	}
-}
-
-func newIDTokenLockKey(snowflakeHost, user string) *tokenLockKey {
-	return &tokenLockKey{
-		snowflake: snowflakeHost,
-		user:      user,
-		tokenType: "ID",
-	}
-}
-
-func (m *tokenLockKey) lockID() string {
-	return m.snowflake + "|" + m.user + "|" + m.tokenType
-}
-
 func authenticateWithConfig(sc *snowflakeConn) error {
 	var authData *authResponseMain
 	var samlResponse []byte
 	var proofKey []byte
 	var err error
 
-	mfaTokenLockKey := newMfaTokenLockKey(sc.cfg.Host, sc.cfg.User)
-	idTokenLockKey := newIDTokenLockKey(sc.cfg.Host, sc.cfg.User)
+	mfaTokenLockKey := newMfaTokenSpec(sc.cfg)
+	idTokenLockKey := newIDTokenSpec(sc.cfg)
 
 	if sc.cfg.Authenticator == AuthTypeExternalBrowser || sc.cfg.Authenticator == AuthTypeOAuthAuthorizationCode || sc.cfg.Authenticator == AuthTypeOAuthClientCredentials {
 		if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && sc.cfg.ClientStoreTemporaryCredential == sfconfig.BoolNotSet {
@@ -797,7 +731,7 @@ func doRefreshTokenWithLock(sc *snowflakeConn) {
 	if oauthClient, err := newOauthClient(sc.ctx, sc.cfg, sc); err != nil {
 		logger.Warnf("failed to create oauth client. %v", err)
 	} else {
-		lockKey := newRefreshTokenLockKey(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
+		lockKey := newOAuthRefreshTokenSpec(sc.cfg)
 		if _, err = getValueWithLock(chooseLockerForAuth(sc.cfg), lockKey, func() (string, error) {
 			if err = oauthClient.refreshToken(); err != nil {
 				logger.Warnf("cannot refresh token. %v", err)

--- a/auth.go
+++ b/auth.go
@@ -1,6 +1,7 @@
 package gosnowflake
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
@@ -340,10 +341,10 @@ func authenticate(
 			credentialsStorage.deleteCredential(newMfaTokenSpec(sc.cfg.Host, sc.cfg.User))
 		}
 		if sessionParameters[clientStoreTemporaryCredential] == true && sc.cfg.Authenticator == AuthTypeExternalBrowser {
-			credentialsStorage.deleteCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+			credentialsStorage.deleteCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
 		}
 		if sessionParameters[clientStoreTemporaryCredential] == true && isOauthNativeFlow(sc.cfg.Authenticator) {
-			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(sc.cfg.OauthTokenRequestURL, sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
 		}
 		code, err := strconv.Atoi(respd.Code)
 		if err != nil {
@@ -363,7 +364,7 @@ func authenticate(
 	}
 	if sessionParameters[clientStoreTemporaryCredential] == true {
 		token := respd.Data.IDToken
-		credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User, sc.cfg.Role), token)
+		credentialsStorage.setCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User), token)
 	}
 	return &respd.Data, nil
 }
@@ -583,6 +584,12 @@ func (o *oauthLockKey) lockID() string {
 	return o.idp + "|" + o.snowflake + "|" + o.user + "|" + o.role + "|" + o.flowType
 }
 
+// oauthTokenRequestURL returns the full token endpoint URL for OAuth, using the
+// same fallback logic as oauthClient.tokenURL() so that eviction keys match write keys.
+func oauthTokenRequestURL(cfg *Config) string {
+	return cmp.Or(cfg.OauthTokenRequestURL, fmt.Sprintf("%v://%v:%v/oauth/token-request", cfg.Protocol, cfg.Host, cfg.Port))
+}
+
 func authenticateByAuthorizationCode(sc *snowflakeConn) (string, error) {
 	oauthClient, err := newOauthClient(sc.ctx, sc.cfg, sc)
 	if err != nil {
@@ -649,35 +656,29 @@ func prepareJWTToken(config *Config) (string, error) {
 }
 
 type tokenLockKey struct {
-	idp       string
 	snowflake string
 	user      string
-	role      string
 	tokenType string
 }
 
 func newMfaTokenLockKey(snowflakeHost, user string) *tokenLockKey {
 	return &tokenLockKey{
-		idp:       snowflakeHost,
 		snowflake: snowflakeHost,
 		user:      user,
-		role:      "",
 		tokenType: "MFA",
 	}
 }
 
-func newIDTokenLockKey(snowflakeHost, user, role string) *tokenLockKey {
+func newIDTokenLockKey(snowflakeHost, user string) *tokenLockKey {
 	return &tokenLockKey{
-		idp:       snowflakeHost,
 		snowflake: snowflakeHost,
 		user:      user,
-		role:      role,
 		tokenType: "ID",
 	}
 }
 
 func (m *tokenLockKey) lockID() string {
-	return m.idp + "|" + m.snowflake + "|" + m.user + "|" + m.role + "|" + m.tokenType
+	return m.snowflake + "|" + m.user + "|" + m.tokenType
 }
 
 func authenticateWithConfig(sc *snowflakeConn) error {
@@ -687,7 +688,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 	var err error
 
 	mfaTokenLockKey := newMfaTokenLockKey(sc.cfg.Host, sc.cfg.User)
-	idTokenLockKey := newIDTokenLockKey(sc.cfg.Host, sc.cfg.User, sc.cfg.Role)
+	idTokenLockKey := newIDTokenLockKey(sc.cfg.Host, sc.cfg.User)
 
 	if sc.cfg.Authenticator == AuthTypeExternalBrowser || sc.cfg.Authenticator == AuthTypeOAuthAuthorizationCode || sc.cfg.Authenticator == AuthTypeOAuthClientCredentials {
 		if (runtime.GOOS == "windows" || runtime.GOOS == "darwin") && sc.cfg.ClientStoreTemporaryCredential == sfconfig.BoolNotSet {
@@ -698,7 +699,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 				valueAwaiter := valueAwaitHolder.get(idTokenLockKey)
 				defer valueAwaiter.resumeOne()
 				sc.idToken, _ = awaitValue(valueAwaiter, func() (string, error) {
-					credential := credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+					credential := credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
 					return credential, nil
 				}, func(s string, err error) bool {
 					return s != ""
@@ -706,7 +707,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 					return ""
 				})
 			} else if sc.cfg.ClientStoreTemporaryCredential == ConfigBoolTrue {
-				sc.idToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+				sc.idToken = credentialsStorage.getCredential(newIDTokenSpec(sc.cfg.Host, sc.cfg.User))
 			}
 		}
 		// Disable console login by default
@@ -762,7 +763,7 @@ func authenticateWithConfig(sc *snowflakeConn) error {
 	if err != nil {
 		var se *SnowflakeError
 		if errors.As(err, &se) && slices.Contains(refreshOAuthTokenErrorCodes, strconv.Itoa(se.Number)) {
-			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(sc.cfg.OauthTokenRequestURL, sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(oauthTokenRequestURL(sc.cfg), sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
 
 			if sc.cfg.Authenticator == AuthTypeOAuthAuthorizationCode {
 				doRefreshTokenWithLock(sc)
@@ -799,7 +800,7 @@ func doRefreshTokenWithLock(sc *snowflakeConn) {
 		if _, err = getValueWithLock(chooseLockerForAuth(sc.cfg), lockKey, func() (string, error) {
 			if err = oauthClient.refreshToken(); err != nil {
 				logger.Warnf("cannot refresh token. %v", err)
-				credentialsStorage.deleteCredential(newOAuthRefreshTokenSpec(sc.cfg.OauthTokenRequestURL, sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
+				credentialsStorage.deleteCredential(newOAuthRefreshTokenSpec(oauthClient.tokenURL(), sc.cfg.Host, sc.cfg.User, sc.cfg.Role))
 				return "", err
 			}
 			return "", nil

--- a/auth.go
+++ b/auth.go
@@ -616,6 +616,14 @@ func prepareJWTToken(config *Config) (string, error) {
 	return tokenString, err
 }
 
+func (s *hostUserTokenSpec) lockID() string {
+	return s.snowflake + "|" + s.username + "|" + string(s.tokenType)
+}
+
+func (s *oauthTokenSpec) lockID() string {
+	return s.idp + "|" + s.snowflake + "|" + s.username + "|" + s.role + "|" + string(s.tokenType)
+}
+
 func authenticateWithConfig(sc *snowflakeConn) error {
 	var authData *authResponseMain
 	var samlResponse []byte

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -261,6 +261,13 @@ func (oauthClient *oauthClient) defaultAuthorizationURL() string {
 	return fmt.Sprintf("%v://%v:%v/oauth/authorize", oauthClient.cfg.Protocol, oauthClient.cfg.Host, oauthClient.cfg.Port)
 }
 
+// oauthTokenRequestURL returns the full token endpoint URL for OAuth.
+// oauthClient.tokenURL() delegates to this function so that all cache key
+// construction and eviction paths use one canonical URL formula.
+func oauthTokenRequestURL(cfg *Config) string {
+	return cmp.Or(cfg.OauthTokenRequestURL, fmt.Sprintf("%v://%v:%v/oauth/token-request", cfg.Protocol, cfg.Host, cfg.Port))
+}
+
 func (oauthClient *oauthClient) tokenURL() string {
 	return oauthTokenRequestURL(oauthClient.cfg)
 }

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -262,11 +262,7 @@ func (oauthClient *oauthClient) defaultAuthorizationURL() string {
 }
 
 func (oauthClient *oauthClient) tokenURL() string {
-	return cmp.Or(oauthClient.cfg.OauthTokenRequestURL, oauthClient.defaultTokenURL())
-}
-
-func (oauthClient *oauthClient) defaultTokenURL() string {
-	return fmt.Sprintf("%v://%v:%v/oauth/token-request", oauthClient.cfg.Protocol, oauthClient.cfg.Host, oauthClient.cfg.Port)
+	return oauthTokenRequestURL(oauthClient.cfg)
 }
 
 func (oauthClient *oauthClient) buildRedirectURI(port int) string {
@@ -389,7 +385,7 @@ func (oauthClient *oauthClient) refreshToken() error {
 		logger.Debug("credentials storage is disabled, cannot use refresh tokens")
 		return nil
 	}
-	refreshTokenSpec := newOAuthRefreshTokenSpec(oauthClient.tokenURL(), oauthClient.cfg.Host, oauthClient.cfg.User, oauthClient.cfg.Role)
+	refreshTokenSpec := newOAuthRefreshTokenSpec(oauthClient.cfg)
 	refreshToken := credentialsStorage.getCredential(refreshTokenSpec)
 	if refreshToken == "" {
 		logger.Debug("no refresh token in cache, full flow must be run")
@@ -439,12 +435,12 @@ type tokenExchangeResponseBody struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func (oauthClient *oauthClient) accessTokenSpec() *secureTokenSpec {
-	return newOAuthAccessTokenSpec(oauthClient.tokenURL(), oauthClient.cfg.Host, oauthClient.cfg.User, oauthClient.cfg.Role)
+func (oauthClient *oauthClient) accessTokenSpec() *oauthTokenSpec {
+	return newOAuthAccessTokenSpec(oauthClient.cfg)
 }
 
-func (oauthClient *oauthClient) refreshTokenSpec() *secureTokenSpec {
-	return newOAuthRefreshTokenSpec(oauthClient.tokenURL(), oauthClient.cfg.Host, oauthClient.cfg.User, oauthClient.cfg.Role)
+func (oauthClient *oauthClient) refreshTokenSpec() *oauthTokenSpec {
+	return newOAuthRefreshTokenSpec(oauthClient.cfg)
 }
 
 func (oauthClient *oauthClient) logIfHTTPInUse(u string) {

--- a/auth_oauth.go
+++ b/auth_oauth.go
@@ -389,7 +389,7 @@ func (oauthClient *oauthClient) refreshToken() error {
 		logger.Debug("credentials storage is disabled, cannot use refresh tokens")
 		return nil
 	}
-	refreshTokenSpec := newOAuthRefreshTokenSpec(oauthClient.cfg.OauthTokenRequestURL, oauthClient.cfg.Host, oauthClient.cfg.User, oauthClient.cfg.Role)
+	refreshTokenSpec := newOAuthRefreshTokenSpec(oauthClient.tokenURL(), oauthClient.cfg.Host, oauthClient.cfg.User, oauthClient.cfg.Role)
 	refreshToken := credentialsStorage.getCredential(refreshTokenSpec)
 	if refreshToken == "" {
 		logger.Debug("no refresh token in cache, full flow must be run")

--- a/auth_oauth_test.go
+++ b/auth_oauth_test.go
@@ -35,8 +35,8 @@ func TestUnitOAuthAuthorizationCode(t *testing.T) {
 	}
 	client, err := newOauthClient(context.WithValue(context.Background(), oauth2.HTTPClient, httpClient), cfg, &snowflakeConn{})
 	assertNilF(t, err)
-	accessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-	refreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+	accessTokenSpec := newOAuthAccessTokenSpec(cfg)
+	refreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 
 	t.Run("Success", func(t *testing.T) {
 		credentialsStorage.deleteCredential(accessTokenSpec)
@@ -184,7 +184,7 @@ func TestUnitOAuthClientCredentials(t *testing.T) {
 		}
 	}
 	cfg := cfgFactory()
-	cacheTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+	cacheTokenSpec := newOAuthAccessTokenSpec(cfg)
 	client, err := newOauthClient(context.WithValue(context.Background(), oauth2.HTTPClient, httpClient), cfg, &snowflakeConn{})
 	assertNilF(t, err)
 
@@ -287,8 +287,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.deleteCredential(oauthAccessTokenSpec)
 		credentialsStorage.deleteCredential(oauthRefreshTokenSpec)
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
@@ -321,8 +321,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 				cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 				cfg.Transporter = roundTripper
 				cfg.SingleAuthenticationPrompt = singleAuthenticationPrompt
-				oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-				oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+				oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+				oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 				credentialsStorage.deleteCredential(oauthAccessTokenSpec)
 				credentialsStorage.deleteCredential(oauthRefreshTokenSpec)
 				connector := NewConnector(SnowflakeDriver{}, *cfg)
@@ -349,8 +349,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
 		cfg.EnableSingleUseRefreshTokens = true
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.deleteCredential(oauthAccessTokenSpec)
 		credentialsStorage.deleteCredential(oauthRefreshTokenSpec)
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
@@ -369,8 +369,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.deleteCredential(oauthAccessTokenSpec)
 		credentialsStorage.deleteCredential(oauthRefreshTokenSpec)
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
@@ -398,8 +398,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.setCredential(oauthAccessTokenSpec, "expired-token")
 		credentialsStorage.deleteCredential(oauthRefreshTokenSpec)
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
@@ -416,8 +416,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.deleteCredential(oauthAccessTokenSpec)
 		credentialsStorage.setCredential(oauthRefreshTokenSpec, "refresh-token-123")
 		wiremock.registerMappings(t, newWiremockMapping("auth/oauth2/login_request_with_expired_access_token.json"),
@@ -440,8 +440,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.setCredential(oauthAccessTokenSpec, "expired-token")
 		credentialsStorage.setCredential(oauthRefreshTokenSpec, "refresh-token-123")
 		wiremock.registerMappings(t, newWiremockMapping("auth/oauth2/login_request_with_expired_access_token.json"),
@@ -464,8 +464,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.setCredential(oauthAccessTokenSpec, "expired-token")
 		credentialsStorage.setCredential(oauthRefreshTokenSpec, "refresh-token-123")
 		wiremock.registerMappings(t, newWiremockMapping("auth/oauth2/login_request_with_expired_access_token.json"),
@@ -488,8 +488,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.Authenticator = AuthTypeOAuthAuthorizationCode
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.setCredential(oauthAccessTokenSpec, "expired-token")
 		credentialsStorage.setCredential(oauthRefreshTokenSpec, "expired-refresh-token")
 		wiremock.registerMappings(t, newWiremockMapping("auth/oauth2/login_request_with_expired_access_token.json"),
@@ -513,8 +513,8 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 		cfg.OauthRedirectURI = "http://localhost:1234/snowflake/oauth-redirect"
 		cfg.Transporter = roundTripper
 		cfg.ClientStoreTemporaryCredential = ConfigBoolFalse
-		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+		oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+		oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 		credentialsStorage.setCredential(oauthAccessTokenSpec, "old-access-token")
 		credentialsStorage.setCredential(oauthRefreshTokenSpec, "old-refresh-token")
 		wiremock.registerMappings(t, newWiremockMapping("auth/oauth2/authorization_code/successful_flow_with_offline_access.json"),
@@ -551,8 +551,8 @@ func TestClientCredentialsFlow(t *testing.T) {
 	cfg.Authenticator = AuthTypeOAuthClientCredentials
 	cfg.Transporter = roundTripper
 
-	oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
-	oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role)
+	oauthAccessTokenSpec := newOAuthAccessTokenSpec(cfg)
+	oauthRefreshTokenSpec := newOAuthRefreshTokenSpec(cfg)
 
 	t.Run("successful flow", func(t *testing.T) {
 		credentialsStorage.deleteCredential(oauthAccessTokenSpec)

--- a/auth_test.go
+++ b/auth_test.go
@@ -819,11 +819,11 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User, cfg.Role))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		runSmokeQuery(t, db)
-		assertEqualE(t, credentialsStorage.getCredential(newIDTokenSpec(cfg.Host, cfg.User, cfg.Role)), "test-id-token")
+		assertEqualE(t, credentialsStorage.getCredential(newIDTokenSpec(cfg.Host, cfg.User)), "test-id-token")
 	})
 
 	t.Run("ID token cached", func(t *testing.T) {
@@ -834,7 +834,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.setCredential(newIDTokenSpec(cfg.Host, cfg.User, cfg.Role), "test-id-token")
+		credentialsStorage.setCredential(newIDTokenSpec(cfg.Host, cfg.User), "test-id-token")
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		runSmokeQuery(t, db)
@@ -853,7 +853,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User, cfg.Role))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		conn1, err := db.Conn(context.Background())
@@ -879,7 +879,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User, cfg.Role))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		errs := initPoolWithSizeAndReturnErrors(db, 20)
@@ -899,7 +899,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User, cfg.Role))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		errs := initPoolWithSizeAndReturnErrors(db, 20)
@@ -1260,7 +1260,7 @@ func TestWithOauthAuthorizationCodeFlowManual(t *testing.T) {
 			assertNilF(t, err)
 			defer conn2.Close()
 			runSmokeQueryWithConn(t, conn2)
-			credentialsStorage.setCredential(newOAuthAccessTokenSpec(cfg.OauthTokenRequestURL, cfg.Host, cfg.User, cfg.Role), "expired-token")
+			credentialsStorage.setCredential(newOAuthAccessTokenSpec(tokenRequestURL, cfg.Host, cfg.User, cfg.Role), "expired-token")
 			conn3, err := db.Conn(context.Background())
 			assertNilF(t, err)
 			defer conn3.Close()

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,7 +1,6 @@
 package gosnowflake
 
 import (
-	"cmp"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -726,7 +725,7 @@ func TestMfaParallelLogin(t *testing.T) {
 	skipOnMissingHome(t)
 	skipOnMac(t, "interactive keyring access not available on macOS runners")
 	cfg := wiremock.connectionConfig()
-	tokenSpec := newMfaTokenSpec(cfg.Host, cfg.User)
+	tokenSpec := newMfaTokenSpec(cfg)
 
 	for _, singleAuthenticationPrompt := range []ConfigBool{ConfigBoolTrue, ConfigBoolFalse} {
 		t.Run("starts without mfa token, singleAuthenticationPrompt="+singleAuthenticationPrompt.String(), func(t *testing.T) {
@@ -819,11 +818,11 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		runSmokeQuery(t, db)
-		assertEqualE(t, credentialsStorage.getCredential(newIDTokenSpec(cfg.Host, cfg.User)), "test-id-token")
+		assertEqualE(t, credentialsStorage.getCredential(newIDTokenSpec(cfg)), "test-id-token")
 	})
 
 	t.Run("ID token cached", func(t *testing.T) {
@@ -834,7 +833,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.setCredential(newIDTokenSpec(cfg.Host, cfg.User), "test-id-token")
+		credentialsStorage.setCredential(newIDTokenSpec(cfg), "test-id-token")
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		runSmokeQuery(t, db)
@@ -853,7 +852,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		conn1, err := db.Conn(context.Background())
@@ -879,7 +878,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		errs := initPoolWithSizeAndReturnErrors(db, 20)
@@ -899,7 +898,7 @@ func TestUnitAuthenticateWithExternalBrowserParallel(t *testing.T) {
 		cfg.Authenticator = AuthTypeExternalBrowser
 		cfg.ClientStoreTemporaryCredential = ConfigBoolTrue
 		connector := NewConnector(SnowflakeDriver{}, *cfg)
-		credentialsStorage.deleteCredential(newIDTokenSpec(cfg.Host, cfg.User))
+		credentialsStorage.deleteCredential(newIDTokenSpec(cfg))
 		db := sql.OpenDB(connector)
 		defer db.Close()
 		errs := initPoolWithSizeAndReturnErrors(db, 20)
@@ -1246,9 +1245,8 @@ func TestWithOauthAuthorizationCodeFlowManual(t *testing.T) {
 			})
 			assertNilF(t, err)
 			cfg.Authenticator = AuthTypeOAuthAuthorizationCode
-			tokenRequestURL := cmp.Or(cfg.OauthTokenRequestURL, fmt.Sprintf("https://%v.snowflakecomputing.com:443/oauth/token-request", cfg.Account))
-			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(tokenRequestURL, cfg.Host, cfg.User, cfg.Role))
-			credentialsStorage.deleteCredential(newOAuthRefreshTokenSpec(tokenRequestURL, cfg.Host, cfg.User, cfg.Role))
+			credentialsStorage.deleteCredential(newOAuthAccessTokenSpec(cfg))
+			credentialsStorage.deleteCredential(newOAuthRefreshTokenSpec(cfg))
 			connector := NewConnector(&SnowflakeDriver{}, *cfg)
 			db := sql.OpenDB(connector)
 			defer db.Close()
@@ -1260,7 +1258,7 @@ func TestWithOauthAuthorizationCodeFlowManual(t *testing.T) {
 			assertNilF(t, err)
 			defer conn2.Close()
 			runSmokeQueryWithConn(t, conn2)
-			credentialsStorage.setCredential(newOAuthAccessTokenSpec(tokenRequestURL, cfg.Host, cfg.User, cfg.Role), "expired-token")
+			credentialsStorage.setCredential(newOAuthAccessTokenSpec(cfg), "expired-token")
 			conn3, err := db.Conn(context.Background())
 			assertNilF(t, err)
 			defer conn3.Close()

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -81,7 +81,6 @@ func (s *hostUserTokenSpec) buildKey() (string, error) {
 	})
 }
 
-
 type oauthTokenSpec struct {
 	tokenType tokenType
 	idp       string
@@ -107,7 +106,6 @@ func (s *oauthTokenSpec) buildKey() (string, error) {
 		Username:  normalizeIdentifier(s.username),
 	})
 }
-
 
 // finalizeCacheKey produces the versioned, SHA-256-hashed cache key
 //

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -75,15 +75,14 @@ func (s *hostUserTokenSpec) buildKey() (string, error) {
 	if s.username == "" {
 		return "", errors.New("username is required for token cache key")
 	}
-	keyData := mfaIDKeyData{
+	return marshalAndFinalize(s.tokenType, mfaIDKeyData{
 		Snowflake: normalizeURL(s.snowflake),
 		Username:  normalizeIdentifier(s.username),
-	}
-	jsonBytes, err := json.Marshal(keyData)
-	if err != nil {
-		return "", fmt.Errorf("failed to serialize cache key: %w", err)
-	}
-	return finalizeCacheKey(s.tokenType, jsonBytes), nil
+	})
+}
+
+func (s *hostUserTokenSpec) lockID() string {
+	return s.snowflake + "|" + s.username + "|" + string(s.tokenType)
 }
 
 type oauthTokenSpec struct {
@@ -104,17 +103,16 @@ func (s *oauthTokenSpec) buildKey() (string, error) {
 	if s.idp == "" {
 		return "", errors.New("idp URL is required for OAuth token cache key")
 	}
-	keyData := oauthKeyData{
+	return marshalAndFinalize(s.tokenType, oauthKeyData{
 		Idp:       normalizeURL(s.idp),
 		Role:      normalizeIdentifier(s.role),
 		Snowflake: normalizeURL(s.snowflake),
 		Username:  normalizeIdentifier(s.username),
-	}
-	jsonBytes, err := json.Marshal(keyData)
-	if err != nil {
-		return "", fmt.Errorf("failed to serialize cache key: %w", err)
-	}
-	return finalizeCacheKey(s.tokenType, jsonBytes), nil
+	})
+}
+
+func (s *oauthTokenSpec) lockID() string {
+	return s.idp + "|" + s.snowflake + "|" + s.username + "|" + s.role + "|" + string(s.tokenType)
 }
 
 // finalizeCacheKey produces the versioned, SHA-256-hashed cache key
@@ -128,6 +126,14 @@ func finalizeCacheKey(tt tokenType, jsonBytes []byte) string {
 	sum := sha256.Sum256(jsonBytes)
 	hexHash := hex.EncodeToString(sum[:])
 	return "SnowflakeTokenCache.v2." + string(tt) + "." + hexHash
+}
+
+func marshalAndFinalize(tt tokenType, keyData any) (string, error) {
+	jsonBytes, err := json.Marshal(keyData)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize cache key: %w", err)
+	}
+	return finalizeCacheKey(tt, jsonBytes), nil
 }
 
 func newMfaTokenSpec(cfg *Config) *hostUserTokenSpec {

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -44,66 +44,132 @@ var defaultLinuxCacheDirConf = []cacheDirConf{
 	{envVar: "HOME", pathSegments: []string{".cache", "snowflake"}},
 }
 
-// cacheKeyInput contains the fields that define a unique token cache entry.
-// All fields are raw (un-normalized) values; normalization happens inside buildCacheKey.
-// For OAuth flows the key uses all four data fields (idp, role, snowflake, username).
-// For MFA/ID token flows only snowflake and username are included in keyData.
-type cacheKeyInput struct {
-	tokenType tokenType // canonical wire string (e.g. "MFA_TOKEN"); appears in key prefix, not in keyData
-	idp       string    // raw IdP/token-endpoint URL (OAuth only)
-	snowflake string    // raw Snowflake server URL
-	username  string    // raw username
-	role      string    // raw role (OAuth only)
+type secureTokenSpec interface {
+	buildKey() (string, error)
 }
 
-type secureTokenSpec struct {
-	input cacheKeyInput
+// Fields must remain in lexicographic order to match the cross-driver hash contract.
+type mfaIDKeyData struct {
+	Snowflake string `json:"snowflake"`
+	Username  string `json:"username"`
 }
 
-func (t *secureTokenSpec) buildKey() (string, error) {
-	return buildCacheKey(t.input)
+// Fields must remain in lexicographic order to match the cross-driver hash contract.
+type oauthKeyData struct {
+	Idp       string `json:"idp"`
+	Role      string `json:"role"`
+	Snowflake string `json:"snowflake"`
+	Username  string `json:"username"`
 }
 
-func newMfaTokenSpec(snowflakeURL, username string) *secureTokenSpec {
-	return &secureTokenSpec{cacheKeyInput{
+type hostUserTokenSpec struct {
+	tokenType tokenType
+	snowflake string
+	username  string
+}
+
+func (s *hostUserTokenSpec) buildKey() (string, error) {
+	if s.snowflake == "" {
+		return "", errors.New("snowflake URL is required for token cache key")
+	}
+	if s.username == "" {
+		return "", errors.New("username is required for token cache key")
+	}
+	keyData := mfaIDKeyData{
+		Snowflake: normalizeURL(s.snowflake),
+		Username:  normalizeIdentifier(s.username),
+	}
+	jsonBytes, err := json.Marshal(keyData)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize cache key: %w", err)
+	}
+	return finalizeCacheKey(s.tokenType, jsonBytes), nil
+}
+
+type oauthTokenSpec struct {
+	tokenType tokenType
+	idp       string
+	snowflake string
+	username  string
+	role      string
+}
+
+func (s *oauthTokenSpec) buildKey() (string, error) {
+	if s.snowflake == "" {
+		return "", errors.New("snowflake URL is required for token cache key")
+	}
+	if s.username == "" {
+		return "", errors.New("username is required for token cache key")
+	}
+	if s.idp == "" {
+		return "", errors.New("idp URL is required for OAuth token cache key")
+	}
+	keyData := oauthKeyData{
+		Idp:       normalizeURL(s.idp),
+		Role:      normalizeIdentifier(s.role),
+		Snowflake: normalizeURL(s.snowflake),
+		Username:  normalizeIdentifier(s.username),
+	}
+	jsonBytes, err := json.Marshal(keyData)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize cache key: %w", err)
+	}
+	return finalizeCacheKey(s.tokenType, jsonBytes), nil
+}
+
+// finalizeCacheKey produces the versioned, SHA-256-hashed cache key
+//
+//	SnowflakeTokenCache.v2.<TOKEN_TYPE>.<lowercase_sha256(canonical_json(keyData))>
+//
+// The token type lives in the readable key prefix and is never part of keyData.
+// The canonical JSON (compact, keys sorted lexicographically) is identical across
+// all Snowflake drivers, enabling cross-driver token reuse.
+func finalizeCacheKey(tt tokenType, jsonBytes []byte) string {
+	sum := sha256.Sum256(jsonBytes)
+	hexHash := hex.EncodeToString(sum[:])
+	return "SnowflakeTokenCache.v2." + string(tt) + "." + hexHash
+}
+
+func newMfaTokenSpec(cfg *Config) *hostUserTokenSpec {
+	return &hostUserTokenSpec{
 		tokenType: mfaToken,
-		snowflake: snowflakeURL,
-		username:  username,
-	}}
+		snowflake: cfg.Host,
+		username:  cfg.User,
+	}
 }
 
-func newIDTokenSpec(snowflakeURL, username string) *secureTokenSpec {
-	return &secureTokenSpec{cacheKeyInput{
+func newIDTokenSpec(cfg *Config) *hostUserTokenSpec {
+	return &hostUserTokenSpec{
 		tokenType: idToken,
-		snowflake: snowflakeURL,
-		username:  username,
-	}}
+		snowflake: cfg.Host,
+		username:  cfg.User,
+	}
 }
 
-func newOAuthAccessTokenSpec(idpURL, snowflakeURL, username, role string) *secureTokenSpec {
-	return &secureTokenSpec{cacheKeyInput{
+func newOAuthAccessTokenSpec(cfg *Config) *oauthTokenSpec {
+	return &oauthTokenSpec{
 		tokenType: oauthAccessToken,
-		idp:       idpURL,
-		snowflake: snowflakeURL,
-		username:  username,
-		role:      role,
-	}}
+		idp:       oauthTokenRequestURL(cfg),
+		snowflake: cfg.Host,
+		username:  cfg.User,
+		role:      cfg.Role,
+	}
 }
 
-func newOAuthRefreshTokenSpec(idpURL, snowflakeURL, username, role string) *secureTokenSpec {
-	return &secureTokenSpec{cacheKeyInput{
+func newOAuthRefreshTokenSpec(cfg *Config) *oauthTokenSpec {
+	return &oauthTokenSpec{
 		tokenType: oauthRefreshToken,
-		idp:       idpURL,
-		snowflake: snowflakeURL,
-		username:  username,
-		role:      role,
-	}}
+		idp:       oauthTokenRequestURL(cfg),
+		snowflake: cfg.Host,
+		username:  cfg.User,
+		role:      cfg.Role,
+	}
 }
 
 type secureStorageManager interface {
-	setCredential(tokenSpec *secureTokenSpec, value string)
-	getCredential(tokenSpec *secureTokenSpec) string
-	deleteCredential(tokenSpec *secureTokenSpec)
+	setCredential(tokenSpec secureTokenSpec, value string)
+	getCredential(tokenSpec secureTokenSpec) string
+	deleteCredential(tokenSpec secureTokenSpec)
 }
 
 var credentialsStorage = newSecureStorageManager()
@@ -244,7 +310,7 @@ func (ssm *fileBasedSecureStorageManager) withCacheFile(action func(*os.File)) {
 	action(cacheFile)
 }
 
-func (ssm *fileBasedSecureStorageManager) setCredential(tokenSpec *secureTokenSpec, value string) {
+func (ssm *fileBasedSecureStorageManager) setCredential(tokenSpec secureTokenSpec, value string) {
 	if value == "" {
 		logger.Debug("no token provided")
 		return
@@ -268,7 +334,7 @@ func (ssm *fileBasedSecureStorageManager) setCredential(tokenSpec *secureTokenSp
 		if err != nil {
 			logger.Warnf("Set credential failed. Unable to write cache. %v", err)
 		} else {
-			logger.Debugf("Set credential succeeded. Authentication type: %v, User: %v,  file location: %v", tokenSpec.input.tokenType, tokenSpec.input.username, ssm.credFilePath())
+			logger.Debugf("Set credential succeeded. Key: %v, file location: %v", credentialsKey, ssm.credFilePath())
 		}
 	})
 }
@@ -353,7 +419,7 @@ func (ssm *fileBasedSecureStorageManager) unlockFile() {
 	}
 }
 
-func (ssm *fileBasedSecureStorageManager) getCredential(tokenSpec *secureTokenSpec) string {
+func (ssm *fileBasedSecureStorageManager) getCredential(tokenSpec secureTokenSpec) string {
 	credentialsKey, err := tokenSpec.buildKey()
 	if err != nil {
 		logger.Warnf("cannot build token spec: %v", err)
@@ -440,7 +506,7 @@ func (ssm *fileBasedSecureStorageManager) readTemporaryCacheFile(cacheFile *os.F
 	return credentialsMap, nil
 }
 
-func (ssm *fileBasedSecureStorageManager) deleteCredential(tokenSpec *secureTokenSpec) {
+func (ssm *fileBasedSecureStorageManager) deleteCredential(tokenSpec secureTokenSpec) {
 	credentialsKey, err := tokenSpec.buildKey()
 	if err != nil {
 		logger.Warnf("cannot build token spec: %v", err)
@@ -459,7 +525,7 @@ func (ssm *fileBasedSecureStorageManager) deleteCredential(tokenSpec *secureToke
 		if err != nil {
 			logger.Warnf("Set credential failed. Unable to write cache. %v", err)
 		} else {
-			logger.Debugf("Deleted credential succeeded. Authentication type: %v, User: %v,  file location: %v", tokenSpec.input.tokenType, tokenSpec.input.username, ssm.credFilePath())
+			logger.Debugf("Deleted credential succeeded. Key: %v, file location: %v", credentialsKey, ssm.credFilePath())
 		}
 	})
 }
@@ -478,58 +544,6 @@ func (ssm *fileBasedSecureStorageManager) writeTemporaryCacheFile(cache map[stri
 		return fmt.Errorf("failed to write the credential cache file: %w", err)
 	}
 	return nil
-}
-
-// mfaOrIDTokenTypes are the flows whose keyData contains only snowflake +
-// username. All other (OAuth) flows additionally include idp + role.
-var mfaOrIDTokenTypes = map[tokenType]bool{
-	mfaToken: true,
-	idToken:  true,
-}
-
-// buildCacheKey produces the versioned, SHA-256-hashed cache key
-//
-//	SnowflakeTokenCache.v2.<TOKEN_TYPE>.<lowercase_sha256(canonical_json(keyData))>
-//
-// The token type lives in the readable key prefix and is never part of keyData.
-// keyData is flow-specific: OAuth flows serialize idp, role, snowflake and
-// username; MFA/ID token flows serialize only snowflake and username, because
-// those flows never embed an idp or a role. The canonical JSON (compact, keys
-// sorted lexicographically) is identical across all Snowflake drivers, enabling
-// cross-driver token reuse.
-func buildCacheKey(input cacheKeyInput) (string, error) {
-	if input.snowflake == "" {
-		return "", errors.New("snowflake URL is required for token cache key")
-	}
-	if input.username == "" {
-		return "", errors.New("username is required for token cache key")
-	}
-
-	var keyData map[string]string
-	if mfaOrIDTokenTypes[input.tokenType] {
-		keyData = map[string]string{
-			"snowflake": normalizeURL(input.snowflake),
-			"username":  normalizeIdentifier(input.username),
-		}
-	} else {
-		keyData = map[string]string{
-			"idp":       normalizeURL(input.idp),
-			"role":      normalizeIdentifier(input.role),
-			"snowflake": normalizeURL(input.snowflake),
-			"username":  normalizeIdentifier(input.username),
-		}
-	}
-
-	// json.Marshal on a map[string]string emits compact JSON with keys in
-	// lexicographic order, ensuring a stable serialization.
-	jsonBytes, err := json.Marshal(keyData)
-	if err != nil {
-		return "", fmt.Errorf("failed to serialize cache key: %w", err)
-	}
-
-	sum := sha256.Sum256(jsonBytes)
-	hexHash := hex.EncodeToString(sum[:])
-	return "SnowflakeTokenCache.v2." + string(input.tokenType) + "." + hexHash, nil
 }
 
 // normalizeURL strips the scheme and userinfo, drops query/fragment,
@@ -574,14 +588,14 @@ func newNoopSecureStorageManager() *noopSecureStorageManager {
 	return &noopSecureStorageManager{}
 }
 
-func (ssm *noopSecureStorageManager) setCredential(_ *secureTokenSpec, _ string) {
+func (ssm *noopSecureStorageManager) setCredential(_ secureTokenSpec, _ string) {
 }
 
-func (ssm *noopSecureStorageManager) getCredential(_ *secureTokenSpec) string {
+func (ssm *noopSecureStorageManager) getCredential(_ secureTokenSpec) string {
 	return ""
 }
 
-func (ssm *noopSecureStorageManager) deleteCredential(_ *secureTokenSpec) {
+func (ssm *noopSecureStorageManager) deleteCredential(_ secureTokenSpec) {
 }
 
 type threadSafeSecureStorageManager struct {
@@ -589,19 +603,19 @@ type threadSafeSecureStorageManager struct {
 	delegate secureStorageManager
 }
 
-func (ssm *threadSafeSecureStorageManager) setCredential(tokenSpec *secureTokenSpec, value string) {
+func (ssm *threadSafeSecureStorageManager) setCredential(tokenSpec secureTokenSpec, value string) {
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
 	ssm.delegate.setCredential(tokenSpec, value)
 }
 
-func (ssm *threadSafeSecureStorageManager) getCredential(tokenSpec *secureTokenSpec) string {
+func (ssm *threadSafeSecureStorageManager) getCredential(tokenSpec secureTokenSpec) string {
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
 	return ssm.delegate.getCredential(tokenSpec)
 }
 
-func (ssm *threadSafeSecureStorageManager) deleteCredential(tokenSpec *secureTokenSpec) {
+func (ssm *threadSafeSecureStorageManager) deleteCredential(tokenSpec secureTokenSpec) {
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
 	ssm.delegate.deleteCredential(tokenSpec)

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -480,13 +480,23 @@ func (ssm *fileBasedSecureStorageManager) writeTemporaryCacheFile(cache map[stri
 	return nil
 }
 
-// buildCacheKey produces a versioned, SHA-256-hashed cache key from the
-// normalized values of the five key fields.
+// mfaOrIDTokenTypes are the flows whose keyData contains only snowflake +
+// username. All other (OAuth) flows additionally include idp + role.
 var mfaOrIDTokenTypes = map[tokenType]bool{
 	mfaToken: true,
 	idToken:  true,
 }
 
+// buildCacheKey produces the versioned, SHA-256-hashed cache key
+//
+//	SnowflakeTokenCache.v2.<TOKEN_TYPE>.<lowercase_sha256(canonical_json(keyData))>
+//
+// The token type lives in the readable key prefix and is never part of keyData.
+// keyData is flow-specific: OAuth flows serialize idp, role, snowflake and
+// username; MFA/ID token flows serialize only snowflake and username, because
+// those flows never embed an idp or a role. The canonical JSON (compact, keys
+// sorted lexicographically) is identical across all Snowflake drivers, enabling
+// cross-driver token reuse.
 func buildCacheKey(input cacheKeyInput) (string, error) {
 	if input.snowflake == "" {
 		return "", errors.New("snowflake URL is required for token cache key")

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -44,14 +44,16 @@ var defaultLinuxCacheDirConf = []cacheDirConf{
 	{envVar: "HOME", pathSegments: []string{".cache", "snowflake"}},
 }
 
-// cacheKeyInput contains the five fields that define a unique token cache entry.
+// cacheKeyInput contains the fields that define a unique token cache entry.
 // All fields are raw (un-normalized) values; normalization happens inside buildCacheKey.
+// For OAuth flows the key uses all four data fields (idp, role, snowflake, username).
+// For MFA/ID token flows only snowflake and username are included in keyData.
 type cacheKeyInput struct {
-	tokenType tokenType // canonical wire string value (e.g. "MFA_TOKEN")
-	idp       string    // raw IdP/token-endpoint URL
+	tokenType tokenType // canonical wire string (e.g. "MFA_TOKEN"); appears in key prefix, not in keyData
+	idp       string    // raw IdP/token-endpoint URL (OAuth only)
 	snowflake string    // raw Snowflake server URL
 	username  string    // raw username
-	role      string    // raw role; empty for MFA
+	role      string    // raw role (OAuth only)
 }
 
 type secureTokenSpec struct {
@@ -65,20 +67,16 @@ func (t *secureTokenSpec) buildKey() (string, error) {
 func newMfaTokenSpec(snowflakeURL, username string) *secureTokenSpec {
 	return &secureTokenSpec{cacheKeyInput{
 		tokenType: mfaToken,
-		idp:       snowflakeURL,
 		snowflake: snowflakeURL,
 		username:  username,
-		role:      "",
 	}}
 }
 
-func newIDTokenSpec(snowflakeURL, username, role string) *secureTokenSpec {
+func newIDTokenSpec(snowflakeURL, username string) *secureTokenSpec {
 	return &secureTokenSpec{cacheKeyInput{
 		tokenType: idToken,
-		idp:       snowflakeURL,
 		snowflake: snowflakeURL,
 		username:  username,
-		role:      role,
 	}}
 }
 
@@ -484,6 +482,11 @@ func (ssm *fileBasedSecureStorageManager) writeTemporaryCacheFile(cache map[stri
 
 // buildCacheKey produces a versioned, SHA-256-hashed cache key from the
 // normalized values of the five key fields.
+var mfaOrIDTokenTypes = map[tokenType]bool{
+	mfaToken: true,
+	idToken:  true,
+}
+
 func buildCacheKey(input cacheKeyInput) (string, error) {
 	if input.snowflake == "" {
 		return "", errors.New("snowflake URL is required for token cache key")
@@ -492,12 +495,19 @@ func buildCacheKey(input cacheKeyInput) (string, error) {
 		return "", errors.New("username is required for token cache key")
 	}
 
-	keyData := map[string]string{
-		"idp":        normalizeURL(input.idp),
-		"role":       normalizeIdentifier(input.role),
-		"snowflake":  normalizeURL(input.snowflake),
-		"token_type": string(input.tokenType),
-		"username":   normalizeIdentifier(input.username),
+	var keyData map[string]string
+	if mfaOrIDTokenTypes[input.tokenType] {
+		keyData = map[string]string{
+			"snowflake": normalizeURL(input.snowflake),
+			"username":  normalizeIdentifier(input.username),
+		}
+	} else {
+		keyData = map[string]string{
+			"idp":       normalizeURL(input.idp),
+			"role":      normalizeIdentifier(input.role),
+			"snowflake": normalizeURL(input.snowflake),
+			"username":  normalizeIdentifier(input.username),
+		}
 	}
 
 	// json.Marshal on a map[string]string emits compact JSON with keys in
@@ -509,7 +519,7 @@ func buildCacheKey(input cacheKeyInput) (string, error) {
 
 	sum := sha256.Sum256(jsonBytes)
 	hexHash := hex.EncodeToString(sum[:])
-	return "SnowflakeTokenCache.v2." + hexHash, nil
+	return "SnowflakeTokenCache.v2." + string(input.tokenType) + "." + hexHash, nil
 }
 
 // normalizeURL strips the scheme and userinfo, drops query/fragment,

--- a/secure_storage_manager.go
+++ b/secure_storage_manager.go
@@ -81,9 +81,6 @@ func (s *hostUserTokenSpec) buildKey() (string, error) {
 	})
 }
 
-func (s *hostUserTokenSpec) lockID() string {
-	return s.snowflake + "|" + s.username + "|" + string(s.tokenType)
-}
 
 type oauthTokenSpec struct {
 	tokenType tokenType
@@ -111,9 +108,6 @@ func (s *oauthTokenSpec) buildKey() (string, error) {
 	})
 }
 
-func (s *oauthTokenSpec) lockID() string {
-	return s.idp + "|" + s.snowflake + "|" + s.username + "|" + s.role + "|" + string(s.tokenType)
-}
 
 // finalizeCacheKey produces the versioned, SHA-256-hashed cache key
 //

--- a/secure_storage_manager_notlinux.go
+++ b/secure_storage_manager_notlinux.go
@@ -27,7 +27,7 @@ func newKeyringBasedSecureStorageManager() *keyringSecureStorageManager {
 	return &keyringSecureStorageManager{}
 }
 
-func (ssm *keyringSecureStorageManager) setCredential(tokenSpec *secureTokenSpec, value string) {
+func (ssm *keyringSecureStorageManager) setCredential(tokenSpec secureTokenSpec, value string) {
 	if value == "" {
 		logger.Debug("no token provided")
 	} else {
@@ -64,7 +64,7 @@ func (ssm *keyringSecureStorageManager) setCredential(tokenSpec *secureTokenSpec
 	}
 }
 
-func (ssm *keyringSecureStorageManager) getCredential(tokenSpec *secureTokenSpec) string {
+func (ssm *keyringSecureStorageManager) getCredential(tokenSpec secureTokenSpec) string {
 	cred := ""
 	credentialsKey, err := tokenSpec.buildKey()
 	if err != nil {
@@ -100,7 +100,7 @@ func (ssm *keyringSecureStorageManager) getCredential(tokenSpec *secureTokenSpec
 	return cred
 }
 
-func (ssm *keyringSecureStorageManager) deleteCredential(tokenSpec *secureTokenSpec) {
+func (ssm *keyringSecureStorageManager) deleteCredential(tokenSpec secureTokenSpec) {
 	credentialsKey, err := tokenSpec.buildKey()
 	if err != nil {
 		logger.Warnf("cannot build token spec: %v", err)

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -1,6 +1,8 @@
 package gosnowflake
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -82,11 +84,11 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	t.Run("store tokens of different types, hosts and users", func(t *testing.T) {
 		mfaTokenSpec := newMfaTokenSpec("host.com", "johndoe")
 		mfaCred := "token12"
-		idTokenSpec := newIDTokenSpec("host.com", "johndoe", "ANALYST")
+		idTokenSpec := newIDTokenSpec("host.com", "johndoe")
 		idCred := "token34"
-		idTokenSpec2 := newIDTokenSpec("host.org", "johndoe", "ANALYST")
+		idTokenSpec2 := newIDTokenSpec("host.org", "johndoe")
 		idCred2 := "token56"
-		idTokenSpec3 := newIDTokenSpec("host.com", "someoneelse", "ANALYST")
+		idTokenSpec3 := newIDTokenSpec("host.com", "someoneelse")
 		idCred3 := "token78"
 		ssm.setCredential(mfaTokenSpec, mfaCred)
 		ssm.setCredential(idTokenSpec, idCred)
@@ -106,7 +108,7 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	t.Run("override single token", func(t *testing.T) {
 		mfaTokenSpec := newMfaTokenSpec("host.com", "johndoe")
 		mfaCred := "token123"
-		idTokenSpec := newIDTokenSpec("host.com", "johndoe", "ANALYST")
+		idTokenSpec := newIDTokenSpec("host.com", "johndoe")
 		idCred := "token456"
 		ssm.setCredential(mfaTokenSpec, mfaCred)
 		ssm.setCredential(idTokenSpec, idCred)
@@ -240,7 +242,7 @@ func TestSetAndGetCredential(t *testing.T) {
 	skipOnMissingHome(t)
 	for _, tokenSpec := range []*secureTokenSpec{
 		newMfaTokenSpec("testhost", "testuser"),
-		newIDTokenSpec("testhost", "testuser", "testrole"),
+		newIDTokenSpec("testhost", "testuser"),
 	} {
 		t.Run(string(tokenSpec.input.tokenType), func(t *testing.T) {
 			skipOnMac(t, "keyring asks for password")
@@ -258,7 +260,7 @@ func TestSetAndGetCredential(t *testing.T) {
 func TestSkipStoringCredentialIfUserIsEmpty(t *testing.T) {
 	tokenSpecs := []*secureTokenSpec{
 		newMfaTokenSpec("mfaHost.com", ""),
-		newIDTokenSpec("idHost.com", "", "ANALYST"),
+		newIDTokenSpec("idHost.com", ""),
 	}
 
 	for _, tokenSpec := range tokenSpecs {
@@ -272,7 +274,7 @@ func TestSkipStoringCredentialIfUserIsEmpty(t *testing.T) {
 func TestSkipStoringCredentialIfHostIsEmpty(t *testing.T) {
 	tokenSpecs := []*secureTokenSpec{
 		newMfaTokenSpec("", "mfaUser"),
-		newIDTokenSpec("", "idUser", "ANALYST"),
+		newIDTokenSpec("", "idUser"),
 	}
 
 	for _, tokenSpec := range tokenSpecs {
@@ -293,7 +295,7 @@ func TestStoreTemporaryCredential(t *testing.T) {
 		value     string
 	}{
 		{newMfaTokenSpec("testhost", "testuser"), "mfa token"},
-		{newIDTokenSpec("testhost", "testuser", "testrole"), "id token"},
+		{newIDTokenSpec("testhost", "testuser"), "id token"},
 		{newOAuthAccessTokenSpec("https://idp.example.com/token", "testhost", "testuser", "testrole"), "access token"},
 		{newOAuthRefreshTokenSpec("https://idp.example.com/token", "testhost", "testuser", "testrole"), "refresh token"},
 	}
@@ -311,41 +313,44 @@ func TestStoreTemporaryCredential(t *testing.T) {
 	}
 }
 
-func TestBuildCacheKeyGoldenHash(t *testing.T) {
-	// Golden vector uses already-normalized values; normalizeIdentifier
-	// preserves content inside double-quotes verbatim, so passing normalized
-	// values is idempotent.
-	key, err := buildCacheKey(cacheKeyInput{
-		tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
-		idp:       "LOGIN.MICROSOFTONLINE.COM:443/TENANT-ID/OAUTH2/V2.0",
-		snowflake: "MYORG-MYACCOUNT.PRIVATELINK.SNOWFLAKECOMPUTING.COM",
-		username:  `"FIRST LAST"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM`,
-		role:      `"ANALYST ROLE WITH SPACES":NORTH_AMERICA:PROD:READONLY`,
-	})
-	assertNilF(t, err)
-	assertEqualF(t, key, "SnowflakeTokenCache.v2.75ff2ad65a68afb402f125f62894697673c5ef3d863aba466d16b7a81053d1f4") // pragma: allowlist secret
-}
-
-func TestBuildCacheKeyGoldenHashFromRawValues(t *testing.T) {
-	// Same golden test but using raw (un-normalized) URL values.
-	// normalizeURL strips scheme and uppercases; normalizeIdentifier
-	// uppercases outside quotes and preserves inside.
+func TestBuildCacheKeyOAuthGoldenHash(t *testing.T) {
+	// Golden vector A: OAuth flow with DPOP_BUNDLED_ACCESS_TOKEN.
+	// Raw inputs go through normalizeURL and normalizeIdentifier;
+	// lowercase inside quotes is preserved verbatim.
+	// Expected canonical JSON (4 OAuth fields, no token_type):
+	//   {"idp":"LOGIN.MICROSOFTONLINE.COM:443/TENANT-ID/OAUTH2/V2.0",
+	//    "role":"\"Analyst Role With Spaces\":NORTH_AMERICA:PROD:READONLY",
+	//    "snowflake":"MYORG-MYACCOUNT.PRIVATELINK.SNOWFLAKECOMPUTING.COM",
+	//    "username":"\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM"}
 	key, err := buildCacheKey(cacheKeyInput{
 		tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
 		idp:       "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
 		snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
-		username:  `"FIRST LAST"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM`,
-		role:      `"ANALYST ROLE WITH SPACES":NORTH_AMERICA:PROD:READONLY`,
+		username:  `"First Last"@long-corporate-domain.example.com`,
+		role:      `"Analyst Role With Spaces":north_america:prod:readonly`,
 	})
 	assertNilF(t, err)
-	assertEqualF(t, key, "SnowflakeTokenCache.v2.75ff2ad65a68afb402f125f62894697673c5ef3d863aba466d16b7a81053d1f4") // pragma: allowlist secret
+	assertEqualF(t, key, "SnowflakeTokenCache.v2.DPOP_BUNDLED_ACCESS_TOKEN.be782aa7c9abf8698adc9e6de61b954ccec7d9202899b44c2eb4e1dfa4313d5f") // pragma: allowlist secret
+}
+
+func TestBuildCacheKeyMfaGoldenHash(t *testing.T) {
+	// Golden vector B: MFA flow — only snowflake + username in keyData.
+	// Expected canonical JSON (2 MFA fields, no idp/role/token_type):
+	//   {"snowflake":"MYORG-MYACCOUNT.PRIVATELINK.SNOWFLAKECOMPUTING.COM",
+	//    "username":"\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM"}
+	key, err := buildCacheKey(cacheKeyInput{
+		tokenType: mfaToken,
+		snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
+		username:  `"First Last"@long-corporate-domain.example.com`,
+	})
+	assertNilF(t, err)
+	assertEqualF(t, key, "SnowflakeTokenCache.v2.MFA_TOKEN.a508fa2858a6e22e9fdbc90b4149a3ff666d1acbb286c85ff179499ac92d75c8") // pragma: allowlist secret
 }
 
 func TestBuildCacheKeyValidation(t *testing.T) {
 	t.Run("empty snowflake rejects", func(t *testing.T) {
 		_, err := buildCacheKey(cacheKeyInput{
 			tokenType: mfaToken,
-			idp:       "host.com",
 			snowflake: "",
 			username:  "user",
 		})
@@ -356,7 +361,6 @@ func TestBuildCacheKeyValidation(t *testing.T) {
 	t.Run("empty username rejects", func(t *testing.T) {
 		_, err := buildCacheKey(cacheKeyInput{
 			tokenType: mfaToken,
-			idp:       "host.com",
 			snowflake: "host.com",
 			username:  "",
 		})
@@ -450,58 +454,72 @@ func TestDifferentRolesProduceDifferentKeys(t *testing.T) {
 func TestMfaWithEmptyRoleProducesStableKey(t *testing.T) {
 	key1, err := buildCacheKey(cacheKeyInput{
 		tokenType: mfaToken,
-		idp:       "https://account.snowflakecomputing.com",
 		snowflake: "https://account.snowflakecomputing.com",
 		username:  "user",
-		role:      "",
 	})
 	assertNilF(t, err)
 
 	key2, err := buildCacheKey(cacheKeyInput{
 		tokenType: mfaToken,
-		idp:       "https://account.snowflakecomputing.com",
 		snowflake: "https://account.snowflakecomputing.com",
 		username:  "user",
-		role:      "",
 	})
 	assertNilF(t, err)
 
 	assertEqualF(t, key1, key2)
-	assertStringContainsE(t, key1, "SnowflakeTokenCache.v2.")
+	assertStringContainsE(t, key1, "SnowflakeTokenCache.v2.MFA_TOKEN.")
 }
 
 func TestDifferentTokenTypesProduceDifferentKeys(t *testing.T) {
-	key1, err := buildCacheKey(cacheKeyInput{
-		tokenType: oauthAccessToken,
-		idp:       "https://account.snowflakecomputing.com",
-		snowflake: "https://account.snowflakecomputing.com",
-		username:  "user",
-		role:      "ANALYST",
-	})
-	assertNilF(t, err)
+	t.Run("OAuth access vs refresh", func(t *testing.T) {
+		key1, err := buildCacheKey(cacheKeyInput{
+			tokenType: oauthAccessToken,
+			idp:       "https://idp.example.com/token",
+			snowflake: "https://account.snowflakecomputing.com",
+			username:  "user",
+			role:      "ANALYST",
+		})
+		assertNilF(t, err)
 
-	key2, err := buildCacheKey(cacheKeyInput{
-		tokenType: oauthRefreshToken,
-		idp:       "https://account.snowflakecomputing.com",
-		snowflake: "https://account.snowflakecomputing.com",
-		username:  "user",
-		role:      "ANALYST",
+		key2, err := buildCacheKey(cacheKeyInput{
+			tokenType: oauthRefreshToken,
+			idp:       "https://idp.example.com/token",
+			snowflake: "https://account.snowflakecomputing.com",
+			username:  "user",
+			role:      "ANALYST",
+		})
+		assertNilF(t, err)
+		assertNotEqualF(t, key1, key2)
 	})
-	assertNilF(t, err)
 
-	assertNotEqualF(t, key1, key2)
+	t.Run("MFA vs OAuth for same user/host", func(t *testing.T) {
+		mfaKey, err := buildCacheKey(cacheKeyInput{
+			tokenType: mfaToken,
+			snowflake: "https://account.snowflakecomputing.com",
+			username:  "user",
+		})
+		assertNilF(t, err)
+
+		oauthKey, err := buildCacheKey(cacheKeyInput{
+			tokenType: oauthAccessToken,
+			idp:       "https://account.snowflakecomputing.com",
+			snowflake: "https://account.snowflakecomputing.com",
+			username:  "user",
+			role:      "",
+		})
+		assertNilF(t, err)
+		assertNotEqualF(t, mfaKey, oauthKey)
+	})
 }
 
 func TestCacheKeyUsesV2Prefix(t *testing.T) {
 	key, err := buildCacheKey(cacheKeyInput{
 		tokenType: mfaToken,
-		idp:       "host.com",
 		snowflake: "host.com",
 		username:  "user",
-		role:      "",
 	})
 	assertNilF(t, err)
-	assertStringContainsE(t, key, "SnowflakeTokenCache.v2.")
+	assertStringContainsE(t, key, "SnowflakeTokenCache.v2.MFA_TOKEN.")
 }
 
 func TestFileBackendStoresKeyVerbatim(t *testing.T) {
@@ -525,20 +543,41 @@ func TestFileBackendStoresKeyVerbatim(t *testing.T) {
 
 	expectedKey, err := tokenSpec.buildKey()
 	assertNilF(t, err)
-	assertStringContainsE(t, expectedKey, "SnowflakeTokenCache.v2.")
+	assertStringContainsE(t, expectedKey, "SnowflakeTokenCache.v2.MFA_TOKEN.")
 
 	tokens := m["tokens"].(map[string]any)
 	assertEqualE(t, tokens[expectedKey], "testvalue")
 }
 
-func TestCanonicalJSONFieldOrder(t *testing.T) {
+func TestMfaKeyHasNoIdpOrRole(t *testing.T) {
+	// MFA keyData must contain only snowflake + username — no idp or role.
+	// Verify by computing the hash of the expected 2-field JSON manually.
+	expected2FieldJSON := `{"snowflake":"HOST.COM","username":"USER"}`
+	sum := sha256.Sum256([]byte(expected2FieldJSON))
+	expectedHash := hex.EncodeToString(sum[:])
+
 	key, err := buildCacheKey(cacheKeyInput{
 		tokenType: mfaToken,
-		idp:       "host.com",
 		snowflake: "host.com",
 		username:  "user",
-		role:      "",
 	})
 	assertNilF(t, err)
-	assertNotEqualF(t, key, "")
+	assertEqualF(t, key, "SnowflakeTokenCache.v2.MFA_TOKEN."+expectedHash)
+}
+
+func TestOAuthKeyHasFourFields(t *testing.T) {
+	// OAuth keyData must contain idp, role, snowflake, username — 4 fields.
+	expected4FieldJSON := `{"idp":"IDP.COM","role":"ANALYST","snowflake":"HOST.COM","username":"USER"}`
+	sum := sha256.Sum256([]byte(expected4FieldJSON))
+	expectedHash := hex.EncodeToString(sum[:])
+
+	key, err := buildCacheKey(cacheKeyInput{
+		tokenType: oauthAccessToken,
+		idp:       "idp.com",
+		snowflake: "host.com",
+		username:  "user",
+		role:      "analyst",
+	})
+	assertNilF(t, err)
+	assertEqualF(t, key, "SnowflakeTokenCache.v2.OAUTH_ACCESS_TOKEN."+expectedHash)
 }

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -300,6 +300,12 @@ func TestStoreTemporaryCredential(t *testing.T) {
 		{newOAuthRefreshTokenSpec("https://idp.example.com/token", "testhost", "testuser", "testrole"), "refresh token"},
 	}
 
+	credCacheDir, err := os.MkdirTemp("", "")
+	assertNilF(t, err)
+	defer os.RemoveAll(credCacheDir)
+	credCacheDirEnvOverride := overrideEnv(credCacheDirEnv, credCacheDir)
+	defer credCacheDirEnvOverride.rollback()
+
 	ssm, err := newFileBasedSecureStorageManager()
 	assertNilF(t, err)
 

--- a/secure_storage_manager_test.go
+++ b/secure_storage_manager_test.go
@@ -73,7 +73,7 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	assertNilF(t, err)
 
 	t.Run("store single token", func(t *testing.T) {
-		tokenSpec := newMfaTokenSpec("host.com", "johndoe")
+		tokenSpec := newMfaTokenSpec(&Config{Host: "host.com", User: "johndoe"})
 		cred := "token123"
 		ssm.setCredential(tokenSpec, cred)
 		assertEqualE(t, ssm.getCredential(tokenSpec), cred)
@@ -82,13 +82,13 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	})
 
 	t.Run("store tokens of different types, hosts and users", func(t *testing.T) {
-		mfaTokenSpec := newMfaTokenSpec("host.com", "johndoe")
+		mfaTokenSpec := newMfaTokenSpec(&Config{Host: "host.com", User: "johndoe"})
 		mfaCred := "token12"
-		idTokenSpec := newIDTokenSpec("host.com", "johndoe")
+		idTokenSpec := newIDTokenSpec(&Config{Host: "host.com", User: "johndoe"})
 		idCred := "token34"
-		idTokenSpec2 := newIDTokenSpec("host.org", "johndoe")
+		idTokenSpec2 := newIDTokenSpec(&Config{Host: "host.org", User: "johndoe"})
 		idCred2 := "token56"
-		idTokenSpec3 := newIDTokenSpec("host.com", "someoneelse")
+		idTokenSpec3 := newIDTokenSpec(&Config{Host: "host.com", User: "someoneelse"})
 		idCred3 := "token78"
 		ssm.setCredential(mfaTokenSpec, mfaCred)
 		ssm.setCredential(idTokenSpec, idCred)
@@ -106,9 +106,9 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	})
 
 	t.Run("override single token", func(t *testing.T) {
-		mfaTokenSpec := newMfaTokenSpec("host.com", "johndoe")
+		mfaTokenSpec := newMfaTokenSpec(&Config{Host: "host.com", User: "johndoe"})
 		mfaCred := "token123"
-		idTokenSpec := newIDTokenSpec("host.com", "johndoe")
+		idTokenSpec := newIDTokenSpec(&Config{Host: "host.com", User: "johndoe"})
 		idCred := "token456"
 		ssm.setCredential(mfaTokenSpec, mfaCred)
 		ssm.setCredential(idTokenSpec, idCred)
@@ -120,7 +120,7 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	})
 
 	t.Run("unlock stale cache", func(t *testing.T) {
-		tokenSpec := newMfaTokenSpec("stale", "cache")
+		tokenSpec := newMfaTokenSpec(&Config{Host: "stale", User: "cache"})
 		assertNilF(t, os.Mkdir(ssm.lockPath(), 0700))
 		time.Sleep(1000 * time.Millisecond)
 		ssm.setCredential(tokenSpec, "unlocked")
@@ -128,7 +128,7 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	})
 
 	t.Run("wait for other process to unlock cache", func(t *testing.T) {
-		tokenSpec := newMfaTokenSpec("stale", "cache")
+		tokenSpec := newMfaTokenSpec(&Config{Host: "stale", User: "cache"})
 		startTime := time.Now()
 		assertNilF(t, os.Mkdir(ssm.lockPath(), 0700))
 		time.Sleep(500 * time.Millisecond)
@@ -148,14 +148,14 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 		}`)
 		err = os.WriteFile(ssm.credFilePath(), content, 0600)
 		assertNilF(t, err)
-		ssm.setCredential(newMfaTokenSpec("somehost.com", "someUser"), "someToken")
+		ssm.setCredential(newMfaTokenSpec(&Config{Host: "somehost.com", User: "someUser"}), "someToken")
 		result, err := os.ReadFile(ssm.credFilePath())
 		assertNilF(t, err)
 		assertStringContainsE(t, string(result), `"otherKey":"otherValue"`)
 	})
 
 	t.Run("should not modify file if it has wrong permission", func(t *testing.T) {
-		tokenSpec := newMfaTokenSpec("somehost.com", "someUser")
+		tokenSpec := newMfaTokenSpec(&Config{Host: "somehost.com", User: "someUser"})
 		ssm.setCredential(tokenSpec, "initialValue")
 		assertEqualE(t, ssm.getCredential(tokenSpec), "initialValue")
 		err = os.Chmod(ssm.credFilePath(), 0644)
@@ -177,7 +177,7 @@ func TestSnowflakeFileBasedSecureStorageManager(t *testing.T) {
 	})
 
 	t.Run("should not modify file if its dir has wrong permission", func(t *testing.T) {
-		tokenSpec := newMfaTokenSpec("somehost.com", "someUser")
+		tokenSpec := newMfaTokenSpec(&Config{Host: "somehost.com", User: "someUser"})
 		ssm.setCredential(tokenSpec, "initialValue")
 		assertEqualE(t, ssm.getCredential(tokenSpec), "initialValue")
 		err = os.Chmod(ssm.credDirPath, 0777)
@@ -213,7 +213,7 @@ func TestFileBasedCacheSkipPermissionsVerification(t *testing.T) {
 	ssm, err := newFileBasedSecureStorageManager()
 	assertNilF(t, err)
 
-	tokenSpec := newMfaTokenSpec("somehost.com", "someUser")
+	tokenSpec := newMfaTokenSpec(&Config{Host: "somehost.com", User: "someUser"})
 
 	t.Run("round-trip with 0644 cache file", func(t *testing.T) {
 		ssm.setCredential(tokenSpec, "initialValue")
@@ -240,47 +240,55 @@ func TestFileBasedCacheSkipPermissionsVerification(t *testing.T) {
 
 func TestSetAndGetCredential(t *testing.T) {
 	skipOnMissingHome(t)
-	for _, tokenSpec := range []*secureTokenSpec{
-		newMfaTokenSpec("testhost", "testuser"),
-		newIDTokenSpec("testhost", "testuser"),
+	for _, tc := range []struct {
+		name string
+		spec secureTokenSpec
+	}{
+		{string(mfaToken), newMfaTokenSpec(&Config{Host: "testhost", User: "testuser"})},
+		{string(idToken), newIDTokenSpec(&Config{Host: "testhost", User: "testuser"})},
 	} {
-		t.Run(string(tokenSpec.input.tokenType), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			skipOnMac(t, "keyring asks for password")
 			fakeMfaToken := "test token"
-			tokenSpec := newMfaTokenSpec("testHost", "testUser")
-			credentialsStorage.setCredential(tokenSpec, fakeMfaToken)
-			assertEqualE(t, credentialsStorage.getCredential(tokenSpec), fakeMfaToken)
+			credentialsStorage.setCredential(tc.spec, fakeMfaToken)
+			assertEqualE(t, credentialsStorage.getCredential(tc.spec), fakeMfaToken)
 
-			credentialsStorage.deleteCredential(tokenSpec)
-			assertEqualE(t, credentialsStorage.getCredential(tokenSpec), "")
+			credentialsStorage.deleteCredential(tc.spec)
+			assertEqualE(t, credentialsStorage.getCredential(tc.spec), "")
 		})
 	}
 }
 
 func TestSkipStoringCredentialIfUserIsEmpty(t *testing.T) {
-	tokenSpecs := []*secureTokenSpec{
-		newMfaTokenSpec("mfaHost.com", ""),
-		newIDTokenSpec("idHost.com", ""),
+	specs := []struct {
+		host string
+		spec secureTokenSpec
+	}{
+		{"mfaHost.com", newMfaTokenSpec(&Config{Host: "mfaHost.com", User: ""})},
+		{"idHost.com", newIDTokenSpec(&Config{Host: "idHost.com", User: ""})},
 	}
 
-	for _, tokenSpec := range tokenSpecs {
-		t.Run(tokenSpec.input.snowflake, func(t *testing.T) {
-			credentialsStorage.setCredential(tokenSpec, "non-empty-value")
-			assertEqualE(t, credentialsStorage.getCredential(tokenSpec), "")
+	for _, tc := range specs {
+		t.Run(tc.host, func(t *testing.T) {
+			credentialsStorage.setCredential(tc.spec, "non-empty-value")
+			assertEqualE(t, credentialsStorage.getCredential(tc.spec), "")
 		})
 	}
 }
 
 func TestSkipStoringCredentialIfHostIsEmpty(t *testing.T) {
-	tokenSpecs := []*secureTokenSpec{
-		newMfaTokenSpec("", "mfaUser"),
-		newIDTokenSpec("", "idUser"),
+	specs := []struct {
+		user string
+		spec secureTokenSpec
+	}{
+		{"mfaUser", newMfaTokenSpec(&Config{Host: "", User: "mfaUser"})},
+		{"idUser", newIDTokenSpec(&Config{Host: "", User: "idUser"})},
 	}
 
-	for _, tokenSpec := range tokenSpecs {
-		t.Run(tokenSpec.input.username, func(t *testing.T) {
-			credentialsStorage.setCredential(tokenSpec, "non-empty-value")
-			assertEqualE(t, credentialsStorage.getCredential(tokenSpec), "")
+	for _, tc := range specs {
+		t.Run(tc.user, func(t *testing.T) {
+			credentialsStorage.setCredential(tc.spec, "non-empty-value")
+			assertEqualE(t, credentialsStorage.getCredential(tc.spec), "")
 		})
 	}
 }
@@ -291,13 +299,13 @@ func TestStoreTemporaryCredential(t *testing.T) {
 	}
 
 	testcases := []struct {
-		tokenSpec *secureTokenSpec
+		tokenSpec secureTokenSpec
 		value     string
 	}{
-		{newMfaTokenSpec("testhost", "testuser"), "mfa token"},
-		{newIDTokenSpec("testhost", "testuser"), "id token"},
-		{newOAuthAccessTokenSpec("https://idp.example.com/token", "testhost", "testuser", "testrole"), "access token"},
-		{newOAuthRefreshTokenSpec("https://idp.example.com/token", "testhost", "testuser", "testrole"), "refresh token"},
+		{newMfaTokenSpec(&Config{Host: "testhost", User: "testuser"}), "mfa token"},
+		{newIDTokenSpec(&Config{Host: "testhost", User: "testuser"}), "id token"},
+		{newOAuthAccessTokenSpec(&Config{OauthTokenRequestURL: "https://idp.example.com/token", Host: "testhost", User: "testuser", Role: "testrole"}), "access token"},
+		{newOAuthRefreshTokenSpec(&Config{OauthTokenRequestURL: "https://idp.example.com/token", Host: "testhost", User: "testuser", Role: "testrole"}), "refresh token"},
 	}
 
 	credCacheDir, err := os.MkdirTemp("", "")
@@ -328,13 +336,14 @@ func TestBuildCacheKeyOAuthGoldenHash(t *testing.T) {
 	//    "role":"\"Analyst Role With Spaces\":NORTH_AMERICA:PROD:READONLY",
 	//    "snowflake":"MYORG-MYACCOUNT.PRIVATELINK.SNOWFLAKECOMPUTING.COM",
 	//    "username":"\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM"}
-	key, err := buildCacheKey(cacheKeyInput{
+	spec := &oauthTokenSpec{
 		tokenType: "DPOP_BUNDLED_ACCESS_TOKEN",
 		idp:       "https://login.microsoftonline.com:443/tenant-id/oauth2/v2.0",
 		snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
 		username:  `"First Last"@long-corporate-domain.example.com`,
 		role:      `"Analyst Role With Spaces":north_america:prod:readonly`,
-	})
+	}
+	key, err := spec.buildKey()
 	assertNilF(t, err)
 	assertEqualF(t, key, "SnowflakeTokenCache.v2.DPOP_BUNDLED_ACCESS_TOKEN.be782aa7c9abf8698adc9e6de61b954ccec7d9202899b44c2eb4e1dfa4313d5f") // pragma: allowlist secret
 }
@@ -344,34 +353,36 @@ func TestBuildCacheKeyMfaGoldenHash(t *testing.T) {
 	// Expected canonical JSON (2 MFA fields, no idp/role/token_type):
 	//   {"snowflake":"MYORG-MYACCOUNT.PRIVATELINK.SNOWFLAKECOMPUTING.COM",
 	//    "username":"\"First Last\"@LONG-CORPORATE-DOMAIN.EXAMPLE.COM"}
-	key, err := buildCacheKey(cacheKeyInput{
+	spec := &hostUserTokenSpec{
 		tokenType: mfaToken,
 		snowflake: "https://myorg-myaccount.privatelink.snowflakecomputing.com",
 		username:  `"First Last"@long-corporate-domain.example.com`,
-	})
+	}
+	key, err := spec.buildKey()
 	assertNilF(t, err)
 	assertEqualF(t, key, "SnowflakeTokenCache.v2.MFA_TOKEN.a508fa2858a6e22e9fdbc90b4149a3ff666d1acbb286c85ff179499ac92d75c8") // pragma: allowlist secret
 }
 
 func TestBuildCacheKeyValidation(t *testing.T) {
 	t.Run("empty snowflake rejects", func(t *testing.T) {
-		_, err := buildCacheKey(cacheKeyInput{
-			tokenType: mfaToken,
-			snowflake: "",
-			username:  "user",
-		})
+		spec := &hostUserTokenSpec{tokenType: mfaToken, snowflake: "", username: "user"}
+		_, err := spec.buildKey()
 		assertNotNilF(t, err)
 		assertStringContainsE(t, err.Error(), "snowflake URL is required")
 	})
 
 	t.Run("empty username rejects", func(t *testing.T) {
-		_, err := buildCacheKey(cacheKeyInput{
-			tokenType: mfaToken,
-			snowflake: "host.com",
-			username:  "",
-		})
+		spec := &hostUserTokenSpec{tokenType: mfaToken, snowflake: "host.com", username: ""}
+		_, err := spec.buildKey()
 		assertNotNilF(t, err)
 		assertStringContainsE(t, err.Error(), "username is required")
+	})
+
+	t.Run("OAuth empty idp rejects", func(t *testing.T) {
+		spec := &oauthTokenSpec{tokenType: oauthAccessToken, idp: "", snowflake: "host.com", username: "user"}
+		_, err := spec.buildKey()
+		assertNotNilF(t, err)
+		assertStringContainsE(t, err.Error(), "idp URL is required")
 	})
 }
 
@@ -414,62 +425,62 @@ func TestNormalizeIdentifier(t *testing.T) {
 }
 
 func TestDifferentSnowflakeHostsProduceDifferentKeys(t *testing.T) {
-	key1, err := buildCacheKey(cacheKeyInput{
+	key1, err := (&oauthTokenSpec{
 		tokenType: oauthAccessToken,
 		idp:       "https://idp.example.com/token",
 		snowflake: "https://account1.snowflakecomputing.com",
 		username:  "user",
 		role:      "ANALYST",
-	})
+	}).buildKey()
 	assertNilF(t, err)
 
-	key2, err := buildCacheKey(cacheKeyInput{
+	key2, err := (&oauthTokenSpec{
 		tokenType: oauthAccessToken,
 		idp:       "https://idp.example.com/token",
 		snowflake: "https://account2.snowflakecomputing.com",
 		username:  "user",
 		role:      "ANALYST",
-	})
+	}).buildKey()
 	assertNilF(t, err)
 
 	assertNotEqualF(t, key1, key2)
 }
 
 func TestDifferentRolesProduceDifferentKeys(t *testing.T) {
-	key1, err := buildCacheKey(cacheKeyInput{
+	key1, err := (&oauthTokenSpec{
 		tokenType: oauthAccessToken,
 		idp:       "https://idp.example.com/token",
 		snowflake: "https://account.snowflakecomputing.com",
 		username:  "user",
 		role:      "ANALYST",
-	})
+	}).buildKey()
 	assertNilF(t, err)
 
-	key2, err := buildCacheKey(cacheKeyInput{
+	key2, err := (&oauthTokenSpec{
 		tokenType: oauthAccessToken,
 		idp:       "https://idp.example.com/token",
 		snowflake: "https://account.snowflakecomputing.com",
 		username:  "user",
 		role:      "ADMIN",
-	})
+	}).buildKey()
 	assertNilF(t, err)
 
 	assertNotEqualF(t, key1, key2)
 }
 
 func TestMfaWithEmptyRoleProducesStableKey(t *testing.T) {
-	key1, err := buildCacheKey(cacheKeyInput{
+	key1, err := (&hostUserTokenSpec{
 		tokenType: mfaToken,
 		snowflake: "https://account.snowflakecomputing.com",
 		username:  "user",
-	})
+	}).buildKey()
 	assertNilF(t, err)
 
-	key2, err := buildCacheKey(cacheKeyInput{
+	key2, err := (&hostUserTokenSpec{
 		tokenType: mfaToken,
 		snowflake: "https://account.snowflakecomputing.com",
 		username:  "user",
-	})
+	}).buildKey()
 	assertNilF(t, err)
 
 	assertEqualF(t, key1, key2)
@@ -478,52 +489,49 @@ func TestMfaWithEmptyRoleProducesStableKey(t *testing.T) {
 
 func TestDifferentTokenTypesProduceDifferentKeys(t *testing.T) {
 	t.Run("OAuth access vs refresh", func(t *testing.T) {
-		key1, err := buildCacheKey(cacheKeyInput{
+		key1, err := (&oauthTokenSpec{
 			tokenType: oauthAccessToken,
 			idp:       "https://idp.example.com/token",
 			snowflake: "https://account.snowflakecomputing.com",
 			username:  "user",
 			role:      "ANALYST",
-		})
+		}).buildKey()
 		assertNilF(t, err)
 
-		key2, err := buildCacheKey(cacheKeyInput{
+		key2, err := (&oauthTokenSpec{
 			tokenType: oauthRefreshToken,
 			idp:       "https://idp.example.com/token",
 			snowflake: "https://account.snowflakecomputing.com",
 			username:  "user",
 			role:      "ANALYST",
-		})
+		}).buildKey()
 		assertNilF(t, err)
 		assertNotEqualF(t, key1, key2)
 	})
 
 	t.Run("MFA vs OAuth for same user/host", func(t *testing.T) {
-		mfaKey, err := buildCacheKey(cacheKeyInput{
+		mfaKey, err := (&hostUserTokenSpec{
 			tokenType: mfaToken,
 			snowflake: "https://account.snowflakecomputing.com",
 			username:  "user",
-		})
+		}).buildKey()
 		assertNilF(t, err)
 
-		oauthKey, err := buildCacheKey(cacheKeyInput{
+		oauthKey, err := (&oauthTokenSpec{
 			tokenType: oauthAccessToken,
 			idp:       "https://account.snowflakecomputing.com",
 			snowflake: "https://account.snowflakecomputing.com",
 			username:  "user",
 			role:      "",
-		})
+		}).buildKey()
 		assertNilF(t, err)
 		assertNotEqualF(t, mfaKey, oauthKey)
 	})
 }
 
 func TestCacheKeyUsesV2Prefix(t *testing.T) {
-	key, err := buildCacheKey(cacheKeyInput{
-		tokenType: mfaToken,
-		snowflake: "host.com",
-		username:  "user",
-	})
+	spec := &hostUserTokenSpec{tokenType: mfaToken, snowflake: "host.com", username: "user"}
+	key, err := spec.buildKey()
 	assertNilF(t, err)
 	assertStringContainsE(t, key, "SnowflakeTokenCache.v2.MFA_TOKEN.")
 }
@@ -538,7 +546,7 @@ func TestFileBackendStoresKeyVerbatim(t *testing.T) {
 	ssm, err := newFileBasedSecureStorageManager()
 	assertNilF(t, err)
 
-	tokenSpec := newMfaTokenSpec("host.com", "testuser")
+	tokenSpec := newMfaTokenSpec(&Config{Host: "host.com", User: "testuser"})
 	ssm.setCredential(tokenSpec, "testvalue")
 
 	fileContent, err := os.ReadFile(ssm.credFilePath())
@@ -562,11 +570,8 @@ func TestMfaKeyHasNoIdpOrRole(t *testing.T) {
 	sum := sha256.Sum256([]byte(expected2FieldJSON))
 	expectedHash := hex.EncodeToString(sum[:])
 
-	key, err := buildCacheKey(cacheKeyInput{
-		tokenType: mfaToken,
-		snowflake: "host.com",
-		username:  "user",
-	})
+	spec := &hostUserTokenSpec{tokenType: mfaToken, snowflake: "host.com", username: "user"}
+	key, err := spec.buildKey()
 	assertNilF(t, err)
 	assertEqualF(t, key, "SnowflakeTokenCache.v2.MFA_TOKEN."+expectedHash)
 }
@@ -577,13 +582,14 @@ func TestOAuthKeyHasFourFields(t *testing.T) {
 	sum := sha256.Sum256([]byte(expected4FieldJSON))
 	expectedHash := hex.EncodeToString(sum[:])
 
-	key, err := buildCacheKey(cacheKeyInput{
+	spec := &oauthTokenSpec{
 		tokenType: oauthAccessToken,
 		idp:       "idp.com",
 		snowflake: "host.com",
 		username:  "user",
 		role:      "analyst",
-	})
+	}
+	key, err := spec.buildKey()
 	assertNilF(t, err)
 	assertEqualF(t, key, "SnowflakeTokenCache.v2.OAUTH_ACCESS_TOKEN."+expectedHash)
 }


### PR DESCRIPTION
### Description

SNOW-3784429  This is changing previous https://github.com/snowflakedb/gosnowflake/pull/1817 to support token caching in two distinct cases differently: 
* OAuth token keys with added Role and IdP host to avoid token collisions in the cache
* SSO/MFA tokens without Role and IdP as such tokens are irrelevant of those values
* Separate golden hash tests provide interoperability of the tokens in the cache across different drivers

### Checklist
- [ ] Added proper logging (if possible)
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
