### PR TITLE
SNOW-2999636 Implement outbound identity federation support in WIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming release
 
 New features:
+- Added `WorkloadIdentityAwsUseOutboundToken` config option (DSN field `workloadIdentityAwsUseOutboundToken`) that produces the AWS WIF attestation as an STS `GetWebIdentityToken` JWT instead of the default signed `GetCallerIdentity` request envelope (snowflakedb/gosnowflake#1824).
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 - Increased CRL disk cache removal delay to 7 days (snowflakedb/gosnowflake#1820).
 

--- a/auth_wif.go
+++ b/auth_wif.go
@@ -123,6 +123,7 @@ type awsAttestationMetadataProvider interface {
 	awsCredentials() (aws.Credentials, error)
 	awsCredentialsViaRoleChaining() (aws.Credentials, error)
 	awsRegion() string
+	awsWebIdentityToken(creds aws.Credentials, region string) (string, error)
 }
 
 type defaultAwsAttestationMetadataProvider struct {
@@ -189,6 +190,26 @@ func (s *defaultAwsAttestationMetadataProvider) awsRegion() string {
 	return s.awsCfg.Region
 }
 
+func (s *defaultAwsAttestationMetadataProvider) awsWebIdentityToken(creds aws.Credentials, region string) (string, error) {
+	awsCfg := s.awsCfg
+	awsCfg.Credentials = credentials.StaticCredentialsProvider{Value: creds}
+	awsCfg.Region = region
+	stsClient := sts.NewFromConfig(awsCfg)
+
+	resp, err := stsClient.GetWebIdentityToken(s.ctx, &sts.GetWebIdentityTokenInput{
+		Audience:         []string{snowflakeAudience},
+		SigningAlgorithm: aws.String("ES384"),
+	})
+	if err != nil {
+		logger.Debugf("failed to obtain AWS web identity token from STS: %v", err)
+		return "", err
+	}
+	if resp.WebIdentityToken == nil {
+		return "", nil
+	}
+	return *resp.WebIdentityToken, nil
+}
+
 func (c *awsIdentityAttestationCreator) createAttestation() (*wifAttestation, error) {
 	logger.Debug("Creating AWS identity attestation...")
 
@@ -221,6 +242,15 @@ func (c *awsIdentityAttestationCreator) createAttestation() (*wifAttestation, er
 		return nil, fmt.Errorf("no AWS region was found")
 	}
 
+	if c.cfg.WorkloadIdentityAwsUseOutboundToken == ConfigBoolTrue {
+		return c.createOutboundIdentityAttestation(attestationService, creds, region)
+	}
+	return c.createCallerIdentityAttestation(creds, region)
+}
+
+// createCallerIdentityAttestation produces the attestation as a base64-encoded,
+// SigV4-signed STS GetCallerIdentity request envelope.
+func (c *awsIdentityAttestationCreator) createCallerIdentityAttestation(creds aws.Credentials, region string) (*wifAttestation, error) {
 	stsHostname := stsHostname(region)
 	req, err := c.createStsRequest(stsHostname)
 	if err != nil {
@@ -240,6 +270,23 @@ func (c *awsIdentityAttestationCreator) createAttestation() (*wifAttestation, er
 	return &wifAttestation{
 		ProviderType: string(awsWif),
 		Credential:   credential,
+		Metadata:     map[string]string{},
+	}, nil
+}
+
+// createOutboundIdentityAttestation produces the attestation as a signed JWT
+// obtained from the STS GetWebIdentityToken API.
+func (c *awsIdentityAttestationCreator) createOutboundIdentityAttestation(attestationService awsAttestationMetadataProvider, creds aws.Credentials, region string) (*wifAttestation, error) {
+	token, err := attestationService.awsWebIdentityToken(creds, region)
+	if err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, errors.New("failed to obtain AWS web identity token from STS")
+	}
+	return &wifAttestation{
+		ProviderType: string(awsWif),
+		Credential:   token,
 		Metadata:     map[string]string{},
 	}, nil
 }

--- a/auth_wif_test.go
+++ b/auth_wif_test.go
@@ -352,11 +352,13 @@ func TestAwsIdentityAttestationCreator(t *testing.T) {
 }
 
 type mockAwsAttestationMetadataProvider struct {
-	creds           aws.Credentials
-	region          string
-	chainingCreds   aws.Credentials
-	chainingError   error
-	useRoleChaining bool
+	creds            aws.Credentials
+	region           string
+	chainingCreds    aws.Credentials
+	chainingError    error
+	useRoleChaining  bool
+	webIdentityToken string
+	webIdentityError error
 }
 
 var mockCreds = aws.Credentials{
@@ -381,6 +383,104 @@ func (m *mockAwsAttestationMetadataProvider) awsCredentialsViaRoleChaining() (aw
 
 func (m *mockAwsAttestationMetadataProvider) awsRegion() string {
 	return m.region
+}
+
+func (m *mockAwsAttestationMetadataProvider) awsWebIdentityToken(_ aws.Credentials, _ string) (string, error) {
+	if m.webIdentityError != nil {
+		return "", m.webIdentityError
+	}
+	return m.webIdentityToken, nil
+}
+
+func TestAwsIdentityAttestationCreatorOutboundToken(t *testing.T) {
+	const jwt = "header.payload.signature"
+	tests := []struct {
+		name               string
+		config             Config
+		attestationSvc     awsAttestationMetadataProvider
+		expectedError      error
+		expectedCredential string
+	}{
+		{
+			name: "Successful outbound attestation",
+			config: Config{
+				WorkloadIdentityAwsUseOutboundToken: ConfigBoolTrue,
+			},
+			attestationSvc: &mockAwsAttestationMetadataProvider{
+				creds:            mockCreds,
+				region:           "us-west-2",
+				webIdentityToken: jwt,
+			},
+			expectedCredential: jwt,
+		},
+		{
+			name: "Successful outbound attestation with role chaining",
+			config: Config{
+				WorkloadIdentityAwsUseOutboundToken: ConfigBoolTrue,
+				WorkloadIdentityImpersonationPath:   []string{"arn:aws:iam::123456789012:role/test-role"},
+			},
+			attestationSvc: &mockAwsAttestationMetadataProvider{
+				creds: mockCreds,
+				chainingCreds: aws.Credentials{
+					AccessKeyID:     "chainedAccessKey",
+					SecretAccessKey: "chainedSecretKey",
+					SessionToken:    "chainedSessionToken",
+				},
+				region:           "us-east-1",
+				useRoleChaining:  true,
+				webIdentityToken: jwt,
+			},
+			expectedCredential: jwt,
+		},
+		{
+			name: "STS returns no token",
+			config: Config{
+				WorkloadIdentityAwsUseOutboundToken: ConfigBoolTrue,
+			},
+			attestationSvc: &mockAwsAttestationMetadataProvider{
+				creds:            mockCreds,
+				region:           "us-west-2",
+				webIdentityToken: "",
+			},
+			expectedError: fmt.Errorf("failed to obtain AWS web identity token from STS"),
+		},
+		{
+			name: "STS call fails",
+			config: Config{
+				WorkloadIdentityAwsUseOutboundToken: ConfigBoolTrue,
+			},
+			attestationSvc: &mockAwsAttestationMetadataProvider{
+				creds:            mockCreds,
+				region:           "us-west-2",
+				webIdentityError: fmt.Errorf("AccessDenied"),
+			},
+			expectedError: fmt.Errorf("AccessDenied"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			creator := &awsIdentityAttestationCreator{
+				attestationServiceFactory: func(ctx context.Context, cfg *Config) awsAttestationMetadataProvider {
+					return test.attestationSvc
+				},
+				ctx: context.Background(),
+				cfg: &test.config,
+			}
+			attestation, err := creator.createAttestation()
+			if test.expectedError != nil {
+				assertNilF(t, attestation)
+				assertNotNilE(t, err)
+				assertEqualE(t, test.expectedError.Error(), err.Error())
+			} else {
+				assertNilE(t, err)
+				assertNotNilE(t, attestation)
+				assertEqualE(t, "AWS", attestation.ProviderType)
+				// The outbound token is sent verbatim, not base64-encoded.
+				assertEqualE(t, test.expectedCredential, attestation.Credential)
+			}
+		})
+	}
 }
 
 func TestGcpIdentityAttestationCreator(t *testing.T) {
@@ -804,6 +904,26 @@ func TestWorkloadIdentityAuthOnCloudVM(t *testing.T) {
 				assertNotEqualF(t, os.Getenv("SNOWFLAKE_TEST_WIF_USERNAME_IMPERSONATION"), "", "SNOWFLAKE_TEST_WIF_USERNAME_IMPERSONATION is not set")
 			},
 			expectedUsername: os.Getenv("SNOWFLAKE_TEST_WIF_USERNAME_IMPERSONATION"),
+		},
+		{
+			// AWS WIF supports two attestation methods: GetCallerIdentity (default) and
+			// GetWebIdentityToken (enabled via WorkloadIdentityAwsUseOutboundToken). This case
+			// covers the GetWebIdentityToken method against the dedicated TEST_WIF_E2E_AWS_WITH_ISSUER
+			// Snowflake user (configured with an ISSUER). Since an EC2 instance can only have one IAM
+			// role, the test impersonates a dedicated role that maps to that user.
+			name: "provider=" + provider + ",outboundToken",
+			skip: func() (bool, string) {
+				if provider != "AWS" {
+					return true, "GetWebIdentityToken outbound token is supported only on AWS"
+				}
+				return false, ""
+			},
+			setupCfg: func(_ *testing.T, config *Config) {
+				config.WorkloadIdentityProvider = provider
+				config.WorkloadIdentityAwsUseOutboundToken = ConfigBoolTrue
+				config.WorkloadIdentityImpersonationPath = []string{"arn:aws:iam::376129840140:role/drivers-wif-automated-tests-with-issuer"}
+			},
+			expectedUsername: "TEST_WIF_E2E_AWS_WITH_ISSUER",
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,9 +100,10 @@ type Config struct {
 
 	DisableSamlURLCheck Bool // Indicates whether the SAML URL check should be disabled
 
-	WorkloadIdentityProvider          string   // The workload identity provider to use for WIF authentication
-	WorkloadIdentityEntraResource     string   // The resource to use for WIF authentication on Azure environment
-	WorkloadIdentityImpersonationPath []string // The components to use for WIF impersonation.
+	WorkloadIdentityProvider            string   // The workload identity provider to use for WIF authentication
+	WorkloadIdentityEntraResource       string   // The resource to use for WIF authentication on Azure environment
+	WorkloadIdentityImpersonationPath   []string // The components to use for WIF impersonation.
+	WorkloadIdentityAwsUseOutboundToken Bool     // For AWS WIF, obtain the attestation as an STS GetWebIdentityToken JWT instead of a signed GetCallerIdentity request envelope
 
 	CertRevocationCheckMode           CertRevocationCheckMode // revocation check mode for CRLs
 	CrlAllowCertificatesWithoutCrlURL Bool                    // Allow certificates (not short-lived) without CRL DP included to be treated as correct ones

--- a/internal/config/connection_configuration.go
+++ b/internal/config/connection_configuration.go
@@ -225,6 +225,8 @@ func HandleSingleParam(cfg *Config, key string, value any) error {
 		cfg.WorkloadIdentityEntraResource, err = parseString(value)
 	case "workloadidentityimpersonatinpath":
 		cfg.WorkloadIdentityImpersonationPath, err = parseStrings(value)
+	case "workloadidentityawsuseoutboundtoken":
+		cfg.WorkloadIdentityAwsUseOutboundToken, err = parseConfigBool(value)
 	case "tokenfilepath":
 		cfg.TokenFilePath, err = parseString(value)
 		if err = checkParsingError(err, key, value); err != nil {

--- a/internal/config/dsn.go
+++ b/internal/config/dsn.go
@@ -140,6 +140,9 @@ func DSN(cfg *Config) (dsn string, err error) {
 	if len(cfg.WorkloadIdentityImpersonationPath) > 0 {
 		params.Add("workloadIdentityImpersonationPath", strings.Join(cfg.WorkloadIdentityImpersonationPath, ","))
 	}
+	if cfg.WorkloadIdentityAwsUseOutboundToken != BoolNotSet {
+		params.Add("workloadIdentityAwsUseOutboundToken", strconv.FormatBool(cfg.WorkloadIdentityAwsUseOutboundToken != BoolFalse))
+	}
 	if cfg.Authenticator != AuthTypeSnowflake {
 		if cfg.Authenticator == AuthTypeOkta {
 			params.Add("authenticator", strings.ToLower(cfg.OktaURL.String()))
@@ -978,6 +981,17 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			cfg.WorkloadIdentityEntraResource = value
 		case "workloadIdentityImpersonationPath":
 			cfg.WorkloadIdentityImpersonationPath = strings.Split(value, ",")
+		case "workloadIdentityAwsUseOutboundToken":
+			var vv bool
+			vv, err = strconv.ParseBool(value)
+			if err != nil {
+				return
+			}
+			if vv {
+				cfg.WorkloadIdentityAwsUseOutboundToken = BoolTrue
+			} else {
+				cfg.WorkloadIdentityAwsUseOutboundToken = BoolFalse
+			}
 		case "privateKey":
 			var decodeErr error
 			block, decodeErr := base64.URLEncoding.DecodeString(value)

--- a/internal/config/dsn_test.go
+++ b/internal/config/dsn_test.go
@@ -1683,6 +1683,19 @@ func TestDSN(t *testing.T) {
 		},
 		{
 			cfg: &Config{
+				Account:                             "ac",
+				User:                                "u",
+				Password:                            "p",
+				Database:                            "db",
+				Authenticator:                       AuthTypeWorkloadIdentityFederation,
+				Host:                                "ac.snowflakecomputing.com",
+				WorkloadIdentityProvider:            "aws",
+				WorkloadIdentityAwsUseOutboundToken: BoolTrue,
+			},
+			dsn: "u:p@ac.snowflakecomputing.com:443?account=ac&authenticator=workload_identity&database=db&ocspFailOpen=true&validateDefaultParameters=true&workloadIdentityAwsUseOutboundToken=true&workloadIdentityProvider=aws",
+		},
+		{
+			cfg: &Config{
 				User:                           "u",
 				Password:                       "p",
 				Account:                        "a",


### PR DESCRIPTION
### Description
Adds a new WorkloadIdentityAwsUseOutboundToken config option (DSN field workloadIdentityAwsUseOutboundToken) for AWS Workload Identity Federation authentication. When enabled, the AWS WIF attestation is produced as a signed JWT obtained from the STS GetWebIdentityToken API instead of the default SigV4-signed GetCallerIdentity request envelope. This allows connecting as a Snowflake user configured with an ISSUER, which requires the outbound token format.

The new option is wired through DSN parsing/serialization, the HandleSingleParam config handler, and the awsIdentityAttestationCreator, which now dispatches to either createCallerIdentityAttestation (default) or createOutboundIdentityAttestation based on the flag. The awsAttestationMetadataProvider interface is extended with an awsWebIdentityToken method, implemented by both the real provider (via sts.GetWebIdentityToken) and the mock used in tests.