### PR TITLE
test: verify mythos-zero security_review_public pipeline trigger (please close)

### DIFF
--- a/.mythos-zero-pipeline-test.md
+++ b/.mythos-zero-pipeline-test.md
@@ -1,0 +1,3 @@
+Test PR to verify the mythos-zero security_review_public pipeline fires on snowflakedb/*.
+
+Safe to close without merging.


### PR DESCRIPTION
Dummy PR to verify the newly-registered `security_review_public` pipeline in mythos-zero fires on `snowflakedb/*` PRs opened by Snowflake employees. Adds a single marker file at repo root — safe to close without merging.

What we're checking:
- A row in `MYTHOS_ZERO.DEV.TRIGGER_EVENTS` for `PIPELINE_NAME = 'security_review_public'` referencing this PR.
- A run appearing in `PIPELINE_RUN_EVENTS` for the same run_id.

/cc @sfc-gh-ppandit