### PR TITLE
SNOW-3831259 Download OCSP cache only if any cert has OCSP responder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 - Added support for Go 1.27, dropped support for Go 1.24 (snowflakedb/gosnowflake#TBD).
 
 Bug fixes:
+- OCSP revocation now accepts a connection when any one verified certificate chain is fully unrevoked (rejecting only when every chain fails), skips the OCSP cache server download when no certificate has a responder URL to check, and in fail-closed mode fails a chain fast when a certificate has no OCSP responder URL instead of querying responders for the others (snowflakedb/gosnowflake#1828).
 - Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the token type in the key prefix, applied uniformly across keyring (macOS/Windows) and file (Linux) backends; also replaced the bag-of-fields spec struct with typed token-spec types (`hostUserTokenSpec` for MFA/ID flows, `oauthTokenSpec` for OAuth flows) so each spec validates and serializes only its own fields (snowflakedb/gosnowflake#1817, snowflakedb/gosnowflake#1821).
 - Fixed nil pointer dereference panic when a corrupt or malformed OCSP cache key is encountered, either from the remote OCSP cache server or the local cache file (snowflakedb/gosnowflake#1819).
 - Fixed `WithFileGetStream` returning corrupt or wrong-file bytes when a `GET` prefix-matched more than one file; a get-stream can return only one file, so a multi-file match now returns the new `ErrGetStreamMultipleFiles` (pointing to the GET `PATTERN` argument) instead of a nondeterministic mix (snowflakedb/gosnowflake#1809).

--- a/crl_test.go
+++ b/crl_test.go
@@ -1,11 +1,9 @@
 package gosnowflake
 
 import (
-	"cmp"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"database/sql"
@@ -22,15 +20,10 @@ import (
 	"time"
 )
 
-var serialNumber = int64(0) // to be incremented
-
 type allowCertificatesWithoutCrlURLType bool
 type inMemoryCacheDisabledType bool
 type onDiskCacheDisabledType bool
 type downloadMaxSizeType int
-
-type notAfterType time.Time
-type crlEndpointType string
 
 type revokedCert *x509.Certificate
 
@@ -942,78 +935,6 @@ func (m *malformedCrlRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	}
 	response.Body = http.NoBody
 	return &response, nil
-}
-
-func createCa(t *testing.T, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, cn string, port int, crlEndpoints ...crlEndpointType) (*rsa.PrivateKey, *x509.Certificate) {
-	caTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization:       []string{"Snowflake"},
-			OrganizationalUnit: []string{"Drivers"},
-			Locality:           []string{"Warsaw"},
-			CommonName:         cn,
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		BasicConstraintsValid: true,
-		SignatureAlgorithm:    x509.SHA256WithRSA,
-	}
-	return createCert(t, caTemplate, issuerCert, issuerPrivateKey, port, crlEndpoints)
-}
-
-func createLeafCert(t *testing.T, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, port int, params ...any) (*rsa.PrivateKey, *x509.Certificate) {
-	notAfter := time.Now().AddDate(1, 0, 0)
-	var crlEndpoints []crlEndpointType
-	for _, param := range params {
-		switch v := param.(type) {
-		case notAfterType:
-			notAfter = time.Time(v)
-		case crlEndpointType:
-			crlEndpoints = append(crlEndpoints, v)
-		}
-	}
-	serialNumber++
-	certTemplate := &x509.Certificate{
-		SerialNumber: big.NewInt(serialNumber),
-		Subject: pkix.Name{
-			Organization:       []string{"Snowflake"},
-			OrganizationalUnit: []string{"Drivers"},
-			Locality:           []string{"Warsaw"},
-			CommonName:         "localhost",
-		},
-		NotBefore:          time.Now(),
-		NotAfter:           notAfter,
-		IsCA:               false,
-		SignatureAlgorithm: x509.SHA256WithRSA,
-	}
-	return createCert(t, certTemplate, issuerCert, issuerPrivateKey, port, crlEndpoints)
-}
-
-func createCert(t *testing.T, template, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, port int, crlEndpoints []crlEndpointType) (*rsa.PrivateKey, *x509.Certificate) {
-	var distributionPoints []string
-	for _, crlEndpoint := range crlEndpoints {
-		distributionPoints = append(distributionPoints, fmt.Sprintf("http://localhost:%v%v", port, crlEndpoint))
-		template.CRLDistributionPoints = distributionPoints
-	}
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assertNilF(t, err)
-	template.SubjectKeyId = calculateKeyID(t, &privateKey.PublicKey)
-	signerPrivateKey := cmp.Or(issuerPrivateKey, privateKey)
-	issuerCertOrSelfSigned := cmp.Or(issuerCert, template)
-	certBytes, err := x509.CreateCertificate(rand.Reader, template, issuerCertOrSelfSigned, &privateKey.PublicKey, signerPrivateKey)
-	assertNilF(t, err)
-	cert, err := x509.ParseCertificate(certBytes)
-	assertNilF(t, err)
-	return privateKey, cert
-}
-
-func calculateKeyID(t *testing.T, pubKey any) []byte {
-	pubBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-	assertNilF(t, err)
-	hash := sha256.Sum256(pubBytes)
-	return hash[:]
 }
 
 func createCrl(t *testing.T, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, args ...any) *x509.RevocationList {

--- a/ocsp.go
+++ b/ocsp.go
@@ -12,8 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	sfconfig "github.com/snowflakedb/gosnowflake/v2/internal/config"
-	sferrors "github.com/snowflakedb/gosnowflake/v2/internal/errors"
 	"io"
 	"math/big"
 	"net/http"
@@ -25,6 +23,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	sfconfig "github.com/snowflakedb/gosnowflake/v2/internal/config"
+	sferrors "github.com/snowflakedb/gosnowflake/v2/internal/errors"
 
 	"golang.org/x/crypto/ocsp"
 )
@@ -128,6 +129,22 @@ const (
 	ocspMissedCache            ocspStatusCode = -14
 	ocspCacheExpired           ocspStatusCode = -15
 	ocspFailedDecodeResponse   ocspStatusCode = -16
+)
+
+// ocspChainResult is the aggregated revocation verdict for a single verified
+// certificate chain. A connection is accepted as soon
+// as one chain is fully unrevoked, and rejected only when every chain fails.
+type ocspChainResult int
+
+const (
+	// ocspChainUnrevoked means every non-root certificate in the chain was
+	// confirmed good.
+	ocspChainUnrevoked ocspChainResult = iota
+	// ocspChainRevoked means the chain contains a certificate confirmed revoked.
+	ocspChainRevoked
+	// ocspChainError means the chain could not be fully verified (a certificate
+	// had no OCSP responder, an unknown status, or the check failed).
+	ocspChainError
 )
 
 // copied from crypto/ocsp.go
@@ -621,15 +638,8 @@ func (ov *ocspValidator) getRevocationStatus(ctx context.Context, subject, issue
 	logger.WithContext(ctx).Infof("cache missed")
 	logger.WithContext(ctx).Infof("OCSP Server: %v", subject.OCSPServer)
 	testResponderURL := os.Getenv(ocspTestResponderURLEnv)
-	if (len(subject.OCSPServer) == 0 || isTestNoOCSPURL()) && testResponderURL == "" {
-		return &ocspStatus{
-			code: ocspNoServer,
-			err: &SnowflakeError{
-				Number:      ErrOCSPNoOCSPResponderURL,
-				Message:     sferrors.ErrMsgOCSPNoOCSPResponderURL,
-				MessageArgs: []any{subject.Subject},
-			},
-		}
+	if !hasOCSPResponder(subject) {
+		return noOCSPResponderStatus(subject)
 	}
 	ocspHost := testResponderURL
 	if ocspHost == "" && len(subject.OCSPServer) > 0 {
@@ -690,72 +700,164 @@ func isTestNoOCSPURL() bool {
 	return strings.EqualFold(os.Getenv(ocspTestNoOCSPURLEnv), "true")
 }
 
+// hasOCSPResponder reports whether the certificate can be checked via OCSP, i.e.
+// it advertises at least one OCSP responder URL (or the test responder override
+// is set). A certificate without a responder URL can never be verified online
+// and is never present in the OCSP cache server.
+func hasOCSPResponder(subject *x509.Certificate) bool {
+	if os.Getenv(ocspTestResponderURLEnv) != "" {
+		return true
+	}
+	if isTestNoOCSPURL() {
+		return false
+	}
+	return len(subject.OCSPServer) > 0
+}
+
+func noOCSPResponderStatus(subject *x509.Certificate) *ocspStatus {
+	return &ocspStatus{
+		code: ocspNoServer,
+		err: &SnowflakeError{
+			Number:      ErrOCSPNoOCSPResponderURL,
+			Message:     sferrors.ErrMsgOCSPNoOCSPResponderURL,
+			MessageArgs: []any{subject.Subject},
+		},
+	}
+}
+
 func isValidOCSPStatus(status ocspStatusCode) bool {
 	return status == ocspStatusGood || status == ocspStatusRevoked || status == ocspStatusUnknown
 }
 
-// verifyPeerCertificate verifies all of certificate revocation status
+// verifyPeerCertificate verifies the certificate revocation status of the peer.
+//
+// The TLS stack may present several verified chains; they are alternative valid
+// trust paths that share the leaf but may differ in their intermediates. A single
+// fully-unrevoked chain is enough to accept the connection, so we only reject when
+// no chain passes. This matches the CRL validator (see verifyPeerCertificates).
 func (ov *ocspValidator) verifyPeerCertificate(ctx context.Context, verifiedChains [][]*x509.Certificate) (err error) {
-	for _, chain := range verifiedChains {
+	// Persist any cache changes on every return path (including panics).
+	defer ov.flushOCSPCache()
+
+	if len(verifiedChains) == 0 {
+		return nil
+	}
+
+	// Only reach out to the OCSP cache server if at least one certificate that can
+	// be checked online is not already validated by the local cache.
+	if ov.shouldDownloadCacheServer(verifiedChains) {
+		ov.downloadOCSPCacheServer()
+	}
+
+	var revoked, firstError *ocspStatus
+	allRevoked := true
+	for i, chain := range verifiedChains {
 		results := ov.getAllRevocationStatus(ctx, chain)
-		if r := ov.canEarlyExitForOCSP(results, chain); r != nil {
-			return r.err
+		verdict, status := ov.evaluateChain(results, chain)
+		switch verdict {
+		case ocspChainUnrevoked:
+			logger.WithContext(ctx).Debugf("verified chain %d has no revoked certificates", i)
+			return nil
+		case ocspChainRevoked:
+			if revoked == nil {
+				revoked = status
+			}
+		default: // ocspChainError
+			allRevoked = false
+			if firstError == nil {
+				firstError = status
+			}
 		}
 	}
 
+	// A certificate that is revoked in every verified chain is a hard failure in
+	// both fail-open and fail-closed modes.
+	if allRevoked && revoked != nil {
+		return revoked.err
+	}
+	// No chain could be fully verified. In fail-closed mode this rejects the
+	// connection; in fail-open mode we assume the certificates are not revoked.
+	if ov.mode == OCSPFailOpenFalse {
+		if revoked != nil {
+			return revoked.err
+		}
+		if firstError != nil && firstError.err != nil {
+			return firstError.err
+		}
+		return errors.New("OCSP revocation check could not verify any certificate chain")
+	}
+	logger.WithContext(ctx).Debug("no verified chain could be fully checked with OCSP. Assuming certificates are not revoked (fail-open).")
+	return nil
+}
+
+// evaluateChain aggregates the per-certificate revocation results of a single
+// chain into one verdict. A chain is unrevoked only when every non-root
+// certificate is confirmed good; a single revoked certificate makes the whole
+// chain revoked (revoked dominates errors); anything else is an error.
+func (ov *ocspValidator) evaluateChain(results []*ocspStatus, verifiedChain []*x509.Certificate) (ocspChainResult, *ocspStatus) {
+	var revoked, firstError *ocspStatus
+	allGood := len(results) == len(verifiedChain)-1 // root certificate is not checked
+	for _, r := range results {
+		switch {
+		case r == nil:
+			allGood = false
+		case r.code == ocspStatusGood:
+			// certificate confirmed good
+		case r.code == ocspStatusRevoked:
+			allGood = false
+			if revoked == nil {
+				revoked = r
+			}
+		default:
+			allGood = false
+			if firstError == nil {
+				firstError = r
+			}
+		}
+	}
+	switch {
+	case allGood:
+		return ocspChainUnrevoked, nil
+	case revoked != nil:
+		return ocspChainRevoked, revoked
+	default:
+		return ocspChainError, firstError
+	}
+}
+
+// shouldDownloadCacheServer reports whether refreshing the local cache from the
+// OCSP cache server could help. It does only when some certificate that can be
+// checked online (has an OCSP responder URL) is not already validated by the
+// local cache. Certificates without a responder URL are never in the cache
+// server, so they never justify a download.
+func (ov *ocspValidator) shouldDownloadCacheServer(verifiedChains [][]*x509.Certificate) bool {
+	if !ocspCacheServerEnabled {
+		return false
+	}
+	for _, chain := range verifiedChains {
+		n := len(chain) - 1
+		for j := range n {
+			subject := chain[j]
+			if !hasOCSPResponder(subject) {
+				continue
+			}
+			status, _, _ := ov.validateWithCache(subject, chain[j+1])
+			if !isValidOCSPStatus(status.code) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// flushOCSPCache persists the in-memory OCSP response cache to disk if it changed.
+func (ov *ocspValidator) flushOCSPCache() {
 	ocspResponseCacheLock.Lock()
+	defer ocspResponseCacheLock.Unlock()
 	if cacheUpdated {
 		ov.writeOCSPCacheFile()
 	}
 	cacheUpdated = false
-	ocspResponseCacheLock.Unlock()
-	return nil
-}
-
-func (ov *ocspValidator) canEarlyExitForOCSP(results []*ocspStatus, verifiedChain []*x509.Certificate) *ocspStatus {
-	var msg strings.Builder
-	if ov.mode == OCSPFailOpenFalse {
-		// Fail closed. any error is returned to stop connection
-		for _, r := range results {
-			if r.err != nil {
-				return r
-			}
-		}
-	} else {
-		// Fail open and all results are valid.
-		allValid := len(results) == len(verifiedChain)-1 // root certificate is not checked
-		for _, r := range results {
-			if !isValidOCSPStatus(r.code) {
-				allValid = false
-				break
-			}
-		}
-		for _, r := range results {
-			if allValid && r.code == ocspStatusRevoked {
-				return r
-			}
-			if r != nil && r.code != ocspStatusGood && r.err != nil {
-				msg.WriteString("\n" + r.err.Error())
-			}
-		}
-	}
-	if len(msg.String()) > 0 {
-		logger.Debugf("OCSP responder didn't respond correctly. Assuming certificate is not revoked. Detail: %v", msg.String()[1:])
-	}
-	return nil
-}
-
-func (ov *ocspValidator) validateWithCacheForAllCertificates(verifiedChains []*x509.Certificate) bool {
-	n := len(verifiedChains) - 1
-	for j := range n {
-		subject := verifiedChains[j]
-		issuer := verifiedChains[j+1]
-		status, _, _ := ov.validateWithCache(subject, issuer)
-		if !isValidOCSPStatus(status.code) {
-			return false
-		}
-	}
-	return true
 }
 
 func (ov *ocspValidator) validateWithCache(subject, issuer *x509.Certificate) (*ocspStatus, []byte, *certIDKey) {
@@ -825,11 +927,17 @@ func (ov *ocspValidator) downloadOCSPCacheServer() {
 }
 
 func (ov *ocspValidator) getAllRevocationStatus(ctx context.Context, verifiedChains []*x509.Certificate) []*ocspStatus {
-	cached := ov.validateWithCacheForAllCertificates(verifiedChains)
-	if !cached {
-		ov.downloadOCSPCacheServer()
-	}
 	n := len(verifiedChains) - 1
+	// In fail-closed mode every certificate must be verifiable. If any certificate
+	// lacks an OCSP responder URL the chain can never be fully verified, so fail
+	// fast without contacting any responder for the other certificates.
+	if ov.mode == OCSPFailOpenFalse {
+		for j := range n {
+			if !hasOCSPResponder(verifiedChains[j]) {
+				return []*ocspStatus{noOCSPResponderStatus(verifiedChains[j])}
+			}
+		}
+	}
 	results := make([]*ocspStatus, n)
 	for j := range n {
 		results[j] = ov.getRevocationStatus(ctx, verifiedChains[j], verifiedChains[j+1])

--- a/ocsp_test.go
+++ b/ocsp_test.go
@@ -448,114 +448,241 @@ func TestOCSPCacheServerRetry(t *testing.T) {
 	}
 }
 
-type tcCanEarlyExit struct {
-	results       []*ocspStatus
-	resultLen     int
-	retFailOpen   *ocspStatus
-	retFailClosed *ocspStatus
-}
-
-func TestCanEarlyExitForOCSP(t *testing.T) {
-	testcases := []tcCanEarlyExit{
-		{ // 0
+func TestEvaluateChain(t *testing.T) {
+	testcases := []struct {
+		results   []*ocspStatus
+		resultLen int
+		verdict   ocspChainResult
+		// statusCode is the code of the representative status returned alongside the
+		// verdict; ignored for ocspChainUnrevoked (which returns nil).
+		statusCode ocspStatusCode
+	}{
+		{ // 0: every certificate good -> unrevoked
 			results: []*ocspStatus{
-				{
-					code: ocspStatusGood,
-				},
-				{
-					code: ocspStatusGood,
-				},
-				{
-					code: ocspStatusGood,
-				},
+				{code: ocspStatusGood},
+				{code: ocspStatusGood},
+				{code: ocspStatusGood},
 			},
-			retFailOpen:   nil,
-			retFailClosed: nil,
+			verdict: ocspChainUnrevoked,
 		},
-		{ // 1
+		{ // 1: a revoked certificate -> revoked
 			results: []*ocspStatus{
-				{
-					code: ocspStatusRevoked,
-					err:  errors.New("revoked"),
-				},
-				{
-					code: ocspStatusGood,
-				},
-				{
-					code: ocspStatusGood,
-				},
+				{code: ocspStatusRevoked, err: errors.New("revoked")},
+				{code: ocspStatusGood},
+				{code: ocspStatusGood},
 			},
-			retFailOpen:   &ocspStatus{ocspStatusRevoked, errors.New("revoked")},
-			retFailClosed: &ocspStatus{ocspStatusRevoked, errors.New("revoked")},
+			verdict:    ocspChainRevoked,
+			statusCode: ocspStatusRevoked,
 		},
-		{ // 2
+		{ // 2: an unknown status -> error
 			results: []*ocspStatus{
-				{
-					code: ocspStatusUnknown,
-					err:  errors.New("unknown"),
-				},
-				{
-					code: ocspStatusGood,
-				},
-				{
-					code: ocspStatusGood,
-				},
+				{code: ocspStatusUnknown, err: errors.New("unknown")},
+				{code: ocspStatusGood},
+				{code: ocspStatusGood},
 			},
-			retFailOpen:   nil,
-			retFailClosed: &ocspStatus{ocspStatusUnknown, errors.New("unknown")},
+			verdict:    ocspChainError,
+			statusCode: ocspStatusUnknown,
 		},
-		{ // 3: not taken as revoked if any invalid OCSP response (ocspInvalidValidity) is included.
+		{ // 3: revoked dominates other errors (aligned with the CRL validator)
 			results: []*ocspStatus{
-				{
-					code: ocspStatusRevoked,
-					err:  errors.New("revoked"),
-				},
-				{
-					code: ocspInvalidValidity,
-				},
-				{
-					code: ocspStatusGood,
-				},
+				{code: ocspStatusRevoked, err: errors.New("revoked")},
+				{code: ocspInvalidValidity},
+				{code: ocspStatusGood},
 			},
-			retFailOpen:   nil,
-			retFailClosed: &ocspStatus{ocspStatusRevoked, errors.New("revoked")},
+			verdict:    ocspChainRevoked,
+			statusCode: ocspStatusRevoked,
 		},
-		{ // 4: not taken as revoked if the number of results don't match the expected results.
+		{ // 4: fewer results than certificates in the chain -> not unrevoked
 			results: []*ocspStatus{
-				{
-					code: ocspStatusRevoked,
-					err:  errors.New("revoked"),
-				},
-				{
-					code: ocspStatusGood,
-				},
+				{code: ocspStatusRevoked, err: errors.New("revoked")},
+				{code: ocspStatusGood},
 			},
-			resultLen:     3,
-			retFailOpen:   nil,
-			retFailClosed: &ocspStatus{ocspStatusRevoked, errors.New("revoked")},
+			resultLen:  3,
+			verdict:    ocspChainRevoked,
+			statusCode: ocspStatusRevoked,
+		},
+		{ // 5: incomplete results with no revoked certificate -> error
+			results: []*ocspStatus{
+				{code: ocspStatusGood},
+			},
+			resultLen:  3,
+			verdict:    ocspChainError,
+			statusCode: 0,
 		},
 	}
 
+	ov := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenTrue})
 	for idx, tt := range testcases {
 		t.Run("", func(t *testing.T) {
-			ovOpen := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenTrue})
 			expectedLen := len(tt.results)
 			if tt.resultLen > 0 {
 				expectedLen = tt.resultLen
 			}
-			expectedLen++ // add one because normally there is a root certificate that is not included in the results.
+			expectedLen++ // add one for the root certificate that is not checked.
 			mockVerifiedChain := make([]*x509.Certificate, expectedLen)
-			r := ovOpen.canEarlyExitForOCSP(tt.results, mockVerifiedChain)
-			if !(tt.retFailOpen == nil && r == nil) && !(tt.retFailOpen != nil && r != nil && tt.retFailOpen.code == r.code) {
-				t.Fatalf("%d: failed to match return. expected: %v, got: %v", idx, tt.retFailOpen, r)
+			verdict, status := ov.evaluateChain(tt.results, mockVerifiedChain)
+			if verdict != tt.verdict {
+				t.Fatalf("%d: verdict mismatch. expected: %v, got: %v", idx, tt.verdict, verdict)
 			}
-			ovClosed := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenFalse})
-			r = ovClosed.canEarlyExitForOCSP(tt.results, mockVerifiedChain)
-			if !(tt.retFailClosed == nil && r == nil) && !(tt.retFailClosed != nil && r != nil && tt.retFailClosed.code == r.code) {
-				t.Fatalf("%d: failed to match return. expected: %v, got: %v", idx, tt.retFailClosed, r)
+			if tt.verdict == ocspChainUnrevoked {
+				if status != nil {
+					t.Fatalf("%d: expected nil status for unrevoked chain, got: %v", idx, status)
+				}
+				return
+			}
+			if tt.statusCode != 0 && (status == nil || status.code != tt.statusCode) {
+				t.Fatalf("%d: status code mismatch. expected: %v, got: %v", idx, tt.statusCode, status)
 			}
 		})
 	}
+}
+
+// seedOCSPResponse inserts a signed OCSP response for (subject, issuer) into the
+// in-memory response cache so verifyPeerCertificate resolves the certificate's
+// status from cache without any network call. issuerKey signs the response.
+func seedOCSPResponse(t *testing.T, subject, issuer *x509.Certificate, issuerKey crypto.Signer, status int) {
+	tmpl := ocsp.Response{
+		Status:       status,
+		SerialNumber: subject.SerialNumber,
+		ThisUpdate:   time.Now().Add(-time.Hour),
+		NextUpdate:   time.Now().Add(time.Hour),
+	}
+	if status == ocsp.Revoked {
+		tmpl.RevokedAt = time.Now().Add(-2 * time.Hour)
+		tmpl.RevocationReason = ocsp.Unspecified
+	}
+	respBytes, err := ocsp.CreateResponse(issuer, issuer, tmpl, issuerKey)
+	assertNilF(t, err)
+	req, err := ocsp.CreateRequest(subject, issuer, nil)
+	assertNilF(t, err)
+	key, s := extractCertIDKeyFromRequest(req)
+	assertEqualF(t, s.code, ocspSuccess)
+	syncUpdateOcspResponseCache(func() {
+		ocspResponseCache[*key] = &certCacheValue{float64(time.Now().Unix()), base64.StdEncoding.EncodeToString(respBytes)}
+	})
+}
+
+// TestVerifyPeerCertificateMultiChain verifies the multi-chain revocation policy:
+// a connection is accepted as soon as one verified chain is fully unrevoked, and
+// rejected only when every chain fails. Chains are evaluated purely from the
+// in-memory OCSP cache (good/revoked leaves) or a missing responder URL (error
+// leaves), so the test performs no network calls.
+func TestVerifyPeerCertificateMultiChain(t *testing.T) {
+	prevEnabled := ocspCacheServerEnabled
+	prevCacheFile := cacheFileName
+	prevUpdated := cacheUpdated
+	t.Cleanup(func() {
+		ocspCacheServerEnabled = prevEnabled
+		cacheFileName = prevCacheFile
+		cacheUpdated = prevUpdated
+	})
+	ocspCacheServerEnabled = true
+	cacheFileName = fmt.Sprintf("%s/%s", t.TempDir(), cacheFileBaseName)
+
+	caKey, caCert := createCa(t, nil, nil, "root CA", 0)
+	const dummyResponder = ocspServerType("http://ocsp.test.invalid/")
+
+	resetCaches := func() {
+		syncUpdateOcspResponseCache(func() {
+			ocspResponseCache = make(map[certIDKey]*certCacheValue)
+		})
+		ocspParsedRespCacheLock.Lock()
+		ocspParsedRespCache = make(map[parsedOcspRespKey]*ocspStatus)
+		ocspParsedRespCacheLock.Unlock()
+		cacheUpdated = false
+	}
+
+	// goodLeaf / revokedLeaf advertise a responder URL and are resolved from the
+	// seeded cache. errorLeaf has no responder URL and is not cached, so it can
+	// never be verified (and never triggers a network call).
+	goodLeaf := func() *x509.Certificate {
+		_, leaf := createLeafCert(t, caCert, caKey, 0, dummyResponder)
+		seedOCSPResponse(t, leaf, caCert, caKey, ocsp.Good)
+		return leaf
+	}
+	revokedLeaf := func() *x509.Certificate {
+		_, leaf := createLeafCert(t, caCert, caKey, 0, dummyResponder)
+		seedOCSPResponse(t, leaf, caCert, caKey, ocsp.Revoked)
+		return leaf
+	}
+	errorLeaf := func() *x509.Certificate {
+		_, leaf := createLeafCert(t, caCert, caKey, 0)
+		return leaf
+	}
+
+	bothModes := []OCSPFailOpenMode{OCSPFailOpenTrue, OCSPFailOpenFalse}
+
+	t.Run("error chain then good chain is accepted", func(t *testing.T) {
+		for _, mode := range bothModes {
+			resetCaches()
+			chains := [][]*x509.Certificate{
+				{errorLeaf(), caCert},
+				{goodLeaf(), caCert},
+			}
+			ov := newOcspValidator(&Config{OCSPFailOpen: mode})
+			err := ov.verifyPeerCertificate(context.Background(), chains)
+			assertNilF(t, err, fmt.Sprintf("mode %v should accept when any chain is unrevoked", mode))
+		}
+	})
+
+	t.Run("revoked chain then good chain is accepted", func(t *testing.T) {
+		for _, mode := range bothModes {
+			resetCaches()
+			chains := [][]*x509.Certificate{
+				{revokedLeaf(), caCert},
+				{goodLeaf(), caCert},
+			}
+			ov := newOcspValidator(&Config{OCSPFailOpen: mode})
+			err := ov.verifyPeerCertificate(context.Background(), chains)
+			assertNilF(t, err, fmt.Sprintf("mode %v should accept when a later chain is unrevoked", mode))
+		}
+	})
+
+	t.Run("all chains revoked is rejected in both modes", func(t *testing.T) {
+		for _, mode := range bothModes {
+			resetCaches()
+			chains := [][]*x509.Certificate{
+				{revokedLeaf(), caCert},
+				{revokedLeaf(), caCert},
+			}
+			ov := newOcspValidator(&Config{OCSPFailOpen: mode})
+			err := ov.verifyPeerCertificate(context.Background(), chains)
+			assertNotNilF(t, err, fmt.Sprintf("mode %v must reject when every chain is revoked", mode))
+		}
+	})
+
+	t.Run("revoked plus error chain follows CRL semantics", func(t *testing.T) {
+		// Fail-open accepts (the error chain clears allRevoked, no chain is fully
+		// unrevoked, revocation is not treated as definitive); fail-closed rejects.
+		resetCaches()
+		revoked := revokedLeaf()
+		errored := errorLeaf()
+		buildChains := func() [][]*x509.Certificate {
+			return [][]*x509.Certificate{
+				{revoked, caCert},
+				{errored, caCert},
+			}
+		}
+
+		ovOpen := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenTrue})
+		assertNilF(t, ovOpen.verifyPeerCertificate(context.Background(), buildChains()), "fail-open should accept a revoked+error mix")
+
+		ovClosed := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenFalse})
+		assertNotNilF(t, ovClosed.verifyPeerCertificate(context.Background(), buildChains()), "fail-closed should reject a revoked+error mix")
+	})
+
+	t.Run("all chains unverifiable follows mode", func(t *testing.T) {
+		resetCaches()
+		chains := [][]*x509.Certificate{
+			{errorLeaf(), caCert},
+			{errorLeaf(), caCert},
+		}
+		ovOpen := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenTrue})
+		assertNilF(t, ovOpen.verifyPeerCertificate(context.Background(), chains), "fail-open should accept when no chain can be verified")
+
+		ovClosed := newOcspValidator(&Config{OCSPFailOpen: OCSPFailOpenFalse})
+		assertNotNilF(t, ovClosed.verifyPeerCertificate(context.Background(), chains), "fail-closed should reject when no chain can be verified")
+	})
 }
 
 func TestInitOCSPCacheFileCreation(t *testing.T) {

--- a/revocation_test.go
+++ b/revocation_test.go
@@ -1,0 +1,105 @@
+package gosnowflake
+
+// This file holds test helpers shared by the certificate-revocation test suites
+// (CRL and OCSP): a small X.509 certificate factory used to build CA and leaf
+// certificates with optional CRL distribution points and OCSP responder URLs.
+
+import (
+	"cmp"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+)
+
+var serialNumber = int64(0) // to be incremented
+
+// notAfterType overrides a leaf certificate's NotAfter when passed to createLeafCert.
+type notAfterType time.Time
+
+// crlEndpointType adds a CRL distribution point to a certificate created by the factory.
+type crlEndpointType string
+
+// ocspServerType adds an OCSP responder URL to a certificate created by createLeafCert.
+type ocspServerType string
+
+func createCa(t *testing.T, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, cn string, port int, crlEndpoints ...crlEndpointType) (*rsa.PrivateKey, *x509.Certificate) {
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:       []string{"Snowflake"},
+			OrganizationalUnit: []string{"Drivers"},
+			Locality:           []string{"Warsaw"},
+			CommonName:         cn,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+	}
+	return createCert(t, caTemplate, issuerCert, issuerPrivateKey, port, crlEndpoints)
+}
+
+func createLeafCert(t *testing.T, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, port int, params ...any) (*rsa.PrivateKey, *x509.Certificate) {
+	notAfter := time.Now().AddDate(1, 0, 0)
+	var crlEndpoints []crlEndpointType
+	var ocspServers []string
+	for _, param := range params {
+		switch v := param.(type) {
+		case notAfterType:
+			notAfter = time.Time(v)
+		case crlEndpointType:
+			crlEndpoints = append(crlEndpoints, v)
+		case ocspServerType:
+			ocspServers = append(ocspServers, string(v))
+		}
+	}
+	serialNumber++
+	certTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(serialNumber),
+		Subject: pkix.Name{
+			Organization:       []string{"Snowflake"},
+			OrganizationalUnit: []string{"Drivers"},
+			Locality:           []string{"Warsaw"},
+			CommonName:         "localhost",
+		},
+		NotBefore:          time.Now(),
+		NotAfter:           notAfter,
+		IsCA:               false,
+		OCSPServer:         ocspServers,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	return createCert(t, certTemplate, issuerCert, issuerPrivateKey, port, crlEndpoints)
+}
+
+func createCert(t *testing.T, template, issuerCert *x509.Certificate, issuerPrivateKey *rsa.PrivateKey, port int, crlEndpoints []crlEndpointType) (*rsa.PrivateKey, *x509.Certificate) {
+	var distributionPoints []string
+	for _, crlEndpoint := range crlEndpoints {
+		distributionPoints = append(distributionPoints, fmt.Sprintf("http://localhost:%v%v", port, crlEndpoint))
+		template.CRLDistributionPoints = distributionPoints
+	}
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assertNilF(t, err)
+	template.SubjectKeyId = calculateKeyID(t, &privateKey.PublicKey)
+	signerPrivateKey := cmp.Or(issuerPrivateKey, privateKey)
+	issuerCertOrSelfSigned := cmp.Or(issuerCert, template)
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, issuerCertOrSelfSigned, &privateKey.PublicKey, signerPrivateKey)
+	assertNilF(t, err)
+	cert, err := x509.ParseCertificate(certBytes)
+	assertNilF(t, err)
+	return privateKey, cert
+}
+
+func calculateKeyID(t *testing.T, pubKey any) []byte {
+	pubBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	assertNilF(t, err)
+	hash := sha256.Sum256(pubBytes)
+	return hash[:]
+}


### PR DESCRIPTION
### Description

This PR fixes three related OCSP revocation correctness issues:

Multi-chain acceptance policy: verifyPeerCertificate now accepts a connection as soon as any one verified certificate chain is fully unrevoked, and rejects only when every chain fails. Previously the first chain with an error would abort the connection even if a later chain was clean. This aligns OCSP behaviour with the CRL validator.

Unnecessary OCSP cache server downloads: The cache server is no longer contacted when no certificate in any verified chain has an OCSP responder URL. Certificates without a responder URL are never present in the cache server, so downloading it in that case was wasteful and incorrect.

Fail-closed fast-fail on missing responder URL: In fail-closed mode, if any certificate in a chain lacks an OCSP responder URL the chain is immediately failed without querying responders for the remaining certificates. A chain that cannot be fully verified must be rejected in fail-closed mode, and there is no point contacting other responders once the outcome is determined.

Internally, canEarlyExitForOCSP has been replaced by evaluateChain, which returns a typed ocspChainResult (ocspChainUnrevoked, ocspChainRevoked, or ocspChainError) rather than a raw *ocspStatus. The cache-flush logic is now handled by a dedicated flushOCSPCache method called via defer. The certificate factory helpers shared between the CRL and OCSP test suites have been consolidated into a new revocation_test.go file, and createLeafCert now accepts an ocspServerType parameter to embed OCSP responder URLs directly into test certificates. A new TestVerifyPeerCertificateMultiChain test exercises all multi-chain scenarios entirely from the in-memory cache with no network calls.