### PR TITLE
SNOW-2499292 Add serializable Arrow batches for distributed fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features:
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 - Increased CRL disk cache removal delay to 7 days (snowflakedb/gosnowflake#1820).
 - Added option to load private key from `connections.toml` file (snowflakedb/gosnowflake#1822).
+- Added `arrowbatches.SerializableArrowBatch` with `ArrowBatch.ToSerializable` and `SerializableArrowBatch.ToArrowBatch` to enable distributed fetch: Arrow batches can be serialized, shipped to other machines, and downloaded there with an injected HTTP client and no Snowflake connection (snowflakedb/gosnowflake#1833).
 
 Bug fixes:
 - Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the token type in the key prefix, applied uniformly across keyring (macOS/Windows) and file (Linux) backends; also replaced the bag-of-fields spec struct with typed token-spec types (`hostUserTokenSpec` for MFA/ID flows, `oauthTokenSpec` for OAuth flows) so each spec validates and serializes only its own fields (snowflakedb/gosnowflake#1817, snowflakedb/gosnowflake#1821).

--- a/arrowbatches/options.go
+++ b/arrowbatches/options.go
@@ -9,17 +9,21 @@ import (
 // ConversionOptions bundles the options that control how raw Snowflake Arrow data is
 // converted into standard Arrow records (see ArrowBatch.Fetch). It is the single source of
 // truth for these options: add a new option here and thread it through the conversion
-// functions, and everything that carries options forward — including the batch itself —
-// gets it without further changes.
+// functions, and everything that carries options forward — including the batch itself and
+// its serialized form (SerializableArrowBatch) — gets it without further changes.
+//
+// All fields must remain serializable plain data (they are embedded into
+// SerializableArrowBatch); runtime resources such as an HTTP client or allocator do not
+// belong here and are supplied separately via Option.
 type ConversionOptions struct {
 	// TimestampOption controls how Snowflake timestamps are converted (see WithTimestampOption).
-	TimestampOption ia.TimestampOption
+	TimestampOption ia.TimestampOption `json:"timestampOption,omitempty"`
 	// HigherPrecision preserves BigDecimal values instead of converting to int64/float64
 	// (see WithHigherPrecision).
-	HigherPrecision bool
+	HigherPrecision bool `json:"higherPrecision,omitempty"`
 	// Utf8Validation replaces invalid UTF-8 in string columns with the replacement
 	// character (see WithUtf8Validation).
-	Utf8Validation bool
+	Utf8Validation bool `json:"utf8Validation,omitempty"`
 }
 
 // conversionOptionsFromContext snapshots the conversion options set on ctx via the public

--- a/arrowbatches/serializable.go
+++ b/arrowbatches/serializable.go
@@ -35,9 +35,10 @@ const arrowFormatName = "arrow"
 type SerializableArrowBatch struct {
 	// Format is the chunk payload format; currently always "arrow".
 	Format string `json:"format"`
-	// InlineData holds the Arrow IPC bytes for the first batch (embedded in the query
-	// response). When set, the batch is local and no download is performed.
-	InlineData []byte `json:"inlineData,omitempty"`
+	// InlineData holds the base64-encoded Arrow IPC bytes for the first batch (carried
+	// verbatim from the query response). When set, the batch is local and no download is
+	// performed; the bytes are base64-decoded only when the batch is materialized.
+	InlineData string `json:"inlineData,omitempty"`
 	// URL is the presigned cloud-storage URL for a remote chunk (empty for inline batches).
 	URL string `json:"url,omitempty"`
 	// Headers are the HTTP headers required to fetch URL, including the SSE-C key.
@@ -68,7 +69,7 @@ type SerializableArrowBatch struct {
 // released, though the descriptor itself remains valid for re-serialization.
 func (rb *ArrowBatch) ToSerializable() (SerializableArrowBatch, error) {
 	desc := rb.raw.Descriptor
-	if len(desc.InlineData) == 0 && desc.URL == "" {
+	if desc.InlineDataBase64 == "" && desc.URL == "" {
 		return SerializableArrowBatch{}, fmt.Errorf(
 			"arrowbatches: batch has neither inline data nor a chunk URL and cannot be serialized")
 	}
@@ -77,7 +78,7 @@ func (rb *ArrowBatch) ToSerializable() (SerializableArrowBatch, error) {
 
 	return SerializableArrowBatch{
 		Format:                arrowFormatName,
-		InlineData:            desc.InlineData,
+		InlineData:            desc.InlineDataBase64,
 		URL:                   desc.URL,
 		Headers:               desc.Headers,
 		RowCount:              rb.raw.RowCount,
@@ -98,9 +99,11 @@ type arrowBatchOpts struct {
 // Option configures ToArrowBatch.
 type Option func(*arrowBatchOpts)
 
-// WithHTTPClient injects the HTTP client used to download remote chunks. It is required
-// for batches that reference a URL; the worker has no Snowflake connection to build one
-// from, and this is also the seam for configuring proxy/TLS/timeouts.
+// WithHTTPClient injects the HTTP client used to download remote chunks. It is optional:
+// when not set, http.DefaultClient is used. Since the worker has no Snowflake connection to
+// inherit transport settings from, this is the seam for configuring proxy/TLS/timeouts;
+// note that http.DefaultClient has no timeout, so pass a client with one (or a Fetch context
+// with a deadline) for remote batches.
 func WithHTTPClient(client *http.Client) Option {
 	return func(o *arrowBatchOpts) { o.client = client }
 }
@@ -115,9 +118,10 @@ func WithAllocator(pool memory.Allocator) Option {
 // The returned batch's Fetch downloads (if remote) and transforms the records exactly
 // as a batch obtained directly from GetArrowBatches would.
 //
-// A remote batch (URL set) requires an *http.Client via WithHTTPClient. Inline batches
-// need no client. Call WithContext on the returned batch to bind a cancellation context
-// to Fetch.
+// The HTTP client used for a remote batch defaults to http.DefaultClient; supply your own
+// with WithHTTPClient to configure proxy/TLS/timeouts (recommended, since http.DefaultClient
+// has no timeout). Inline batches perform no download. Call WithContext on the returned batch
+// to bind a cancellation context to Fetch.
 func (s SerializableArrowBatch) ToArrowBatch(opts ...Option) (*ArrowBatch, error) {
 	if s.Format != "" && s.Format != arrowFormatName {
 		return nil, fmt.Errorf("arrowbatches: unsupported serialized batch format %q", s.Format)
@@ -130,17 +134,15 @@ func (s SerializableArrowBatch) ToArrowBatch(opts ...Option) (*ArrowBatch, error
 	if o.allocator == nil {
 		o.allocator = memory.DefaultAllocator
 	}
-
-	remote := len(s.InlineData) == 0 && s.URL != ""
-	if remote && o.client == nil {
-		return nil, fmt.Errorf("arrowbatches: a remote arrow batch requires an *http.Client (use WithHTTPClient)")
+	if o.client == nil {
+		o.client = http.DefaultClient
 	}
 
 	client, alloc := o.client, o.allocator
 	desc := ia.ChunkDescriptor{
 		URL:              s.URL,
 		Headers:          s.Headers,
-		InlineData:       s.InlineData,
+		InlineDataBase64: s.InlineData,
 		UncompressedSize: s.UncompressedSize,
 	}
 

--- a/arrowbatches/serializable.go
+++ b/arrowbatches/serializable.go
@@ -1,0 +1,185 @@
+package arrowbatches
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	ia "github.com/snowflakedb/gosnowflake/v2/internal/arrow"
+	"github.com/snowflakedb/gosnowflake/v2/internal/query"
+)
+
+// arrowFormatName is the only result format arrow batches carry today. The Format
+// field is kept for forward compatibility with the streaming/JSON result path.
+const arrowFormatName = "arrow"
+
+// SerializableArrowBatch is a portable, self-contained description of an ArrowBatch.
+// It can be marshaled (e.g. with encoding/json), shipped to another machine that has
+// no Snowflake connection, and turned back into an ArrowBatch with ToArrowBatch. This
+// enables distributed fetch: partition a result set on one node and download the
+// chunks in parallel across many.
+//
+// Security: for remote batches, Headers carries the SSE-C decryption key and URL is a
+// presigned bearer capability granting read access to the chunk. Treat a serialized
+// batch as sensitive and transmit it only over secure channels.
+//
+// Expiry: presigned URLs are valid only for a server-controlled window (typically a few
+// hours). A remote SerializableArrowBatch must be shipped and fetched within it. Inline
+// batches (InlineData set) embed their data and never expire.
+type SerializableArrowBatch struct {
+	// Format is the chunk payload format; currently always "arrow".
+	Format string `json:"format"`
+	// InlineData holds the Arrow IPC bytes for the first batch (embedded in the query
+	// response). When set, the batch is local and no download is performed.
+	InlineData []byte `json:"inlineData,omitempty"`
+	// URL is the presigned cloud-storage URL for a remote chunk (empty for inline batches).
+	URL string `json:"url,omitempty"`
+	// Headers are the HTTP headers required to fetch URL, including the SSE-C key.
+	Headers map[string]string `json:"headers,omitempty"`
+	// RowCount is the number of rows in the batch.
+	RowCount int `json:"rowCount"`
+	// UncompressedSize is the reported uncompressed size of the chunk in bytes.
+	UncompressedSize int64 `json:"uncompressedSize,omitempty"`
+	// RowTypes is the column metadata needed to transform the raw records.
+	RowTypes []query.ExecResponseRowType `json:"rowTypes"`
+	// TimezoneName is the batch's timezone name (loc.String()).
+	TimezoneName string `json:"timezoneName,omitempty"`
+	// TimezoneOffsetSeconds is the batch's timezone offset, used as a fallback when the
+	// worker cannot resolve TimezoneName (e.g. fixed-offset zones, or missing tzdata).
+	TimezoneOffsetSeconds int `json:"timezoneOffsetSeconds,omitempty"`
+	// ConversionOptions carries the options controlling how the raw Arrow data is converted
+	// (timestamp handling, higher precision, UTF-8 validation). It is embedded so its fields
+	// appear at the top level of the serialized form, and it is the single place new
+	// conversion options flow through — see ConversionOptions.
+	ConversionOptions
+}
+
+// ToSerializable converts a batch into a portable descriptor for distributed fetch.
+// It captures the chunk address (inline bytes or URL + headers), the column metadata,
+// timezone, and the conversion options that were captured when the batch was created.
+//
+// Call ToSerializable before Fetch: after a successful Fetch the in-memory records are
+// released, though the descriptor itself remains valid for re-serialization.
+func (rb *ArrowBatch) ToSerializable() (SerializableArrowBatch, error) {
+	desc := rb.raw.Descriptor
+	if len(desc.InlineData) == 0 && desc.URL == "" {
+		return SerializableArrowBatch{}, fmt.Errorf(
+			"arrowbatches: batch has neither inline data nor a chunk URL and cannot be serialized")
+	}
+
+	name, offset := timezoneNameAndOffset(rb.raw.Location)
+
+	return SerializableArrowBatch{
+		Format:                arrowFormatName,
+		InlineData:            desc.InlineData,
+		URL:                   desc.URL,
+		Headers:               desc.Headers,
+		RowCount:              rb.raw.RowCount,
+		UncompressedSize:      desc.UncompressedSize,
+		RowTypes:              rb.rowTypes,
+		TimezoneName:          name,
+		TimezoneOffsetSeconds: offset,
+		ConversionOptions:     rb.conversionOptions,
+	}, nil
+}
+
+// arrowBatchOpts holds options for reconstructing an ArrowBatch on a worker node.
+type arrowBatchOpts struct {
+	client    *http.Client
+	allocator memory.Allocator
+}
+
+// Option configures ToArrowBatch.
+type Option func(*arrowBatchOpts)
+
+// WithHTTPClient injects the HTTP client used to download remote chunks. It is required
+// for batches that reference a URL; the worker has no Snowflake connection to build one
+// from, and this is also the seam for configuring proxy/TLS/timeouts.
+func WithHTTPClient(client *http.Client) Option {
+	return func(o *arrowBatchOpts) { o.client = client }
+}
+
+// WithAllocator sets the Arrow memory allocator used when decoding and transforming
+// records. Defaults to memory.DefaultAllocator.
+func WithAllocator(pool memory.Allocator) Option {
+	return func(o *arrowBatchOpts) { o.allocator = pool }
+}
+
+// ToArrowBatch reconstructs an ArrowBatch from its serialized form on a worker node.
+// The returned batch's Fetch downloads (if remote) and transforms the records exactly
+// as a batch obtained directly from GetArrowBatches would.
+//
+// A remote batch (URL set) requires an *http.Client via WithHTTPClient. Inline batches
+// need no client. Call WithContext on the returned batch to bind a cancellation context
+// to Fetch.
+func (s SerializableArrowBatch) ToArrowBatch(opts ...Option) (*ArrowBatch, error) {
+	if s.Format != "" && s.Format != arrowFormatName {
+		return nil, fmt.Errorf("arrowbatches: unsupported serialized batch format %q", s.Format)
+	}
+
+	var o arrowBatchOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.allocator == nil {
+		o.allocator = memory.DefaultAllocator
+	}
+
+	remote := len(s.InlineData) == 0 && s.URL != ""
+	if remote && o.client == nil {
+		return nil, fmt.Errorf("arrowbatches: a remote arrow batch requires an *http.Client (use WithHTTPClient)")
+	}
+
+	client, alloc := o.client, o.allocator
+	desc := ia.ChunkDescriptor{
+		URL:              s.URL,
+		Headers:          s.Headers,
+		InlineData:       s.InlineData,
+		UncompressedSize: s.UncompressedSize,
+	}
+
+	return &ArrowBatch{
+		rowTypes:          s.RowTypes,
+		allocator:         alloc,
+		ctx:               context.Background(),
+		conversionOptions: s.ConversionOptions,
+		raw: ia.BatchRaw{
+			RowCount:   s.RowCount,
+			Location:   loadLocation(s.TimezoneName, s.TimezoneOffsetSeconds),
+			Descriptor: desc,
+			Download: func(ctx context.Context) (*[]arrow.Record, int, error) {
+				return ia.DownloadBatchRecords(ctx, client, desc, ipc.WithAllocator(alloc))
+			},
+		},
+	}, nil
+}
+
+// timezoneNameAndOffset extracts a serializable timezone name and offset from a location.
+func timezoneNameAndOffset(loc *time.Location) (string, int) {
+	if loc == nil {
+		return "", 0
+	}
+	_, offset := time.Now().In(loc).Zone()
+	return loc.String(), offset
+}
+
+// loadLocation reconstructs a *time.Location from a serialized name and offset. Named
+// IANA zones are resolved via the tz database when available; fixed-offset zones (e.g.
+// "+0300"), the process-local "Local", and any name the worker cannot resolve fall back
+// to a fixed zone built from the stored offset. Named zones with DST transitions require
+// tzdata on the worker for full fidelity.
+func loadLocation(name string, offsetSeconds int) *time.Location {
+	if name == "" || name == "Local" || strings.HasPrefix(name, "+") || strings.HasPrefix(name, "-") {
+		return time.FixedZone(name, offsetSeconds)
+	}
+	if loc, err := time.LoadLocation(name); err == nil {
+		return loc
+	}
+	return time.FixedZone(name, offsetSeconds)
+}

--- a/arrowbatches/serializable_test.go
+++ b/arrowbatches/serializable_test.go
@@ -1,0 +1,401 @@
+package arrowbatches
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/snowflakedb/gosnowflake/v2/internal/query"
+)
+
+// wantInts / wantStrs are the fixture values shared by the tests below.
+var (
+	fixtureInts = []int64{1, 2, 3}
+	fixtureStrs = []string{"alpha", "beta", "gamma"}
+)
+
+// buildFixtureIPC builds a raw (Snowflake-shaped) Arrow record with a "fixed" Int64
+// column and a "text" String column, and returns it encoded as Arrow IPC stream bytes
+// plus the matching row-type metadata. All Arrow memory is released before returning;
+// the returned bytes are plain Go bytes.
+func buildFixtureIPC(t *testing.T) ([]byte, []query.ExecResponseRowType) {
+	t.Helper()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	intB := array.NewInt64Builder(pool)
+	defer intB.Release()
+	intB.AppendValues(fixtureInts, nil)
+	intArr := intB.NewArray()
+	defer intArr.Release()
+
+	strB := array.NewStringBuilder(pool)
+	defer strB.Release()
+	strB.AppendValues(fixtureStrs, nil)
+	strArr := strB.NewArray()
+	defer strArr.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "n", Type: &arrow.Int64Type{}},
+		{Name: "s", Type: &arrow.StringType{}},
+	}, nil)
+	rec := array.NewRecord(schema, []arrow.Array{intArr, strArr}, int64(len(fixtureInts)))
+	defer rec.Release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(schema), ipc.WithAllocator(pool))
+	if err := w.Write(rec); err != nil {
+		t.Fatalf("writing IPC record: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing IPC writer: %v", err)
+	}
+
+	rowTypes := []query.ExecResponseRowType{
+		{Name: "n", Type: "fixed", Scale: 0, Precision: 18, Nullable: true},
+		{Name: "s", Type: "text", Length: 16, Nullable: true},
+	}
+	return buf.Bytes(), rowTypes
+}
+
+func gzipBytes(t *testing.T, in []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(in); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// assertFixture fetches the batch, verifies the values against the fixture, and releases
+// the returned records.
+func assertFixture(t *testing.T, batch *ArrowBatch) {
+	t.Helper()
+	records, err := batch.Fetch()
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	var got int
+	for _, rec := range *records {
+		ints := rec.Column(0).(*array.Int64).Int64Values()
+		strs := rec.Column(1).(*array.String)
+		for i := range ints {
+			if ints[i] != fixtureInts[got] {
+				t.Fatalf("row %d: int = %d, want %d", got, ints[i], fixtureInts[got])
+			}
+			if strs.Value(i) != fixtureStrs[got] {
+				t.Fatalf("row %d: str = %q, want %q", got, strs.Value(i), fixtureStrs[got])
+			}
+			got++
+		}
+		rec.Release()
+	}
+	if got != len(fixtureInts) {
+		t.Fatalf("got %d rows, want %d", got, len(fixtureInts))
+	}
+}
+
+func TestSerializableArrowBatchInline(t *testing.T) {
+	ipcBytes, rowTypes := buildFixtureIPC(t)
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	s := SerializableArrowBatch{
+		Format:       arrowFormatName,
+		InlineData:   ipcBytes,
+		RowCount:     len(fixtureInts),
+		RowTypes:     rowTypes,
+		TimezoneName: "UTC",
+	}
+	// Inline batch needs no HTTP client.
+	batch, err := s.ToArrowBatch(WithAllocator(pool))
+	if err != nil {
+		t.Fatalf("ToArrowBatch: %v", err)
+	}
+	assertFixture(t, batch)
+}
+
+func TestSerializableArrowBatchRemote(t *testing.T) {
+	ipcBytes, rowTypes := buildFixtureIPC(t)
+
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+		gzipped bool
+	}{
+		{name: "plain", payload: ipcBytes},
+		{name: "gzip", payload: gzipBytes(t, ipcBytes), gzipped: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotHeaders http.Header
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotHeaders = r.Header.Clone()
+				_, _ = w.Write(tc.payload)
+			}))
+			defer srv.Close()
+
+			pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+			defer pool.AssertSize(t, 0)
+
+			s := SerializableArrowBatch{
+				Format:   arrowFormatName,
+				URL:      srv.URL + "/chunk",
+				Headers:  map[string]string{"x-amz-server-side-encryption-customer-key": "test-qrmk"},
+				RowCount: len(fixtureInts),
+				RowTypes: rowTypes,
+			}
+			batch, err := s.ToArrowBatch(WithHTTPClient(srv.Client()), WithAllocator(pool))
+			if err != nil {
+				t.Fatalf("ToArrowBatch: %v", err)
+			}
+			assertFixture(t, batch)
+
+			if gotHeaders.Get("x-amz-server-side-encryption-customer-key") != "test-qrmk" {
+				t.Fatalf("SSE-C header not forwarded to storage; got %v", gotHeaders)
+			}
+		})
+	}
+}
+
+func TestSerializableArrowBatchRemoteRequiresClient(t *testing.T) {
+	_, rowTypes := buildFixtureIPC(t)
+	s := SerializableArrowBatch{
+		Format:   arrowFormatName,
+		URL:      "https://example.invalid/chunk",
+		RowCount: len(fixtureInts),
+		RowTypes: rowTypes,
+	}
+	if _, err := s.ToArrowBatch(); err == nil {
+		t.Fatal("expected error when a remote batch has no HTTP client")
+	}
+}
+
+func TestSerializableArrowBatchExpiredURL(t *testing.T) {
+	_, rowTypes := buildFixtureIPC(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "AccessDenied: Request has expired", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	s := SerializableArrowBatch{
+		Format:   arrowFormatName,
+		URL:      srv.URL + "/chunk",
+		RowCount: len(fixtureInts),
+		RowTypes: rowTypes,
+	}
+	batch, err := s.ToArrowBatch(WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("ToArrowBatch: %v", err)
+	}
+	if _, err := batch.Fetch(); err == nil {
+		t.Fatal("expected an error fetching an expired (403) URL")
+	}
+}
+
+func TestSerializableArrowBatchUnsupportedFormat(t *testing.T) {
+	s := SerializableArrowBatch{Format: "json", RowCount: 1}
+	if _, err := s.ToArrowBatch(); err == nil {
+		t.Fatal("expected error for non-arrow format")
+	}
+}
+
+func TestSerializableArrowBatchJSONRoundTrip(t *testing.T) {
+	ipcBytes, rowTypes := buildFixtureIPC(t)
+	// A nested/structured row type to confirm recursive Fields survive JSON.
+	rowTypes = append(rowTypes, query.ExecResponseRowType{
+		Name: "obj", Type: "object", Nullable: true,
+		Fields: []query.FieldMetadata{
+			{Name: "inner", Type: "text", Nullable: true},
+		},
+	})
+
+	orig := SerializableArrowBatch{
+		Format:                arrowFormatName,
+		InlineData:            ipcBytes,
+		URL:                   "https://example.invalid/chunk",
+		Headers:               map[string]string{"h": "v"},
+		RowCount:              len(fixtureInts),
+		UncompressedSize:      4096,
+		RowTypes:              rowTypes,
+		TimezoneName:          "America/New_York",
+		TimezoneOffsetSeconds: -5 * 3600,
+		ConversionOptions: ConversionOptions{
+			HigherPrecision: true,
+			TimestampOption: UseMillisecondTimestamp,
+			Utf8Validation:  true,
+		},
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got SerializableArrowBatch
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !bytes.Equal(got.InlineData, orig.InlineData) {
+		t.Fatal("InlineData did not round-trip")
+	}
+	if got.TimestampOption != orig.TimestampOption || got.HigherPrecision != orig.HigherPrecision || got.Utf8Validation != orig.Utf8Validation {
+		t.Fatalf("conversion flags did not round-trip: %+v", got)
+	}
+	if len(got.RowTypes) != 3 || len(got.RowTypes[2].Fields) != 1 || got.RowTypes[2].Fields[0].Name != "inner" {
+		t.Fatalf("nested RowTypes did not round-trip: %+v", got.RowTypes)
+	}
+	if got.TimezoneName != "America/New_York" || got.TimezoneOffsetSeconds != -5*3600 {
+		t.Fatalf("timezone did not round-trip: %q %d", got.TimezoneName, got.TimezoneOffsetSeconds)
+	}
+}
+
+func TestLoadLocation(t *testing.T) {
+	// Fixed-offset zone (as produced by gosnowflake.Location) — LoadLocation would reject
+	// the name, so we must fall back to the stored offset.
+	loc := loadLocation("+0300", 3*3600)
+	if _, off := time.Now().In(loc).Zone(); off != 3*3600 {
+		t.Fatalf("fixed-offset zone: got offset %d, want %d", off, 3*3600)
+	}
+
+	// "Local" must not resolve to the worker's local zone; it uses the stored offset.
+	loc = loadLocation("Local", -7*3600)
+	if _, off := time.Now().In(loc).Zone(); off != -7*3600 {
+		t.Fatalf("Local zone: got offset %d, want %d", off, -7*3600)
+	}
+
+	// A named IANA zone resolves via tzdata when available.
+	loc = loadLocation("UTC", 0)
+	if got := loc.String(); got != "UTC" {
+		t.Fatalf("named zone: got %q, want UTC", got)
+	}
+
+	// Empty name falls back to a fixed zone from the offset.
+	loc = loadLocation("", 0)
+	if _, off := time.Now().In(loc).Zone(); off != 0 {
+		t.Fatalf("empty zone: got offset %d, want 0", off)
+	}
+}
+
+// TestToSerializableRoundTripInline verifies ToSerializable -> ToArrowBatch for an inline
+// batch built directly (exercising both directions offline, without a live connection).
+func TestToSerializableRoundTripInline(t *testing.T) {
+	ipcBytes, rowTypes := buildFixtureIPC(t)
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	src := SerializableArrowBatch{
+		Format:       arrowFormatName,
+		InlineData:   ipcBytes,
+		RowCount:     len(fixtureInts),
+		RowTypes:     rowTypes,
+		TimezoneName: "UTC",
+	}
+	batch, err := src.ToArrowBatch(WithAllocator(pool))
+	if err != nil {
+		t.Fatalf("ToArrowBatch: %v", err)
+	}
+	// Re-serialize the reconstructed batch (before Fetch) and confirm the descriptor survives.
+	round, err := batch.ToSerializable()
+	if err != nil {
+		t.Fatalf("ToSerializable: %v", err)
+	}
+	if !bytes.Equal(round.InlineData, ipcBytes) || round.RowCount != len(fixtureInts) {
+		t.Fatalf("re-serialized descriptor mismatch: %+v", round)
+	}
+	batch2, err := round.ToArrowBatch(WithAllocator(pool))
+	if err != nil {
+		t.Fatalf("ToArrowBatch (round): %v", err)
+	}
+	assertFixture(t, batch2)
+}
+
+// buildDecimalIPC builds a raw Decimal128 column (as Snowflake sends for NUMBER(_,1))
+// encoded as Arrow IPC bytes, plus its scale-1 row-type metadata.
+func buildDecimalIPC(t *testing.T) ([]byte, []query.ExecResponseRowType) {
+	t.Helper()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	dt := &arrow.Decimal128Type{Precision: 10, Scale: 1}
+	b := array.NewDecimal128Builder(pool, dt)
+	defer b.Release()
+	b.Append(decimal128.FromU64(1234)) // 123.4 at scale 1
+	arr := b.NewArray()
+	defer arr.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "n", Type: dt}}, nil)
+	rec := array.NewRecord(schema, []arrow.Array{arr}, 1)
+	defer rec.Release()
+
+	var buf bytes.Buffer
+	w := ipc.NewWriter(&buf, ipc.WithSchema(schema), ipc.WithAllocator(pool))
+	if err := w.Write(rec); err != nil {
+		t.Fatalf("write ipc: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close ipc: %v", err)
+	}
+	return buf.Bytes(), []query.ExecResponseRowType{{Name: "n", Type: "fixed", Scale: 1, Precision: 10, Nullable: true}}
+}
+
+// TestSerializableArrowBatchAppliesConversionOptions proves that the ConversionOptions
+// carried by a serialized batch are actually applied when it is reconstructed and fetched —
+// not merely round-tripped as data. HigherPrecision keeps a scale!=0 NUMBER as Decimal128;
+// without it the value is converted to Float64. This guards against a regression where the
+// reconstructed batch silently converts with default options.
+func TestSerializableArrowBatchAppliesConversionOptions(t *testing.T) {
+	ipcBytes, rowTypes := buildDecimalIPC(t)
+
+	for _, tc := range []struct {
+		name            string
+		higherPrecision bool
+		wantType        arrow.Type
+	}{
+		{name: "higher precision keeps decimal", higherPrecision: true, wantType: arrow.DECIMAL128},
+		{name: "no higher precision casts to float64", higherPrecision: false, wantType: arrow.FLOAT64},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+			defer pool.AssertSize(t, 0)
+
+			s := SerializableArrowBatch{
+				Format:            arrowFormatName,
+				InlineData:        ipcBytes,
+				RowCount:          1,
+				RowTypes:          rowTypes,
+				ConversionOptions: ConversionOptions{HigherPrecision: tc.higherPrecision},
+			}
+			batch, err := s.ToArrowBatch(WithAllocator(pool))
+			if err != nil {
+				t.Fatalf("ToArrowBatch: %v", err)
+			}
+			records, err := batch.Fetch()
+			if err != nil {
+				t.Fatalf("Fetch: %v", err)
+			}
+			if len(*records) == 0 {
+				t.Fatal("expected at least one record")
+			}
+			if got := (*records)[0].Column(0).DataType().ID(); got != tc.wantType {
+				t.Fatalf("column type = %v, want %v", got, tc.wantType)
+			}
+			for _, rec := range *records {
+				rec.Release()
+			}
+		})
+	}
+}

--- a/arrowbatches/serializable_test.go
+++ b/arrowbatches/serializable_test.go
@@ -3,6 +3,7 @@ package arrowbatches
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -116,7 +117,7 @@ func TestSerializableArrowBatchInline(t *testing.T) {
 
 	s := SerializableArrowBatch{
 		Format:       arrowFormatName,
-		InlineData:   ipcBytes,
+		InlineData:   base64.StdEncoding.EncodeToString(ipcBytes),
 		RowCount:     len(fixtureInts),
 		RowTypes:     rowTypes,
 		TimezoneName: "UTC",
@@ -171,7 +172,7 @@ func TestSerializableArrowBatchRemote(t *testing.T) {
 	}
 }
 
-func TestSerializableArrowBatchRemoteRequiresClient(t *testing.T) {
+func TestSerializableArrowBatchRemoteDefaultsHTTPClient(t *testing.T) {
 	_, rowTypes := buildFixtureIPC(t)
 	s := SerializableArrowBatch{
 		Format:   arrowFormatName,
@@ -179,8 +180,13 @@ func TestSerializableArrowBatchRemoteRequiresClient(t *testing.T) {
 		RowCount: len(fixtureInts),
 		RowTypes: rowTypes,
 	}
-	if _, err := s.ToArrowBatch(); err == nil {
-		t.Fatal("expected error when a remote batch has no HTTP client")
+	// No WithHTTPClient: a remote batch is reconstructed successfully using http.DefaultClient.
+	batch, err := s.ToArrowBatch()
+	if err != nil {
+		t.Fatalf("ToArrowBatch without a client should succeed (defaults to http.DefaultClient): %v", err)
+	}
+	if batch == nil {
+		t.Fatal("expected a non-nil batch")
 	}
 }
 
@@ -225,7 +231,7 @@ func TestSerializableArrowBatchJSONRoundTrip(t *testing.T) {
 
 	orig := SerializableArrowBatch{
 		Format:                arrowFormatName,
-		InlineData:            ipcBytes,
+		InlineData:            base64.StdEncoding.EncodeToString(ipcBytes),
 		URL:                   "https://example.invalid/chunk",
 		Headers:               map[string]string{"h": "v"},
 		RowCount:              len(fixtureInts),
@@ -249,7 +255,7 @@ func TestSerializableArrowBatchJSONRoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	if !bytes.Equal(got.InlineData, orig.InlineData) {
+	if got.InlineData != orig.InlineData {
 		t.Fatal("InlineData did not round-trip")
 	}
 	if got.TimestampOption != orig.TimestampOption || got.HigherPrecision != orig.HigherPrecision || got.Utf8Validation != orig.Utf8Validation {
@@ -297,9 +303,10 @@ func TestToSerializableRoundTripInline(t *testing.T) {
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer pool.AssertSize(t, 0)
 
+	inlineB64 := base64.StdEncoding.EncodeToString(ipcBytes)
 	src := SerializableArrowBatch{
 		Format:       arrowFormatName,
-		InlineData:   ipcBytes,
+		InlineData:   inlineB64,
 		RowCount:     len(fixtureInts),
 		RowTypes:     rowTypes,
 		TimezoneName: "UTC",
@@ -313,7 +320,7 @@ func TestToSerializableRoundTripInline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToSerializable: %v", err)
 	}
-	if !bytes.Equal(round.InlineData, ipcBytes) || round.RowCount != len(fixtureInts) {
+	if round.InlineData != inlineB64 || round.RowCount != len(fixtureInts) {
 		t.Fatalf("re-serialized descriptor mismatch: %+v", round)
 	}
 	batch2, err := round.ToArrowBatch(WithAllocator(pool))
@@ -374,7 +381,7 @@ func TestSerializableArrowBatchAppliesConversionOptions(t *testing.T) {
 
 			s := SerializableArrowBatch{
 				Format:            arrowFormatName,
-				InlineData:        ipcBytes,
+				InlineData:        base64.StdEncoding.EncodeToString(ipcBytes),
 				RowCount:          1,
 				RowTypes:          rowTypes,
 				ConversionOptions: ConversionOptions{HigherPrecision: tc.higherPrecision},

--- a/arrowbatches/serialization_integration_test.go
+++ b/arrowbatches/serialization_integration_test.go
@@ -1,0 +1,168 @@
+package arrowbatches
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	sf "github.com/snowflakedb/gosnowflake/v2"
+)
+
+// fetchValueStrings fetches all records of a batch and returns their values rendered
+// as strings (rows x cols), releasing the records afterwards.
+func fetchValueStrings(t *testing.T, batch *ArrowBatch) [][]string {
+	t.Helper()
+	records, err := batch.Fetch()
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	var out [][]string
+	for _, rec := range *records {
+		nCols := int(rec.NumCols())
+		for r := 0; r < int(rec.NumRows()); r++ {
+			row := make([]string, nCols)
+			for c := range nCols {
+				row[c] = rec.Column(c).ValueStr(r)
+			}
+			out = append(out, row)
+		}
+		rec.Release()
+	}
+	return out
+}
+
+// roundTrip serializes a batch, JSON-encodes and decodes it (simulating shipping to
+// another machine), and reconstructs it with a fresh HTTP client that has no Snowflake
+// connection — mimicking a distributed-fetch worker.
+func roundTrip(t *testing.T, s SerializableArrowBatch, pool memory.Allocator) *ArrowBatch {
+	t.Helper()
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded SerializableArrowBatch
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	batch, err := decoded.ToArrowBatch(WithHTTPClient(&http.Client{}), WithAllocator(pool))
+	if err != nil {
+		t.Fatalf("ToArrowBatch: %v", err)
+	}
+	return batch
+}
+
+func assertEqualValues(t *testing.T, want, got [][]string, batchIdx int) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("batch %d: row count mismatch: direct=%d reconstructed=%d", batchIdx, len(want), len(got))
+	}
+	for r := range want {
+		if len(want[r]) != len(got[r]) {
+			t.Fatalf("batch %d row %d: col count mismatch: %d vs %d", batchIdx, r, len(want[r]), len(got[r]))
+		}
+		for c := range want[r] {
+			if want[r][c] != got[r][c] {
+				t.Fatalf("batch %d row %d col %d: %q vs %q", batchIdx, r, c, want[r][c], got[r][c])
+			}
+		}
+	}
+}
+
+// TestSerializableArrowBatchesDistributedRoundTrip exercises the full producer->worker
+// path against a live account: a result large enough to yield an inline first batch and
+// at least one downloaded chunk is serialized, JSON round-tripped, and re-fetched with a
+// connection-less HTTP client; the reconstructed values must match a direct Fetch.
+func TestSerializableArrowBatchesDistributedRoundTrip(t *testing.T) {
+	numRows := 100000
+	directPool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer directPool.AssertSize(t, 0)
+	workerPool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer workerPool.AssertSize(t, 0)
+
+	ctx := sf.WithArrowAllocator(WithArrowBatches(context.Background()), directPool)
+	query := fmt.Sprintf(
+		"SELECT SEQ8() AS n, RANDSTR(200, RANDOM()) AS s FROM TABLE(GENERATOR(ROWCOUNT=>%d))", numRows)
+	sfRows, cleanup := queryRawRows(ctx, t, query)
+	defer cleanup()
+
+	batches, err := GetArrowBatches(sfRows)
+	if err != nil {
+		t.Fatalf("GetArrowBatches failed: %v", err)
+	}
+	if len(batches) == 0 {
+		t.Fatal("expected at least one batch")
+	}
+	t.Logf("result produced %d batches", len(batches))
+
+	// Serialize every batch before fetching any (descriptor is captured up front).
+	serialized := make([]SerializableArrowBatch, len(batches))
+	for i, b := range batches {
+		s, err := b.ToSerializable()
+		if err != nil {
+			t.Fatalf("ToSerializable batch %d: %v", i, err)
+		}
+		serialized[i] = s
+	}
+
+	total := 0
+	var sum int64
+	for i, b := range batches {
+		direct := fetchValueStrings(t, b)
+		recon := fetchValueStrings(t, roundTrip(t, serialized[i], workerPool))
+		assertEqualValues(t, direct, recon, i)
+
+		for _, row := range recon {
+			total++
+			var n int64
+			if _, err := fmt.Sscan(row[0], &n); err != nil {
+				t.Fatalf("parsing column n %q: %v", row[0], err)
+			}
+			sum += n
+		}
+	}
+
+	if total != numRows {
+		t.Fatalf("row count mismatch: expected %d, got %d", numRows, total)
+	}
+	// SEQ8() yields 0..numRows-1, so the sum is deterministic.
+	wantSum := int64(numRows) * int64(numRows-1) / 2
+	if sum != wantSum {
+		t.Fatalf("value integrity check failed: sum=%d, want %d", sum, wantSum)
+	}
+}
+
+// TestSerializableArrowBatchStructuredType confirms structured/nested types survive the
+// serialize -> reconstruct -> fetch path (the row-type Fields drive the transform).
+func TestSerializableArrowBatchStructuredType(t *testing.T) {
+	directPool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer directPool.AssertSize(t, 0)
+	workerPool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer workerPool.AssertSize(t, 0)
+
+	ctx := sf.WithArrowAllocator(WithArrowBatches(context.Background()), directPool)
+	query := "SELECT 1 AS n, {'s': 'some string', 'i': 42}::OBJECT(s VARCHAR, i INTEGER) AS o"
+	sfRows, cleanup := queryRawRows(ctx, t, query)
+	defer cleanup()
+
+	batches, err := GetArrowBatches(sfRows)
+	if err != nil {
+		t.Fatalf("GetArrowBatches failed: %v", err)
+	}
+	if len(batches) == 0 {
+		t.Fatal("expected at least one batch")
+	}
+
+	for i, b := range batches {
+		s, err := b.ToSerializable()
+		if err != nil {
+			t.Fatalf("ToSerializable batch %d: %v", i, err)
+		}
+		direct := fetchValueStrings(t, b)
+		recon := fetchValueStrings(t, roundTrip(t, s, workerPool))
+		assertEqualValues(t, direct, recon, i)
+	}
+}

--- a/chunk_downloader.go
+++ b/chunk_downloader.go
@@ -10,6 +10,7 @@ import (
 	errors2 "github.com/snowflakedb/gosnowflake/v2/internal/errors"
 	"github.com/snowflakedb/gosnowflake/v2/internal/query"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -407,18 +408,27 @@ func downloadChunk(ctx context.Context, scd *snowflakeChunkDownloader, idx int) 
 	logger.Debugf("“Processed %v chunk %v out of %v. It took %v ms. Chunk size: %v, rows: %v”.", scd.getQueryResultFormat(), idx+1, len(scd.ChunkMetas), elapsedTime, scd.ChunkMetas[idx].UncompressedSize, scd.ChunkMetas[idx].RowCount)
 }
 
-func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx int) error {
+// chunkDownloadHeaders builds the HTTP headers used to fetch a result chunk. If
+// chunkHeader is non-empty it is used directly (e.g. GCS/Azure); otherwise the S3
+// SSE-C headers carrying the query result master key (qrmk) are used, so cloud
+// storage decrypts the chunk server-side. This is the single source of truth for
+// chunk headers, shared by the live download path and GetArrowBatches (which embeds
+// the same headers into a serializable ChunkDescriptor).
+func chunkDownloadHeaders(chunkHeader map[string]string, qrmk string) map[string]string {
 	headers := make(map[string]string)
-	if len(scd.ChunkHeader) > 0 {
-		logger.WithContext(ctx).Debug("chunk header is provided.")
-		for k, v := range scd.ChunkHeader {
-			logger.WithContext(ctx).Debugf("adding header: %v, value: %v", k, v)
-
-			headers[k] = v
-		}
+	if len(chunkHeader) > 0 {
+		maps.Copy(headers, chunkHeader)
 	} else {
 		headers[headerSseCAlgorithm] = headerSseCAes
-		headers[headerSseCKey] = scd.Qrmk
+		headers[headerSseCKey] = qrmk
+	}
+	return headers
+}
+
+func downloadChunkHelper(ctx context.Context, scd *snowflakeChunkDownloader, idx int) error {
+	headers := chunkDownloadHeaders(scd.ChunkHeader, scd.Qrmk)
+	if len(scd.ChunkHeader) > 0 {
+		logger.WithContext(ctx).Debug("chunk header is provided.")
 	}
 
 	resp, err := scd.FuncGet(ctx, scd.sc, scd.ChunkMetas[idx].URL, headers, scd.sc.rest.RequestTimeout)

--- a/cmd/arrow/serializablebatches/.gitignore
+++ b/cmd/arrow/serializablebatches/.gitignore
@@ -1,0 +1,1 @@
+serializable_batches

--- a/cmd/arrow/serializablebatches/Makefile
+++ b/cmd/arrow/serializablebatches/Makefile
@@ -1,0 +1,16 @@
+include ../../../gosnowflake.mak
+CMD_TARGET=serializable_batches
+
+## Install
+install: cinstall
+
+## Run
+run: crun
+
+## Lint
+lint: clint
+
+## Format source codes
+fmt: cfmt
+
+.PHONY: install run lint fmt

--- a/cmd/arrow/serializablebatches/serializable_batches.go
+++ b/cmd/arrow/serializablebatches/serializable_batches.go
@@ -1,0 +1,161 @@
+// This example demonstrates distributed fetch of Arrow batches.
+//
+// A "producer" runs a query and obtains ArrowBatch handles, converts each to a
+// SerializableArrowBatch, and JSON-encodes it. The encoded bytes could be shipped to
+// other machines (e.g. Spark/Hadoop workers). Here we simulate the workers in-process:
+// each worker decodes a descriptor and fetches its chunk using a plain *http.Client with
+// NO Snowflake connection — the presigned chunk URL and SSE-C headers are all it needs.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	sf "github.com/snowflakedb/gosnowflake/v2"
+	"github.com/snowflakedb/gosnowflake/v2/arrowbatches"
+)
+
+func main() {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	cfg, err := sf.GetConfigFromEnv([]*sf.ConfigParam{
+		{Name: "Account", EnvName: "SNOWFLAKE_TEST_ACCOUNT", FailOnMissing: true},
+		{Name: "User", EnvName: "SNOWFLAKE_TEST_USER", FailOnMissing: true},
+		{Name: "Password", EnvName: "SNOWFLAKE_TEST_PASSWORD", FailOnMissing: true},
+		{Name: "Host", EnvName: "SNOWFLAKE_TEST_HOST", FailOnMissing: false},
+		{Name: "Port", EnvName: "SNOWFLAKE_TEST_PORT", FailOnMissing: false},
+		{Name: "Protocol", EnvName: "SNOWFLAKE_TEST_PROTOCOL", FailOnMissing: false},
+		{Name: "Warehouse", EnvName: "SNOWFLAKE_TEST_WAREHOUSE", FailOnMissing: false},
+	})
+	if err != nil {
+		log.Fatalf("failed to create Config, err: %v", err)
+	}
+
+	dsn, err := sf.DSN(cfg)
+	if err != nil {
+		log.Fatalf("failed to create DSN from Config: %v, err: %v", cfg, err)
+	}
+
+	db, err := sql.Open("snowflake", dsn)
+	if err != nil {
+		log.Fatalf("failed to connect. %v, err: %v", dsn, err)
+	}
+
+	// ---- Producer: run the query and serialize the batches ----
+	descriptors := produce(db)
+	fmt.Printf("producer serialized %d batches\n", len(descriptors))
+
+	// ---- Close the Snowflake connection entirely ----
+	// The workers below fetch chunks with no Snowflake session at all — only the serialized
+	// descriptors and a plain HTTP client. Closing the DB here makes that independence
+	// explicit: everything after this point runs without a live connection.
+	if err := db.Close(); err != nil {
+		log.Fatalf("failed to close db: %v", err)
+	}
+
+	// ---- Ship the descriptors (here: just the encoded bytes) ----
+	// In a real deployment these bytes would be sent to remote workers. NOTE: a descriptor
+	// embeds the presigned URL and SSE-C decryption key, so treat it as a credential and
+	// send it only over secure channels. Presigned URLs also expire after a few hours.
+
+	// ---- Workers: reconstruct and fetch, with no Snowflake connection ----
+	totalRows := consume(descriptors)
+	fmt.Printf("workers fetched %d rows in total\n", totalRows)
+}
+
+// produce runs a query in arrow-batches mode and returns each batch as JSON-encoded
+// SerializableArrowBatch bytes.
+func produce(db *sql.DB) [][]byte {
+	ctx := arrowbatches.WithArrowBatches(context.Background())
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatalf("cannot create a connection from the pool. err: %v", err)
+	}
+	defer conn.Close()
+
+	query := "SELECT SEQ8() AS n, RANDSTR(200, RANDOM()) AS s FROM TABLE(GENERATOR(ROWCOUNT=>100000))"
+	var rows driver.Rows
+	if err = conn.Raw(func(x any) error {
+		rows, err = x.(driver.QueryerContext).QueryContext(ctx, query, nil)
+		return err
+	}); err != nil {
+		log.Fatalf("unable to run the query. err: %v", err)
+	}
+	defer rows.Close()
+
+	batches, err := arrowbatches.GetArrowBatches(rows.(sf.SnowflakeRows))
+	if err != nil {
+		log.Fatalf("unable to get arrow batches. err: %v", err)
+	}
+
+	descriptors := make([][]byte, len(batches))
+	for i, b := range batches {
+		s, err := b.ToSerializable()
+		if err != nil {
+			log.Fatalf("unable to serialize batch %d. err: %v", i, err)
+		}
+		data, err := json.Marshal(s)
+		if err != nil {
+			log.Fatalf("unable to marshal batch %d. err: %v", i, err)
+		}
+		descriptors[i] = data
+	}
+	return descriptors
+}
+
+// consume simulates distributed workers: each decodes a descriptor and fetches its chunk
+// using a fresh HTTP client, with no Snowflake session.
+func consume(descriptors [][]byte) int64 {
+	pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+
+	var total int64
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i, descriptor := range descriptors {
+		wg.Add(1)
+		go func(workerID int, descriptor []byte) {
+			defer wg.Done()
+
+			var s arrowbatches.SerializableArrowBatch
+			if err := json.Unmarshal(descriptor, &s); err != nil {
+				log.Fatalf("worker %d: unmarshal failed: %v", workerID, err)
+			}
+			batch, err := s.ToArrowBatch(
+				arrowbatches.WithHTTPClient(&http.Client{}),
+				arrowbatches.WithAllocator(pool),
+			)
+			if err != nil {
+				log.Fatalf("worker %d: ToArrowBatch failed: %v", workerID, err)
+			}
+			records, err := batch.Fetch()
+			if err != nil {
+				log.Fatalf("worker %d: Fetch failed: %v", workerID, err)
+			}
+			var rows int64
+			for _, rec := range *records {
+				rows += rec.NumRows()
+				rec.Release()
+			}
+			mu.Lock()
+			total += rows
+			mu.Unlock()
+		}(i, descriptor)
+	}
+	wg.Wait()
+
+	if pool.CurrentAlloc() != 0 {
+		fmt.Printf("Memory leak detected: %d bytes still allocated\n", pool.CurrentAlloc())
+	}
+	return total
+}

--- a/doc.go
+++ b/doc.go
@@ -931,6 +931,37 @@ WHen using NUMBERs with non zero scale, the value is returned as an integer type
 Example. When we have a 123.45 value that comes from NUMBER(9, 4), it will be represented as 1234500 with scale equal to 4. It is a client responsibility to interpret it correctly.
 Also - see limitations section above.
 
+How to serialize Arrow batches for distributed fetch:
+
+An ArrowBatch is a live handle bound to the connection that produced it, so it cannot be
+shipped to another process or machine directly. To distribute the download of a large result
+across workers (e.g. Spark/Hadoop), convert each batch to a serializable descriptor:
+
+	batches, _ := arrowbatches.GetArrowBatches(rows.(sf.SnowflakeRows))
+	for _, b := range batches {
+		s, _ := b.ToSerializable()   // call before Fetch
+		data, _ := json.Marshal(s)   // ship `data` to a worker
+	}
+
+A worker reconstructs the batch and fetches it with its own HTTP client — no Snowflake
+connection is required, because the chunk URL is presigned and any decryption is performed
+server-side by cloud storage using the SSE-C key carried in the descriptor's headers:
+
+	var s arrowbatches.SerializableArrowBatch
+	json.Unmarshal(data, &s)
+	batch, _ := s.ToArrowBatch(arrowbatches.WithHTTPClient(&http.Client{}))
+	records, _ := batch.Fetch()
+
+See the cmd/arrow/serializablebatches example. Two important caveats:
+
+ 1. Security: a remote descriptor embeds the presigned URL (a bearer capability) and the
+    SSE-C decryption key in its headers. Treat a serialized batch as a credential and transmit
+    it only over secure channels.
+ 2. Expiry: presigned URLs are valid only for a server-controlled window (typically a few
+    hours). A remote descriptor must be shipped and fetched within it. The first (inline)
+    batch embeds its data and never expires. Named timezones with DST require tzdata on the
+    worker for full fidelity; fixed offsets are always preserved.
+
 How to handle JSON responses in Arrow batches:
 
 Due to technical limitations Snowflake backend may return JSON even if client expects Arrow.

--- a/internal/arrow/arrow.go
+++ b/internal/arrow/arrow.go
@@ -103,13 +103,32 @@ func HigherPrecisionEnabled(ctx context.Context) bool {
 	return ok && d
 }
 
+// ChunkDescriptor holds the portable, serializable information needed to fetch a
+// single result chunk without a live Snowflake connection. Either InlineData is set
+// (the first batch, whose Arrow IPC bytes are embedded in the query response) or URL
+// and Headers point at a presigned cloud-storage object.
+//
+// Headers may carry the SSE-C decryption key (Qrmk); treat a ChunkDescriptor as
+// sensitive. Presigned URLs expire (server-controlled, typically a few hours).
+type ChunkDescriptor struct {
+	URL              string
+	Headers          map[string]string
+	InlineData       []byte
+	UncompressedSize int64
+}
+
 // BatchRaw holds raw (untransformed) arrow records for a single batch.
+//
+// Records/Download are live-handle state used within the same process. Descriptor
+// holds the portable fetch information used to serialize the batch for distributed
+// fetch (see the arrowbatches sub-package).
 type BatchRaw struct {
-	Records  *[]arrow.Record
-	Index    int
-	RowCount int
-	Location *time.Location
-	Download func(ctx context.Context) (*[]arrow.Record, int, error)
+	Records    *[]arrow.Record
+	Index      int
+	RowCount   int
+	Location   *time.Location
+	Download   func(ctx context.Context) (*[]arrow.Record, int, error)
+	Descriptor ChunkDescriptor
 }
 
 // BatchDataInfo contains all information needed to build arrow batches.

--- a/internal/arrow/arrow.go
+++ b/internal/arrow/arrow.go
@@ -104,16 +104,20 @@ func HigherPrecisionEnabled(ctx context.Context) bool {
 }
 
 // ChunkDescriptor holds the portable, serializable information needed to fetch a
-// single result chunk without a live Snowflake connection. Either InlineData is set
-// (the first batch, whose Arrow IPC bytes are embedded in the query response) or URL
-// and Headers point at a presigned cloud-storage object.
+// single result chunk without a live Snowflake connection. Either InlineDataBase64 is set
+// (the first batch, whose Arrow IPC bytes are embedded base64-encoded in the query
+// response) or URL and Headers point at a presigned cloud-storage object.
+//
+// InlineDataBase64 is kept as the server's base64 string and decoded only when the batch is
+// materialized (on the worker), avoiding a needless decode/re-encode round trip on the
+// producer.
 //
 // Headers may carry the SSE-C decryption key (Qrmk); treat a ChunkDescriptor as
 // sensitive. Presigned URLs expire (server-controlled, typically a few hours).
 type ChunkDescriptor struct {
 	URL              string
 	Headers          map[string]string
-	InlineData       []byte
+	InlineDataBase64 string
 	UncompressedSize int64
 }
 

--- a/internal/arrow/download.go
+++ b/internal/arrow/download.go
@@ -1,0 +1,135 @@
+package arrow
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+)
+
+// errorBodyLimit bounds how much of a non-200 response body is read for error messages.
+const errorBodyLimit = 4096
+
+// chunkStream adapts an HTTP response body (optionally gzip-decompressed) into an
+// io.ReadCloser whose Close releases both the gzip reader and the underlying body.
+type chunkStream struct {
+	r    io.Reader
+	gz   *gzip.Reader
+	body io.ReadCloser
+}
+
+func (c *chunkStream) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+func (c *chunkStream) Close() error {
+	var err error
+	if c.gz != nil {
+		err = c.gz.Close()
+	}
+	if bodyErr := c.body.Close(); bodyErr != nil && err == nil {
+		err = bodyErr
+	}
+	return err
+}
+
+// OpenChunkStream performs an HTTP GET against a presigned result-chunk URL and returns
+// a reader over the (gzip-decompressed if needed) payload. The provided client is used
+// as-is: request cancellation and timeouts come from ctx and the client's own settings.
+//
+// No Snowflake session is required — the URL is presigned and any decryption is performed
+// server-side by cloud storage using the SSE-C key passed in headers. The caller must
+// Close the returned stream.
+func OpenChunkStream(ctx context.Context, client *http.Client, url string, headers map[string]string) (io.ReadCloser, error) {
+	if client == nil {
+		return nil, fmt.Errorf("arrow: no http client provided for chunk download")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("arrow: creating chunk request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("arrow: fetching chunk: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		return nil, fmt.Errorf("arrow: failed to get chunk: HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+	}
+
+	bufStream := bufio.NewReader(resp.Body)
+	// Peek is best-effort: a short or empty payload simply skips gzip detection and lets
+	// the IPC reader surface any real decode error.
+	magic, _ := bufStream.Peek(2)
+	cs := &chunkStream{body: resp.Body}
+	if len(magic) == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+		gz, err := gzip.NewReader(bufStream)
+		if err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("arrow: creating gzip reader: %w", err)
+		}
+		cs.gz = gz
+		cs.r = gz
+	} else {
+		cs.r = bufStream
+	}
+	return cs, nil
+}
+
+// DecodeIPCRecords reads all Arrow record batches from an IPC stream. Returned records are
+// retained and must be released by the caller. On error, any records already read are released.
+//
+// Options are passed through to ipc.NewReader; in particular ipc.WithAllocator controls the
+// memory allocator. When none is provided the Arrow default allocator is used.
+func DecodeIPCRecords(r io.Reader, opts ...ipc.Option) (*[]arrow.Record, int, error) {
+	reader, err := ipc.NewReader(r, opts...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("arrow: creating ipc reader: %w", err)
+	}
+	defer reader.Release()
+
+	var records []arrow.Record
+	rowCount := 0
+	for reader.Next() {
+		rec := reader.Record()
+		rec.Retain()
+		records = append(records, rec)
+		rowCount += int(rec.NumRows())
+	}
+	if err := reader.Err(); err != nil {
+		for _, rec := range records {
+			rec.Release()
+		}
+		return nil, 0, fmt.Errorf("arrow: reading ipc records: %w", err)
+	}
+	return &records, rowCount, nil
+}
+
+// DownloadBatchRecords resolves a single batch, described by desc, to its raw (untransformed)
+// Arrow records. If desc.InlineData is set it is decoded directly; otherwise the chunk is
+// downloaded from desc.URL using the injected client. Options are passed through to the IPC
+// reader (e.g. ipc.WithAllocator). The returned records are retained and must be released by
+// the caller (ArrowBatch.Fetch does this after transforming them).
+func DownloadBatchRecords(ctx context.Context, client *http.Client, desc ChunkDescriptor, opts ...ipc.Option) (*[]arrow.Record, int, error) {
+	if len(desc.InlineData) > 0 {
+		return DecodeIPCRecords(bytes.NewReader(desc.InlineData), opts...)
+	}
+	if desc.URL == "" {
+		empty := make([]arrow.Record, 0)
+		return &empty, 0, nil
+	}
+	stream, err := OpenChunkStream(ctx, client, desc.URL, desc.Headers)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = stream.Close() }()
+	return DecodeIPCRecords(stream, opts...)
+}

--- a/internal/arrow/download.go
+++ b/internal/arrow/download.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -119,8 +120,12 @@ func DecodeIPCRecords(r io.Reader, opts ...ipc.Option) (*[]arrow.Record, int, er
 // reader (e.g. ipc.WithAllocator). The returned records are retained and must be released by
 // the caller (ArrowBatch.Fetch does this after transforming them).
 func DownloadBatchRecords(ctx context.Context, client *http.Client, desc ChunkDescriptor, opts ...ipc.Option) (*[]arrow.Record, int, error) {
-	if len(desc.InlineData) > 0 {
-		return DecodeIPCRecords(bytes.NewReader(desc.InlineData), opts...)
+	if desc.InlineDataBase64 != "" {
+		inline, err := base64.StdEncoding.DecodeString(desc.InlineDataBase64)
+		if err != nil {
+			return nil, 0, fmt.Errorf("arrow: decoding inline batch base64: %w", err)
+		}
+		return DecodeIPCRecords(bytes.NewReader(inline), opts...)
 	}
 	if desc.URL == "" {
 		empty := make([]arrow.Record, 0)

--- a/rows.go
+++ b/rows.go
@@ -3,6 +3,7 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
+	"encoding/base64"
 	"github.com/snowflakedb/gosnowflake/v2/internal/errors"
 	"io"
 	"reflect"
@@ -201,12 +202,27 @@ func (rows *snowflakeRows) GetArrowBatches() (*ia.BatchDataInfo, error) {
 			if scd.firstBatchRaw != nil {
 				capturedIdx = i - 1
 			}
+			chunkMeta := scd.ChunkMetas[capturedIdx]
+			batch.Descriptor = ia.ChunkDescriptor{
+				URL:              chunkMeta.URL,
+				Headers:          chunkDownloadHeaders(scd.ChunkHeader, scd.Qrmk),
+				UncompressedSize: chunkMeta.UncompressedSize,
+			}
 			batch.Download = func(ctx context.Context) (*[]arrow.Record, int, error) {
 				if err := scd.FuncDownloadHelper(ctx, scd, capturedIdx); err != nil {
 					return nil, 0, err
 				}
 				actualRaw := scd.rawBatches[capturedIdx]
 				return actualRaw.records, actualRaw.rowCount, nil
+			}
+		} else if scd.RowSet.RowSetBase64 != "" {
+			// The first (inline) batch carries its Arrow IPC bytes in the query
+			// response; embed them verbatim so the batch can be serialized without
+			// re-encoding (there is no IPC writer in the driver).
+			if inlineBytes, err := base64.StdEncoding.DecodeString(scd.RowSet.RowSetBase64); err == nil {
+				batch.Descriptor = ia.ChunkDescriptor{InlineData: inlineBytes}
+			} else {
+				logger.WithContext(scd.ctx).Warnf("failed to decode RowSetBase64 for arrow batch serialization: %v", err)
 			}
 		}
 		batches[i] = batch

--- a/rows.go
+++ b/rows.go
@@ -3,7 +3,6 @@ package gosnowflake
 import (
 	"context"
 	"database/sql/driver"
-	"encoding/base64"
 	"github.com/snowflakedb/gosnowflake/v2/internal/errors"
 	"io"
 	"reflect"
@@ -216,14 +215,11 @@ func (rows *snowflakeRows) GetArrowBatches() (*ia.BatchDataInfo, error) {
 				return actualRaw.records, actualRaw.rowCount, nil
 			}
 		} else if scd.RowSet.RowSetBase64 != "" {
-			// The first (inline) batch carries its Arrow IPC bytes in the query
-			// response; embed them verbatim so the batch can be serialized without
-			// re-encoding (there is no IPC writer in the driver).
-			if inlineBytes, err := base64.StdEncoding.DecodeString(scd.RowSet.RowSetBase64); err == nil {
-				batch.Descriptor = ia.ChunkDescriptor{InlineData: inlineBytes}
-			} else {
-				logger.WithContext(scd.ctx).Warnf("failed to decode RowSetBase64 for arrow batch serialization: %v", err)
-			}
+			// The first (inline) batch carries its Arrow IPC bytes base64-encoded in the
+			// query response. Keep the server's base64 string verbatim; it is decoded only
+			// if and when the batch is materialized on a worker (avoiding a decode/re-encode
+			// round trip here, since this data is used only for serialization).
+			batch.Descriptor = ia.ChunkDescriptor{InlineDataBase64: scd.RowSet.RowSetBase64}
 		}
 		batches[i] = batch
 	}


### PR DESCRIPTION
### TL;DR

Adds `SerializableArrowBatch` with `ArrowBatch.ToSerializable` and `SerializableArrowBatch.ToArrowBatch` to enable distributed fetch of Arrow result batches across machines with no Snowflake connection.

### What changed?

- Introduced `arrowbatches.SerializableArrowBatch`, a portable JSON-serializable descriptor that captures everything needed to fetch a result chunk: the presigned URL, SSE-C headers, inline IPC bytes (for the first batch), row count, column metadata, timezone, and conversion options.
- Added `ArrowBatch.ToSerializable()` to convert a live batch handle into a `SerializableArrowBatch` before fetching.
- Added `SerializableArrowBatch.ToArrowBatch(opts ...Option)` to reconstruct a fully functional `ArrowBatch` on a worker node using only an injected `*http.Client` — no Snowflake session required.
- Extracted `chunkDownloadHeaders` in `chunk_downloader.go` as a shared helper so the same SSE-C/GCS/Azure header logic is used by both the live download path and the serializable descriptor construction.
- Populated `BatchRaw.Descriptor` (a new `ChunkDescriptor` field on `ia.BatchRaw`) in `rows.go` for both remote chunks (URL + headers) and the inline first batch (base64-decoded `RowSetBase64`).
- Added `internal/arrow/download.go` with `OpenChunkStream`, `DecodeIPCRecords`, and `DownloadBatchRecords` — low-level primitives that perform HTTP download and IPC decoding without any driver state, used by the reconstructed batch's `Download` closure.
- Added JSON struct tags to `ConversionOptions` fields so they survive serialization as part of `SerializableArrowBatch`.
- Added a `cmd/arrow/serializablebatches` example demonstrating the full producer → serialize → worker → fetch flow.
- Updated `doc.go` with documentation covering the distributed fetch pattern, security considerations (presigned URLs and SSE-C keys are sensitive), and expiry caveats.

### How to test?

Unit tests in `arrowbatches/serializable_test.go` cover:
- Inline batch round-trip (no HTTP client needed).
- Remote batch download with plain and gzip-compressed payloads, including SSE-C header forwarding.
- Error cases: missing HTTP client for remote batches, expired/403 URLs, unsupported formats.
- Full JSON marshal/unmarshal round-trip including nested `RowTypes` and all `ConversionOptions` flags.
- `loadLocation` behavior for fixed-offset, `Local`, named IANA, and empty timezone names.
- Verification that `ConversionOptions` (e.g. `HigherPrecision`) carried in the serialized form are actually applied during fetch, not just round-tripped as data.

Integration tests in `arrowbatches/serialization_integration_test.go` (require a live account) cover:
- A 100,000-row result serialized, JSON round-tripped, and re-fetched with a connection-less HTTP client, with value and row-count integrity checks.
- Structured/nested column types surviving the serialize → reconstruct → fetch path.

### Why make this change?

Arrow batches returned by `GetArrowBatches` are live handles tied to the Snowflake connection that produced them. Distributed compute frameworks (Spark, Hadoop, etc.) need to partition a large result on a coordinator node and download chunks in parallel on worker nodes that have no Snowflake session. `SerializableArrowBatch` provides the seam for this: the coordinator serializes batch descriptors (which embed presigned URLs and decryption keys), ships them to workers, and each worker fetches its chunk independently using only a standard HTTP client.