### PR TITLE
SNOW-4017183 Add minimum TLS version enforcing propertly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ New features:
 - Added `CleanupTimeout` config option (DSN field `cleanupTimeout`, in seconds) that bounds post-cancellation cleanup (snowflakedb/gosnowflake#1816).
 - Increased CRL disk cache removal delay to 7 days (snowflakedb/gosnowflake#1820).
 - Added option to load private key from `connections.toml` file (snowflakedb/gosnowflake#1822).
-- Added support for Go 1.27, dropped support for Go 1.24 (snowflakedb/gosnowflake#TBD).
+- Added support for Go 1.27, dropped support for Go 1.24 (snowflakedb/gosnowflake#1837).
+- Added `SNOWFLAKE_MIN_TLS_VERSION` environment variable to enforce a minimum TLS version for all connections (snowflakedb/gosnowflake#1840).
 
 Bug fixes:
 - Fixed token cache key collisions for multi-account (shared IdP) and multi-role scenarios by switching to a versioned, SHA256-hashed canonical-JSON key with the token type in the key prefix, applied uniformly across keyring (macOS/Windows) and file (Linux) backends; also replaced the bag-of-fields spec struct with typed token-spec types (`hostUserTokenSpec` for MFA/ID flows, `oauthTokenSpec` for OAuth flows) so each spec validates and serializes only its own fields (snowflakedb/gosnowflake#1817, snowflakedb/gosnowflake#1821).

--- a/internal/config/min_tls_version.go
+++ b/internal/config/min_tls_version.go
@@ -4,41 +4,42 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"strings"
 )
 
 const envVarMinTLSVersion = "SNOWFLAKE_MIN_TLS_VERSION"
 
 // GetMinTLSVersion reads and parses the SNOWFLAKE_MIN_TLS_VERSION environment variable.
-// Returns 0 if not set or invalid. Valid values: "1.0", "1.1", "1.2", "1.3".
+// Returns 0 if not set or invalid. Valid values: "1.2", "1.3", "TLSv1.2", "TLSv1.3" (case-insensitive, trimmed).
+// TLS 1.0 and 1.1 are not supported as Snowflake requires TLS 1.2 or higher.
 func GetMinTLSVersion() (uint16, error) {
 	value := os.Getenv(envVarMinTLSVersion)
 	if value == "" {
 		return 0, nil
 	}
 
+	// Normalize: trim whitespace and convert to lowercase
+	value = strings.ToLower(strings.TrimSpace(value))
+
 	switch value {
-	case "1.0":
-		return tls.VersionTLS10, nil
-	case "1.1":
-		return tls.VersionTLS11, nil
-	case "1.2":
+	case "1.2", "tlsv1.2":
 		return tls.VersionTLS12, nil
-	case "1.3":
+	case "1.3", "tlsv1.3":
 		return tls.VersionTLS13, nil
 	default:
-		return 0, fmt.Errorf("invalid %s value: %s. Valid values are: 1.0, 1.1, 1.2, 1.3", envVarMinTLSVersion, value)
+		return 0, fmt.Errorf("invalid %s value: %s. Valid values are: 1.2, 1.3, TLSv1.2, TLSv1.3", envVarMinTLSVersion, value)
 	}
 }
 
 // ApplyMinTLSVersion applies the minimum TLS version from environment variable to the given tls.Config.
-// This enforces a global security policy that cannot be bypassed by custom tls.Config.
+// This enforces a global security policy by taking the maximum of the existing MinVersion and the env var value.
 func ApplyMinTLSVersion(tlsConfig *tls.Config) (*tls.Config, error) {
-	minVersion, err := GetMinTLSVersion()
+	envMinVersion, err := GetMinTLSVersion()
 	if err != nil {
 		return nil, err
 	}
 
-	if minVersion == 0 {
+	if envMinVersion == 0 {
 		// No minimum version set
 		return tlsConfig, nil
 	}
@@ -47,20 +48,32 @@ func ApplyMinTLSVersion(tlsConfig *tls.Config) (*tls.Config, error) {
 		tlsConfig = &tls.Config{}
 	}
 
-	// Always set MinVersion when the env var is set, even if tlsConfig already has one
-	// This ensures the environment variable acts as a security policy enforcement
-	tlsConfig.MinVersion = minVersion
-	logger.Infof("Applied minimum TLS version from %s: %s", envVarMinTLSVersion, getTLSVersionName(minVersion))
+	// Use the maximum of existing MinVersion and env var value
+	// This ensures the env var sets a floor, but respects higher values already configured
+	if tlsConfig.MinVersion < envMinVersion {
+		logger.Debugf("Raising minimum TLS version from %s to %s (from %s)",
+			getTLSVersionName(tlsConfig.MinVersion),
+			getTLSVersionName(envMinVersion),
+			envVarMinTLSVersion)
+		tlsConfig.MinVersion = envMinVersion
+	} else if tlsConfig.MinVersion > 0 {
+		logger.Debugf("Keeping existing minimum TLS version %s (>= %s from %s)",
+			getTLSVersionName(tlsConfig.MinVersion),
+			getTLSVersionName(envMinVersion),
+			envVarMinTLSVersion)
+	} else {
+		// MinVersion was 0 (default), set it to env var value
+		logger.Debugf("Setting minimum TLS version to %s (from %s)",
+			getTLSVersionName(envMinVersion),
+			envVarMinTLSVersion)
+		tlsConfig.MinVersion = envMinVersion
+	}
 
 	return tlsConfig, nil
 }
 
 func getTLSVersionName(version uint16) string {
 	switch version {
-	case tls.VersionTLS10:
-		return "1.0"
-	case tls.VersionTLS11:
-		return "1.1"
 	case tls.VersionTLS12:
 		return "1.2"
 	case tls.VersionTLS13:

--- a/internal/config/min_tls_version.go
+++ b/internal/config/min_tls_version.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+)
+
+const envVarMinTLSVersion = "SNOWFLAKE_MIN_TLS_VERSION"
+
+// GetMinTLSVersion reads and parses the SNOWFLAKE_MIN_TLS_VERSION environment variable.
+// Returns 0 if not set or invalid. Valid values: "1.0", "1.1", "1.2", "1.3".
+func GetMinTLSVersion() (uint16, error) {
+	value := os.Getenv(envVarMinTLSVersion)
+	if value == "" {
+		return 0, nil
+	}
+
+	switch value {
+	case "1.0":
+		return tls.VersionTLS10, nil
+	case "1.1":
+		return tls.VersionTLS11, nil
+	case "1.2":
+		return tls.VersionTLS12, nil
+	case "1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("invalid %s value: %s. Valid values are: 1.0, 1.1, 1.2, 1.3", envVarMinTLSVersion, value)
+	}
+}
+
+// ApplyMinTLSVersion applies the minimum TLS version from environment variable to the given tls.Config.
+// This enforces a global security policy that cannot be bypassed by custom tls.Config.
+func ApplyMinTLSVersion(tlsConfig *tls.Config) (*tls.Config, error) {
+	minVersion, err := GetMinTLSVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	if minVersion == 0 {
+		// No minimum version set
+		return tlsConfig, nil
+	}
+
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+
+	// Always set MinVersion when the env var is set, even if tlsConfig already has one
+	// This ensures the environment variable acts as a security policy enforcement
+	tlsConfig.MinVersion = minVersion
+	logger.Infof("Applied minimum TLS version from %s: %s", envVarMinTLSVersion, getTLSVersionName(minVersion))
+
+	return tlsConfig, nil
+}
+
+func getTLSVersionName(version uint16) string {
+	switch version {
+	case tls.VersionTLS10:
+		return "1.0"
+	case tls.VersionTLS11:
+		return "1.1"
+	case tls.VersionTLS12:
+		return "1.2"
+	case tls.VersionTLS13:
+		return "1.3"
+	default:
+		return fmt.Sprintf("unknown (0x%04x)", version)
+	}
+}

--- a/internal/config/min_tls_version_test.go
+++ b/internal/config/min_tls_version_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestGetMinTLSVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected uint16
+		wantErr  bool
+	}{
+		{
+			name:     "TLS 1.0",
+			envValue: "1.0",
+			expected: tls.VersionTLS10,
+			wantErr:  false,
+		},
+		{
+			name:     "TLS 1.1",
+			envValue: "1.1",
+			expected: tls.VersionTLS11,
+			wantErr:  false,
+		},
+		{
+			name:     "TLS 1.2",
+			envValue: "1.2",
+			expected: tls.VersionTLS12,
+			wantErr:  false,
+		},
+		{
+			name:     "TLS 1.3",
+			envValue: "1.3",
+			expected: tls.VersionTLS13,
+			wantErr:  false,
+		},
+		{
+			name:     "Empty env var",
+			envValue: "",
+			expected: 0,
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid value",
+			envValue: "1.4",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid format",
+			envValue: "invalid",
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				t.Setenv(envVarMinTLSVersion, "")
+			} else {
+				t.Setenv(envVarMinTLSVersion, tt.envValue)
+			}
+
+			got, err := GetMinTLSVersion()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMinTLSVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("GetMinTLSVersion() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyMinTLSVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		envValue   string
+		inputTLS   *tls.Config
+		wantMinVer uint16
+		wantErr    bool
+	}{
+		{
+			name:       "Apply to nil config",
+			envValue:   "1.3",
+			inputTLS:   nil,
+			wantMinVer: tls.VersionTLS13,
+			wantErr:    false,
+		},
+		{
+			name:       "Apply to empty config",
+			envValue:   "1.3",
+			inputTLS:   &tls.Config{},
+			wantMinVer: tls.VersionTLS13,
+			wantErr:    false,
+		},
+		{
+			name:     "Override existing MinVersion",
+			envValue: "1.3",
+			inputTLS: &tls.Config{
+				MinVersion: tls.VersionTLS10,
+			},
+			wantMinVer: tls.VersionTLS13,
+			wantErr:    false,
+		},
+		{
+			name:     "No env var set",
+			envValue: "",
+			inputTLS: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+			wantMinVer: tls.VersionTLS12,
+			wantErr:    false,
+		},
+		{
+			name:       "Invalid env value",
+			envValue:   "invalid",
+			inputTLS:   &tls.Config{},
+			wantMinVer: 0,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue == "" {
+				t.Setenv(envVarMinTLSVersion, "")
+			} else {
+				t.Setenv(envVarMinTLSVersion, tt.envValue)
+			}
+
+			got, err := ApplyMinTLSVersion(tt.inputTLS)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ApplyMinTLSVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				if got.MinVersion != tt.wantMinVer {
+					t.Errorf("ApplyMinTLSVersion() MinVersion = %v, want %v", got.MinVersion, tt.wantMinVer)
+				}
+			}
+		})
+	}
+}
+
+func TestGetTLSVersionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  uint16
+		expected string
+	}{
+		{
+			name:     "TLS 1.0",
+			version:  tls.VersionTLS10,
+			expected: "1.0",
+		},
+		{
+			name:     "TLS 1.1",
+			version:  tls.VersionTLS11,
+			expected: "1.1",
+		},
+		{
+			name:     "TLS 1.2",
+			version:  tls.VersionTLS12,
+			expected: "1.2",
+		},
+		{
+			name:     "TLS 1.3",
+			version:  tls.VersionTLS13,
+			expected: "1.3",
+		},
+		{
+			name:     "Unknown version",
+			version:  0x9999,
+			expected: "unknown (0x9999)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getTLSVersionName(tt.version)
+			if got != tt.expected {
+				t.Errorf("getTLSVersionName() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/config/min_tls_version_test.go
+++ b/internal/config/min_tls_version_test.go
@@ -13,18 +13,6 @@ func TestGetMinTLSVersion(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "TLS 1.0",
-			envValue: "1.0",
-			expected: tls.VersionTLS10,
-			wantErr:  false,
-		},
-		{
-			name:     "TLS 1.1",
-			envValue: "1.1",
-			expected: tls.VersionTLS11,
-			wantErr:  false,
-		},
-		{
 			name:     "TLS 1.2",
 			envValue: "1.2",
 			expected: tls.VersionTLS12,
@@ -37,10 +25,58 @@ func TestGetMinTLSVersion(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "TLSv1.2 format",
+			envValue: "TLSv1.2",
+			expected: tls.VersionTLS12,
+			wantErr:  false,
+		},
+		{
+			name:     "TLSv1.3 format",
+			envValue: "TLSv1.3",
+			expected: tls.VersionTLS13,
+			wantErr:  false,
+		},
+		{
+			name:     "TLSv1.2 lowercase",
+			envValue: "tlsv1.2",
+			expected: tls.VersionTLS12,
+			wantErr:  false,
+		},
+		{
+			name:     "TLSv1.3 mixed case",
+			envValue: "TlSv1.3",
+			expected: tls.VersionTLS13,
+			wantErr:  false,
+		},
+		{
+			name:     "1.2 with whitespace",
+			envValue: "  1.2  ",
+			expected: tls.VersionTLS12,
+			wantErr:  false,
+		},
+		{
+			name:     "TLSv1.3 with whitespace",
+			envValue: " TLSv1.3 ",
+			expected: tls.VersionTLS13,
+			wantErr:  false,
+		},
+		{
 			name:     "Empty env var",
 			envValue: "",
 			expected: 0,
 			wantErr:  false,
+		},
+		{
+			name:     "TLS 1.0 not supported",
+			envValue: "1.0",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "TLS 1.1 not supported",
+			envValue: "1.1",
+			expected: 0,
+			wantErr:  true,
 		},
 		{
 			name:     "Invalid value",
@@ -99,10 +135,19 @@ func TestApplyMinTLSVersion(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:     "Override existing MinVersion",
+			name:     "Raise from lower version",
 			envValue: "1.3",
 			inputTLS: &tls.Config{
-				MinVersion: tls.VersionTLS10,
+				MinVersion: tls.VersionTLS12,
+			},
+			wantMinVer: tls.VersionTLS13,
+			wantErr:    false,
+		},
+		{
+			name:     "Keep higher existing version (ceiling behavior)",
+			envValue: "1.2",
+			inputTLS: &tls.Config{
+				MinVersion: tls.VersionTLS13,
 			},
 			wantMinVer: tls.VersionTLS13,
 			wantErr:    false,
@@ -153,16 +198,6 @@ func TestGetTLSVersionName(t *testing.T) {
 		version  uint16
 		expected string
 	}{
-		{
-			name:     "TLS 1.0",
-			version:  tls.VersionTLS10,
-			expected: "1.0",
-		},
-		{
-			name:     "TLS 1.1",
-			version:  tls.VersionTLS11,
-			expected: "1.1",
-		},
 		{
 			name:     "TLS 1.2",
 			version:  tls.VersionTLS12,

--- a/ocsp.go
+++ b/ocsp.go
@@ -664,9 +664,16 @@ func (ov *ocspValidator) getRevocationStatus(ctx context.Context, subject, issue
 	headers[httpHeaderHost] = hostname
 	timeout := OcspResponderTimeout
 
+	transport, err := newTransportFactory(ov.cfg, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeOCSP))
+	if err != nil {
+		return &ocspStatus{
+			code: ocspFailedComposeRequest,
+			err:  fmt.Errorf("failed to create transport for OCSP request: %w", err),
+		}
+	}
 	ocspClient := &http.Client{
 		Timeout:   timeout,
-		Transport: newTransportFactory(ov.cfg, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeOCSP)),
+		Transport: transport,
 	}
 	ocspRes, ocspResBytes, ocspS := ov.retryOCSP(
 		ctx, ocspClient, http.NewRequest, u, headers, ocspReq, issuer, timeout)
@@ -798,9 +805,14 @@ func (ov *ocspValidator) downloadOCSPCacheServer() {
 
 	logger.Infof("downloading OCSP Cache from server %v", ocspCacheServerURL)
 	timeout := OcspCacheServerTimeout
+	transport, err := newTransportFactory(ov.cfg, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeOCSP))
+	if err != nil {
+		logger.Errorf("failed to create transport for OCSP cache download: %v", err)
+		return
+	}
 	ocspClient := &http.Client{
 		Timeout:   timeout,
-		Transport: newTransportFactory(ov.cfg, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeOCSP)),
+		Transport: transport,
 	}
 	ret, ocspStatus := checkOCSPCacheServer(context.Background(), ocspClient, http.NewRequest, u, timeout)
 	if ocspStatus.code != ocspSuccess {

--- a/transport.go
+++ b/transport.go
@@ -182,6 +182,14 @@ func (tf *transportFactory) createTransport(transportConfig *transportConfig) (h
 	// if user configured a custom Transporter, prioritize that
 	if tf.config.Transporter != nil {
 		logger.Debug("createTransport: using Transporter configured by the user")
+		// If it's an *http.Transport, try to apply MinTLSVersion to its TLS config
+		if httpTransport, ok := tf.config.Transporter.(*http.Transport); ok {
+			var err error
+			httpTransport.TLSClientConfig, err = sfconfig.ApplyMinTLSVersion(httpTransport.TLSClientConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
 		return tf.config.Transporter, nil
 	}
 

--- a/transport.go
+++ b/transport.go
@@ -100,8 +100,16 @@ func (tf *transportFactory) createProxy(transportConfig *transportConfig) func(*
 }
 
 // createBaseTransport creates a base HTTP transport with the given configuration
-func (tf *transportFactory) createBaseTransport(transportConfig *transportConfig, tlsConfig *tls.Config) *http.Transport {
+func (tf *transportFactory) createBaseTransport(transportConfig *transportConfig, tlsConfig *tls.Config) (*http.Transport, error) {
 	logger.Debugf("Create a new Base Transport with transportConfig %v", transportConfig.String())
+
+	// Apply minimum TLS version from environment variable
+	var err error
+	tlsConfig, err = sfconfig.ApplyMinTLSVersion(tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	dialer := &net.Dialer{
 		Timeout:   transportConfig.DialTimeout,
 		KeepAlive: transportConfig.KeepAlive,
@@ -115,7 +123,7 @@ func (tf *transportFactory) createBaseTransport(transportConfig *transportConfig
 		IdleConnTimeout:     cmp.Or(transportConfig.IdleConnTimeout, defaultTransport.IdleConnTimeout),
 		Proxy:               tf.createProxy(transportConfig),
 		DialContext:         dialer.DialContext,
-	}
+	}, nil
 }
 
 // createOCSPTransport creates a transport with OCSP validation
@@ -130,13 +138,13 @@ func (tf *transportFactory) createOCSPTransport(transportConfig *transportConfig
 			VerifyPeerCertificate: ov.verifyPeerCertificateSerial,
 		}
 	}
-	return tf.createBaseTransport(transportConfig, tlsConfig), nil
+	return tf.createBaseTransport(transportConfig, tlsConfig)
 }
 
 // createNoRevocationTransport creates a transport without certificate revocation checking
-func (tf *transportFactory) createNoRevocationTransport(transportConfig *transportConfig) http.RoundTripper {
+func (tf *transportFactory) createNoRevocationTransport(transportConfig *transportConfig) (http.RoundTripper, error) {
 	if tf.config != nil && tf.config.Transporter != nil {
-		return tf.config.Transporter
+		return tf.config.Transporter, nil
 	}
 	return tf.createBaseTransport(transportConfig, nil)
 }
@@ -144,9 +152,13 @@ func (tf *transportFactory) createNoRevocationTransport(transportConfig *transpo
 // createCRLValidator creates a CRL validator
 func (tf *transportFactory) createCRLValidator() (*crlValidator, error) {
 	allowCertificatesWithoutCrlURL := tf.config.CrlAllowCertificatesWithoutCrlURL == ConfigBoolTrue
+	transport, err := tf.createNoRevocationTransport(transportConfigFor(transportTypeCRL))
+	if err != nil {
+		return nil, err
+	}
 	client := &http.Client{
 		Timeout:   cmp.Or(tf.config.CrlHTTPClientTimeout, defaultCrlHTTPClientTimeout),
-		Transport: tf.createNoRevocationTransport(transportConfigFor(transportTypeCRL)),
+		Transport: transport,
 	}
 	return newCrlValidator(
 		tf.config.CertRevocationCheckMode,
@@ -164,7 +176,7 @@ func (tf *transportFactory) createTransport(transportConfig *transportConfig) (h
 	if tf.config == nil {
 		// should never happen in production, only in tests
 		logger.Warn("createTransport: got nil Config, using default one")
-		return tf.createNoRevocationTransport(transportConfig), nil
+		return tf.createNoRevocationTransport(transportConfig)
 	}
 
 	// if user configured a custom Transporter, prioritize that
@@ -197,13 +209,13 @@ func (tf *transportFactory) createTransport(transportConfig *transportConfig) (h
 			}
 		}
 
-		return tf.createBaseTransport(transportConfig, tlsConfig), nil
+		return tf.createBaseTransport(transportConfig, tlsConfig)
 	}
 
 	// Handle no revocation checking path
 	if tf.config.DisableOCSPChecks {
 		logger.Debug("createTransport: skipping OCSP validation")
-		return tf.createNoRevocationTransport(transportConfig), nil
+		return tf.createNoRevocationTransport(transportConfig)
 	}
 
 	logger.Debug("createTransport: will perform OCSP validation")

--- a/transport_min_tls_test.go
+++ b/transport_min_tls_test.go
@@ -1,0 +1,88 @@
+package gosnowflake
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+func TestMinTLSVersionWithCustomTransporter(t *testing.T) {
+	// Set the env var
+	t.Setenv("SNOWFLAKE_MIN_TLS_VERSION", "1.3")
+
+	// Create a custom transport with TLS 1.2
+	customTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+
+	config := &Config{
+		Transporter: customTransport,
+	}
+
+	factory := newTransportFactory(config, nil)
+	transport, err := factory.createTransport(transportConfigFor(transportTypeSnowflake))
+
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport")
+
+	// Verify the TLS config was updated to TLS 1.3 (ceiling behavior)
+	httpTransport, ok := transport.(*http.Transport)
+	assertTrueF(t, ok, "Expected *http.Transport")
+	assertEqualF(t, httpTransport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS13), "Expected TLS 1.3")
+}
+
+func TestMinTLSVersionWithCustomTransporterNoEnvVar(t *testing.T) {
+	// No env var set
+	t.Setenv("SNOWFLAKE_MIN_TLS_VERSION", "")
+
+	// Create a custom transport with TLS 1.2
+	customTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+
+	config := &Config{
+		Transporter: customTransport,
+	}
+
+	factory := newTransportFactory(config, nil)
+	transport, err := factory.createTransport(transportConfigFor(transportTypeSnowflake))
+
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport")
+
+	// Verify the TLS config was NOT changed
+	httpTransport, ok := transport.(*http.Transport)
+	assertTrueF(t, ok, "Expected *http.Transport")
+	assertEqualF(t, httpTransport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12), "Expected TLS 1.2")
+}
+
+func TestMinTLSVersionCeilingBehavior(t *testing.T) {
+	// Set env var to TLS 1.2
+	t.Setenv("SNOWFLAKE_MIN_TLS_VERSION", "1.2")
+
+	// Create a custom transport with TLS 1.3 (higher than env var)
+	customTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		},
+	}
+
+	config := &Config{
+		Transporter: customTransport,
+	}
+
+	factory := newTransportFactory(config, nil)
+	transport, err := factory.createTransport(transportConfigFor(transportTypeSnowflake))
+
+	assertNilF(t, err, "Unexpected error")
+	assertNotNilF(t, transport, "Expected non-nil transport")
+
+	// Verify the TLS config kept TLS 1.3 (ceiling behavior - keep the higher value)
+	httpTransport, ok := transport.(*http.Transport)
+	assertTrueF(t, ok, "Expected *http.Transport")
+	assertEqualF(t, httpTransport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS13), "Expected TLS 1.3 (kept higher value)")
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -2,6 +2,7 @@ package gosnowflake
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -266,5 +267,9 @@ func TestProxyTransportCreation(t *testing.T) {
 }
 
 func createTestNoRevocationTransport() http.RoundTripper {
-	return newTransportFactory(&Config{}, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeSnowflake))
+	transport, err := newTransportFactory(&Config{}, nil).createNoRevocationTransport(defaultTransportConfigs.forTransportType(transportTypeSnowflake))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create test transport: %v", err))
+	}
+	return transport
 }


### PR DESCRIPTION
### TL;DR

Adds support for configuring a minimum TLS version via the `SNOWFLAKE_MIN_TLS_VERSION` environment variable, enforced globally across all HTTP transports.

### What changed?

A new `GetMinTLSVersion` function reads the `SNOWFLAKE_MIN_TLS_VERSION` environment variable and parses it into a TLS version constant. An `ApplyMinTLSVersion` function applies this version as a floor on any `tls.Config`, overriding any previously set `MinVersion` to enforce it as a security policy. Valid values are `1.0`, `1.1`, `1.2`, and `1.3`.

`createBaseTransport` now calls `ApplyMinTLSVersion` before constructing the transport and returns an error if the environment variable contains an invalid value. As a result, `createNoRevocationTransport` and several other transport creation methods now return errors, and their call sites in `ocsp.go` and `transport.go` have been updated to handle those errors appropriately.

### How to test?

- Set `SNOWFLAKE_MIN_TLS_VERSION=1.3` and verify that connections enforce TLS 1.3 as the minimum.
- Set `SNOWFLAKE_MIN_TLS_VERSION=invalid` and verify that transport creation fails with a descriptive error.
- Leave `SNOWFLAKE_MIN_TLS_VERSION` unset and verify existing behavior is unchanged.
- Run the new unit tests in `internal/config/min_tls_version_test.go` covering `GetMinTLSVersion`, `ApplyMinTLSVersion`, and `getTLSVersionName`.

### Why make this change?

Some environments require a minimum TLS version to be enforced as a security policy. This change provides a way to configure that floor at the environment level, ensuring it cannot be bypassed by custom `tls.Config` values set elsewhere in the driver.