### PR TITLE
SNOW-4017185 Fix the region parameter rewriting an explicitly provided host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug fixes:
 - Fixed `GET` from a LOCAL_FS stage downloading 0 files and returning `264011: not implemented`. Cloud downloads were unaffected (snowflakedb/gosnowflake#1810).
 - Fixed `NUMBER` columns with a non-zero scale losing precision: values needing more significant digits than a binary float's mantissa were silently rounded, so `NUMBER(20,10)` holding `1234567890.1234567890` returned `1234567890.1234567889`. The `WithHigherPrecision` path is unchanged and still returns a 64-bit `*big.Float` (snowflakedb/gosnowflake#1835).
 - Fixed proxy configuration for a literal IPv6 `ProxyHost`, which was concatenated into an unbracketed `host:port` and left the proxy URL unparseable (snowflakedb/gosnowflake#TBD).
+- Fixed the `region` parameter rewriting an explicitly provided `host` (e.g. `host=myacct.snowflakecomputing.com` with `region=us-east-1` became `myacct.us-east-1.snowflakecomputing.com`); an explicit host now takes precedence (snowflakedb/gosnowflake#1841).
 
 Internal changes:
 - Migrated from deprecated `github.com/aws/aws-sdk-go-v2/feature/s3/manager` (v1.16.15) to `github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager` (v0.3.5).

--- a/internal/config/dsn.go
+++ b/internal/config/dsn.go
@@ -572,8 +572,12 @@ func FillMissingConfigParameters(cfg *Config) error {
 	}
 
 	cfg.Region = strings.Trim(cfg.Region, " ")
-	if cfg.Region != "" {
-		// region is specified but not included in Host
+	if cfg.Region != "" && !hostProvidedByUser(cfg) {
+		// Region is specified but not included in Host. This only patches up a
+		// Host the driver itself synthesized from Account: transformAccountToHost
+		// builds Host before parseDSNParams reads the region parameter, so the
+		// region would otherwise be dropped. It must not run when the user gave
+		// Host explicitly — Host takes precedence over Region.
 		domain, i := extractDomainFromHost(cfg.Host)
 		if i >= 1 {
 			hostPrefix := cfg.Host[0:i]
@@ -694,6 +698,13 @@ func extractRegionFromAccount(account string) (region string, posDot int) {
 
 func hostIncludesTopLevelDomain(host string) bool {
 	return strings.Contains(strings.ToLower(host), topLevelDomainPrefix)
+}
+
+// hostProvidedByUser reports whether Host came from the user rather than from
+// driver-side synthesis out of Account and Region. Callers must run after
+// inferInputShapeIfMissing, which guarantees a non-nil shape.
+func hostProvidedByUser(cfg *Config) bool {
+	return cfg.inputShape != nil && cfg.inputShape.HostProvided
 }
 
 func buildHostFromAccountAndRegion(account, region string) string {

--- a/internal/config/dsn_test.go
+++ b/internal/config/dsn_test.go
@@ -439,6 +439,44 @@ func TestParseDSN(t *testing.T) {
 			err:      nil,
 		},
 		{
+			// An explicitly provided host wins over region: the region is not
+			// spliced into the host even though the host does not carry it.
+			dsn: "u:p@a.snowflakecomputing.com/db/pa?region=eu-faraway",
+			config: &Config{
+				Account: "a", User: "u", Password: "p", Region: "eu-faraway",
+				Protocol: "https", Host: "a.snowflakecomputing.com", Port: 443,
+				Database: "db", Schema: "pa",
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				ValidateDefaultParameters: BoolTrue,
+				ClientTimeout:             time.Duration(DefaultClientTimeout),
+				JWTClientTimeout:          time.Duration(DefaultJWTClientTimeout),
+				ExternalBrowserTimeout:    time.Duration(DefaultExternalBrowserTimeout),
+				CloudStorageTimeout:       defaultCloudStorageTimeout,
+				IncludeRetryReason:        BoolTrue,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
+		{
+			// A full non-Snowflake host (e.g. a TS region) is preserved verbatim
+			// when the authority carries an explicit port and account is given.
+			dsn: "user:pass@myaccount.us-isob-east-1.sc2s.sgov.gov:443/db/pa?account=myaccount",
+			config: &Config{
+				Account: "myaccount", User: "user", Password: "pass",
+				Protocol: "https", Host: "myaccount.us-isob-east-1.sc2s.sgov.gov", Port: 443,
+				Database: "db", Schema: "pa",
+				OCSPFailOpen:              OCSPFailOpenTrue,
+				ValidateDefaultParameters: BoolTrue,
+				ClientTimeout:             time.Duration(DefaultClientTimeout),
+				JWTClientTimeout:          time.Duration(DefaultJWTClientTimeout),
+				ExternalBrowserTimeout:    time.Duration(DefaultExternalBrowserTimeout),
+				CloudStorageTimeout:       defaultCloudStorageTimeout,
+				IncludeRetryReason:        BoolTrue,
+			},
+			ocspMode: ocspModeFailOpen,
+			err:      nil,
+		},
+		{
 			dsn: "u:p@a.eu-faraway.snowflakecomputing.mil/db/pa?account=a&region=eu-faraway",
 			config: &Config{
 				Account: "a", User: "u", Password: "p", Region: "eu-faraway",
@@ -2497,6 +2535,63 @@ func TestFillMissingConfigParametersNonSnowflakeHostRequiresAccount(t *testing.T
 	sfErr, ok := err.(*sferrors.SnowflakeError)
 	assertTrueF(t, ok, "expected SnowflakeError")
 	assertEqualE(t, sfErr.Number, sferrors.ErrCodeEmptyAccountCode, "error number")
+}
+
+// An explicitly provided Host takes precedence over Region: the region must not
+// be spliced into a host the user supplied, even when the host does not carry it.
+func TestFillMissingConfigParametersKeepsExplicitHostOverRegion(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "myacct.snowflakecomputing.com",
+		Region:        "us-east-1",
+		Authenticator: AuthTypeSnowflake,
+	}
+	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters")
+	assertEqualE(t, cfg.Host, "myacct.snowflakecomputing.com", "Host")
+	assertEqualE(t, cfg.Region, "us-east-1", "Region")
+}
+
+// A Host synthesized by the driver from Account still gets the region spliced in,
+// because parseDSNParams reads the region parameter only after
+// transformAccountToHost has already built Host.
+func TestFillMissingConfigParametersInjectsRegionIntoSynthesizedHost(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Account:       "myacct",
+		Region:        "us-east-1",
+		Authenticator: AuthTypeSnowflake,
+	}
+	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters")
+	assertEqualE(t, cfg.Host, "myacct.us-east-1.snowflakecomputing.com", "Host")
+}
+
+// A full non-Snowflake host (e.g. a TS region) is preserved verbatim and does not
+// need an explicit port when Account is supplied alongside it.
+func TestFillMissingConfigParametersPreservesNonSnowflakeHostWithAccount(t *testing.T) {
+	cfg := &Config{
+		User:          "u",
+		Password:      "p",
+		Host:          "myaccount.us-isob-east-1.sc2s.sgov.gov",
+		Account:       "myaccount",
+		Authenticator: AuthTypeSnowflake,
+	}
+	assertNilE(t, FillMissingConfigParameters(cfg), "FillMissingConfigParameters")
+	assertEqualE(t, cfg.Host, "myaccount.us-isob-east-1.sc2s.sgov.gov", "Host")
+	assertEqualE(t, cfg.Account, "myaccount", "Account")
+	assertEqualE(t, cfg.Port, 443, "Port")
+}
+
+// The same host given in a DSN keeps its port and is not rewritten into an
+// account-derived Snowflake host.
+func TestParseDSNPreservesNonSnowflakeHostWithPort(t *testing.T) {
+	cfg, err := ParseDSN("user:pass@myaccount.us-isob-east-1.sc2s.sgov.gov:443/db?account=myaccount")
+	assertNilF(t, err, "ParseDSN")
+	assertEqualE(t, cfg.Host, "myaccount.us-isob-east-1.sc2s.sgov.gov", "Host")
+	assertEqualE(t, cfg.Account, "myaccount", "Account")
+	assertEqualE(t, cfg.Port, 443, "Port")
+	assertEqualE(t, cfg.Region, "", "Region")
 }
 
 func TestFillMissingConfigParametersRejectsHostWithHTTPSScheme(t *testing.T) {


### PR DESCRIPTION
### TL;DR

Fixed a bug where providing an explicit `host` in the DSN or config was being overwritten when a `region` parameter was also present.

### What changed?

When both `host` and `region` are provided, the driver no longer splices the region into the host. A new helper, `hostProvidedByUser`, checks whether the host was explicitly supplied by the user (via `inputShape.HostProvided`). The region-injection logic in `FillMissingConfigParameters` now only runs when the host was synthesized by the driver from the `account` parameter — not when the user provided it directly.

For example, `host=myacct.snowflakecomputing.com` with `region=us-east-1` previously produced `myacct.us-east-1.snowflakecomputing.com`. The explicit host is now preserved as-is. Non-Snowflake hosts (e.g. TS region endpoints like `myaccount.us-isob-east-1.sc2s.sgov.gov`) are also preserved verbatim when supplied alongside an `account`.

### How to test?

- `TestFillMissingConfigParametersKeepsExplicitHostOverRegion` — verifies that an explicit host is not rewritten when a region is also set.
- `TestFillMissingConfigParametersInjectsRegionIntoSynthesizedHost` — verifies that a driver-synthesized host (built from `account`) still gets the region spliced in correctly.
- `TestFillMissingConfigParametersPreservesNonSnowflakeHostWithAccount` — verifies that non-Snowflake hosts are preserved verbatim when `account` is provided alongside them.
- `TestParseDSNPreservesNonSnowflakeHostWithPort` — verifies that a non-Snowflake host with an explicit port in the DSN is not rewritten.
- Two new DSN parse test cases covering the explicit-host-with-region and non-Snowflake-host-with-port scenarios.

### Why make this change?

The `transformAccountToHost` function builds the `Host` field before `parseDSNParams` reads the `region` parameter. The region-injection step was designed to patch up that synthesized host, but it ran unconditionally — including when the user had explicitly provided a `host`. This caused user-supplied hosts to be silently rewritten, breaking connections to custom or non-standard endpoints (snowflakedb/gosnowflake#1841).