### PR TITLE
Treat RESTARTED query status as still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 New features:
 - Added `WorkloadIdentityHost` config option (DSN field `workloadIdentityHost`) that overrides the STS host used by the AWS WIF flows, for endpoints the driver cannot derive from the region (such as an interface VPC endpoint). Must be an STS endpoint for the region the workload runs in (snowflakedb/gosnowflake#5).
- 
+
+Bug fixes:
+- Fixed `GetQueryStatus` treating `RESTARTED` as success by counting that status as still running (snowflakedb/gosnowflake#1842).
+
 ## 2.2.0
 
 New features:

--- a/monitoring.go
+++ b/monitoring.go
@@ -59,7 +59,7 @@ func (qs queryResultStatus) String() string {
 func (qs queryResultStatus) isRunning() bool {
 	switch qs {
 	case SFQueryRunning, SFQueryResumingWarehouse, SFQueryQueued,
-		SFQueryQueueRepairingWarehouse, SFQueryNoData:
+		SFQueryQueueRepairingWarehouse, SFQueryRestarted, SFQueryNoData:
 		return true
 	default:
 		return false

--- a/monitoring_test.go
+++ b/monitoring_test.go
@@ -1,0 +1,12 @@
+package gosnowflake
+
+import "testing"
+
+func TestQueryResultStatusRestartedIsRunning(t *testing.T) {
+	if !SFQueryRestarted.isRunning() {
+		t.Fatal("RESTARTED should be treated as still running")
+	}
+	if SFQueryRestarted.isError() {
+		t.Fatal("RESTARTED should not be treated as an error status")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #1842.

`SFQueryRestarted` was missing from both `isRunning` and `isError`, so `GetQueryStatus` returned nil and callers thought the query was finished. It now counts as still running, same as the other in flight statuses.

## Test plan
- [x] Added `TestQueryResultStatusRestartedIsRunning`
- [ ] Maintainer CI against a live Snowflake account